### PR TITLE
Added trigger_by params for inverse client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Node.js connector for Bybit's REST APIs and WebSockets, with TypeScript & integration tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -124,6 +124,8 @@ export class InverseClient extends SharedEndpoints {
     take_profit?: number;
     stop_loss?: number;
     reduce_only?: boolean;
+    tp_trigger_by?: boolean;
+    sl_trigger_by?: boolean;
     close_on_trigger?: boolean;
     order_link_id?: string;
   }): GenericAPIResponse {


### PR DESCRIPTION
Not sure why these params were missing from inverse client. https://bybit-exchange.github.io/docs/inverse/#t-placeactive shows they are there and they work. 