### PR TITLE
Change endpoint from '/v5/order/price-limit' to '/v5/market/price-limit'

### DIFF
--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -809,7 +809,7 @@ export class RestClientV5 extends BaseRestClient {
     symbol: string;
     category: 'spot' | 'linear' | 'inverse';
   }): Promise<APIResponseV3WithTime<OrderPriceLimitV5>> {
-    return this.get('/v5/order/price-limit', params);
+    return this.get('/v5/market/price-limit', params);
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR updates the endpoint for getting the order price limit from `/v5/order/price-limit` to `/v5/market/price-limit` to align with the latest Bybit API V5 documentation.

-----

## Additional Information

### ⚠️ Breaking Change

The endpoint to fetch the order price limit has been changed.

  * **Old Endpoint:** `/v5/order/price-limit`
  * **New Endpoint:** `/v5/market/price-limit`

This change is based on the official documentation: [https://bybit-exchange.github.io/docs/v5/market/order-price-limit](https://bybit-exchange.github.io/docs/v5/market/order-price-limit)

### New Endpoint Details: Get Order Price Limit

**HTTP Request**

```
GET /v5/market/price-limit
```

**Request Parameters**

| Parameter | Required | Type | Comments |
| :--- | :--- | :--- | :--- |
| `category` | false | string | Product type. `spot`, `linear`, `inverse`. Defaults to `linear`. |
| `symbol` | true | string | Symbol name, like `BTCUSDT`, uppercase only. |

**Response Example**

```json
{
    "retCode": 0,
    "retMsg": "",
    "result": {
        "symbol": "BTCUSDT",
        "buyLmt": "105878.10",
        "sellLmt": "103781.60",
        "ts": "1750302284491"
    },
    "retExtInfo": {},
    "time": 1750302285376
}
```

-----

## PR Checklist

As part of the PR, make sure you have:

  - [x] **No breaking changes / documented all breaking changes clearly.**
  - [ ] Updated & checked that all tests pass.
  - [ ] Increased the version number in the package.json - [ ] Checked `npm install` runs without issue.
  - [ ] Included the package-lock.json, if it changed after npm install - [ ] Checked `npm run build` runs without issue.
  - [ ] Updated the endpoint map (optional, if you know how).
  - [ ] Run llms.txt generator (optional, if you know how).