### PR TITLE
fix(#240): fix sign error on parallel requests due to pointer mutation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -234,10 +234,6 @@ export default abstract class BaseRestClient {
 
     // USDC endpoints, unified margin and a few others use a different way of authenticating requests (headers instead of params)
     if (this.clientType === REST_CLIENT_TYPE_ENUM.v3) {
-      if (!options.headers) {
-        options.headers = {};
-      }
-
       const signResult = await this.prepareSignParams(
         method,
         'v5auth',

--- a/test/linear/private.read.test.ts
+++ b/test/linear/private.read.test.ts
@@ -45,9 +45,10 @@ describe('Private Linear REST API GET Endpoints', () => {
   });
 
   it('getActiveOrderList()', async () => {
-    expect(await api.getActiveOrderList({ symbol: symbol })).toMatchObject(
-      successResponseObject()
-    );
+    expect(await api.getActiveOrderList({ symbol: symbol })).toMatchObject({
+      ...successResponseObject(),
+      // ret_msg: 'ok',
+    });
   });
 
   it('queryActiveOrder()', async () => {


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->
Due to the spread merge of the shared globalRequestOptions object, setting request headers for v3-v5 requests was unintentionally also a pointer mutation. This was causing unintentionally causing requests to affect each other when executed in parallel (Promise.all etc) - fixes #240.

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
