### PR TITLE
feat(v4.2.7): force ws request batching into groups of max 500 topics per batch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bybit-api",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bybit-api",
-      "version": "4.2.6",
+      "version": "4.2.7",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/util/websockets/websocket-util.ts
+++ b/src/util/websockets/websocket-util.ts
@@ -296,7 +296,8 @@ export function getMaxTopicsPerSubscribeEvent(
       if (wsKey === WS_KEY_MAP.v5SpotPublic) {
         return 10;
       }
-      return null;
+
+      return 500;
     }
     default: {
       throw neverGuard(market, 'getWsKeyForTopic(): Unhandled market');


### PR DESCRIPTION

## Summary
<!-- Add a brief description of the pr: -->
- Sending extremely large subscription requests could lead to connection closures. This increases stability by enforcing batching into smaller groups, once topics per request exceed 500. This primarily affects subscribing to a large number of topics.

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

## PR Checklist

As part of the PR, make sure you have:
- [ ] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Run llms.txt generator (optional, if you know how).
