### PR TITLE
REST promise should reject if HTTP status error is seen

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -78,11 +78,18 @@ module.exports = class Request {
 
     return new Promise((resolve, reject) => {
       request(options, function callback(error, response, body) {
-        if(!error && response.statusCode == 200) {
-          resolve(body);
-        } else if(error) {
-          reject(error);
+        if (error) {
+          return reject(error);
         }
+        if (response.statusCode == 200) {
+          return resolve(body);
+        }
+        return reject({
+          code: response.statusCode,
+          message: response.statusMessage,
+          body: response.body,
+          requestOptions: options
+        });
       });
     });
   }


### PR DESCRIPTION
Current logic will get stuck if status error is seen as `request` does not translate errors such as 404 into a rejected promise. Here's a proposed approach to dealing with it.