### PR TITLE
feat(v4.4.2): Update full release notes since 1st October

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -49,249 +49,260 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getSystemStatus()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L389) | :closed_lock_with_key:  | GET | `/v5/system/status` |
-| [fetchServerTime()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L401) |  | GET | `/v5/market/time` |
-| [requestDemoTradingFunds()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L418) | :closed_lock_with_key:  | POST | `/v5/account/demo-apply-money` |
-| [createDemoAccount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L431) | :closed_lock_with_key:  | POST | `/v5/user/create-demo-member` |
-| [getSpreadInstrumentsInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L444) |  | GET | `/v5/spread/instrument` |
-| [getSpreadOrderbook()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L456) |  | GET | `/v5/spread/orderbook` |
-| [getSpreadTickers()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L466) |  | GET | `/v5/spread/tickers` |
-| [getSpreadRecentTrades()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L477) |  | GET | `/v5/spread/recent-trade` |
-| [submitSpreadOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L488) | :closed_lock_with_key:  | POST | `/v5/spread/order/create` |
-| [amendSpreadOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L501) | :closed_lock_with_key:  | POST | `/v5/spread/order/amend` |
-| [cancelSpreadOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L513) | :closed_lock_with_key:  | POST | `/v5/spread/order/cancel` |
-| [cancelAllSpreadOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L531) | :closed_lock_with_key:  | POST | `/v5/spread/order/cancel-all` |
-| [getSpreadOpenOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L550) | :closed_lock_with_key:  | GET | `/v5/spread/order/realtime` |
-| [getSpreadOrderHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L567) | :closed_lock_with_key:  | GET | `/v5/spread/order/history` |
-| [getSpreadTradeHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L583) | :closed_lock_with_key:  | GET | `/v5/spread/execution/list` |
-| [getKline()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L603) |  | GET | `/v5/market/kline` |
-| [getMarkPriceKline()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L618) |  | GET | `/v5/market/mark-price-kline` |
-| [getIndexPriceKline()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L633) |  | GET | `/v5/market/index-price-kline` |
-| [getPremiumIndexPriceKline()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L648) |  | GET | `/v5/market/premium-index-price-kline` |
-| [getOrderbook()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L674) |  | GET | `/v5/market/orderbook` |
-| [getRPIOrderbook()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L688) |  | GET | `/v5/market/rpi_orderbook` |
-| [getTickers()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L694) |  | GET | `/v5/market/tickers` |
-| [getFundingRateHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L732) |  | GET | `/v5/market/funding/history` |
-| [getPublicTradingHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L747) |  | GET | `/v5/market/recent-trade` |
-| [getOpenInterest()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L760) |  | GET | `/v5/market/open-interest` |
-| [getHistoricalVolatility()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L770) |  | GET | `/v5/market/historical-volatility` |
-| [getInsurance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L781) |  | GET | `/v5/market/insurance` |
-| [getRiskLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L792) |  | GET | `/v5/market/risk-limit` |
-| [getOptionDeliveryPrice()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L807) |  | GET | `/v5/market/delivery-price` |
-| [getDeliveryPrice()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L820) |  | GET | `/v5/market/delivery-price` |
-| [getNewDeliveryPrice()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L836) |  | GET | `/v5/market/new-delivery-price` |
-| [getLongShortRatio()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L852) |  | GET | `/v5/market/account-ratio` |
-| [getIndexPriceComponents()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L862) |  | GET | `/v5/market/index-price-components` |
-| [getOrderPriceLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L868) |  | GET | `/v5/market/price-limit` |
-| [getADLAlert()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L882) |  | GET | `/v5/market/adlAlert` |
-| [getFeeGroupStructure()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L895) |  | GET | `/v5/market/fee-group-info` |
-| [submitOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L907) | :closed_lock_with_key:  | POST | `/v5/order/create` |
-| [amendOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L913) | :closed_lock_with_key:  | POST | `/v5/order/amend` |
-| [cancelOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L919) | :closed_lock_with_key:  | POST | `/v5/order/cancel` |
-| [getActiveOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L928) | :closed_lock_with_key:  | GET | `/v5/order/realtime` |
-| [cancelAllOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L934) | :closed_lock_with_key:  | POST | `/v5/order/cancel-all` |
-| [getHistoricOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L947) | :closed_lock_with_key:  | GET | `/v5/order/history` |
-| [getExecutionList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L959) | :closed_lock_with_key:  | GET | `/v5/execution/list` |
-| [batchSubmitOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L977) | :closed_lock_with_key:  | POST | `/v5/order/create-batch` |
-| [batchAmendOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1002) | :closed_lock_with_key:  | POST | `/v5/order/amend-batch` |
-| [batchCancelOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1027) | :closed_lock_with_key:  | POST | `/v5/order/cancel-batch` |
-| [getSpotBorrowCheck()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1049) | :closed_lock_with_key:  | GET | `/v5/order/spot-borrow-check` |
-| [setDisconnectCancelAllWindow()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1070) | :closed_lock_with_key:  | POST | `/v5/order/disconnected-cancel-all` |
-| [setDisconnectCancelAllWindowV2()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1088) | :closed_lock_with_key:  | POST | `/v5/order/disconnected-cancel-all` |
-| [preCheckOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1103) | :closed_lock_with_key:  | POST | `/v5/order/pre-check` |
-| [getPositionInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1126) | :closed_lock_with_key:  | GET | `/v5/position/list` |
-| [setLeverage()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1141) | :closed_lock_with_key:  | POST | `/v5/position/set-leverage` |
-| [switchIsolatedMargin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1154) | :closed_lock_with_key:  | POST | `/v5/position/switch-isolated` |
-| [setTPSLMode()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1168) | :closed_lock_with_key:  | POST | `/v5/position/set-tpsl-mode` |
-| [switchPositionMode()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1183) | :closed_lock_with_key:  | POST | `/v5/position/switch-mode` |
-| [setRiskLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1197) | :closed_lock_with_key:  | POST | `/v5/position/set-risk-limit` |
-| [setTradingStop()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1212) | :closed_lock_with_key:  | POST | `/v5/position/trading-stop` |
-| [setAutoAddMargin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1223) | :closed_lock_with_key:  | POST | `/v5/position/set-auto-add-margin` |
-| [addOrReduceMargin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1235) | :closed_lock_with_key:  | POST | `/v5/position/add-margin` |
-| [getClosedPnL()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1247) | :closed_lock_with_key:  | GET | `/v5/position/closed-pnl` |
-| [getClosedOptionsPositions()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1261) | :closed_lock_with_key:  | GET | `/v5/position/get-closed-positions` |
-| [movePosition()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1286) | :closed_lock_with_key:  | POST | `/v5/position/move-positions` |
-| [getMovePositionHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1297) | :closed_lock_with_key:  | GET | `/v5/position/move-history` |
-| [confirmNewRiskLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1316) | :closed_lock_with_key:  | POST | `/v5/position/confirm-pending-mmr` |
-| [getPreUpgradeOrderHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1336) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/order/history` |
-| [getPreUpgradeTradeHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1351) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/execution/list` |
-| [getPreUpgradeClosedPnl()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1362) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/position/closed-pnl` |
-| [getPreUpgradeTransactions()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1376) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/account/transaction-log` |
-| [getPreUpgradeOptionDeliveryRecord()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1393) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/asset/delivery-record` |
-| [getPreUpgradeUSDCSessionSettlements()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1407) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/asset/settlement-record` |
-| [getWalletBalance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1428) | :closed_lock_with_key:  | GET | `/v5/account/wallet-balance` |
-| [getTransferableAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1439) | :closed_lock_with_key:  | GET | `/v5/account/withdrawal` |
-| [upgradeToUnifiedAccount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1452) | :closed_lock_with_key:  | POST | `/v5/account/upgrade-to-uta` |
-| [getBorrowHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1463) | :closed_lock_with_key:  | GET | `/v5/account/borrow-history` |
-| [repayLiability()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1477) | :closed_lock_with_key:  | POST | `/v5/account/quick-repayment` |
-| [setCollateralCoin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1486) | :closed_lock_with_key:  | POST | `/v5/account/set-collateral-switch` |
-| [batchSetCollateralCoin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1492) | :closed_lock_with_key:  | POST | `/v5/account/set-collateral-switch-batch` |
-| [getCollateralInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1502) | :closed_lock_with_key:  | GET | `/v5/account/collateral-info` |
-| [getCoinGreeks()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1511) | :closed_lock_with_key:  | GET | `/v5/asset/coin-greeks` |
-| [getFeeRate()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1524) | :closed_lock_with_key:  | GET | `/v5/account/fee-rate` |
-| [getAccountInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1533) | :closed_lock_with_key:  | GET | `/v5/account/info` |
-| [getDCPInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1546) | :closed_lock_with_key:  | GET | `/v5/account/query-dcp-info` |
-| [getTransactionLog()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1553) | :closed_lock_with_key:  | GET | `/v5/account/transaction-log` |
-| [getClassicTransactionLogs()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1564) | :closed_lock_with_key:  | GET | `/v5/account/contract-transaction-log` |
-| [getSMPGroup()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1575) | :closed_lock_with_key:  | GET | `/v5/account/smp-group` |
-| [setMarginMode()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1588) | :closed_lock_with_key:  | POST | `/v5/account/set-margin-mode` |
-| [setSpotHedging()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1605) | :closed_lock_with_key:  | POST | `/v5/account/set-hedging-mode` |
-| [setLimitPriceAction()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1618) | :closed_lock_with_key:  | POST | `/v5/account/set-limit-px-action` |
-| [getLimitPriceAction()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1628) | :closed_lock_with_key:  | GET | `/v5/account/user-setting-config` |
-| [setMMP()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1640) | :closed_lock_with_key:  | POST | `/v5/account/mmp-modify` |
-| [resetMMP()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1647) | :closed_lock_with_key:  | POST | `/v5/account/mmp-reset` |
-| [getMMPState()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1654) | :closed_lock_with_key:  | GET | `/v5/account/mmp-state` |
-| [getDeliveryRecord()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1671) | :closed_lock_with_key:  | GET | `/v5/asset/delivery-record` |
-| [getSettlementRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1682) | :closed_lock_with_key:  | GET | `/v5/asset/settlement-record` |
-| [getCoinExchangeRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1695) | :closed_lock_with_key:  | GET | `/v5/asset/exchange/order-record` |
-| [getCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1707) | :closed_lock_with_key:  | GET | `/v5/asset/coin/query-info` |
-| [getSubUID()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1721) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-sub-member-list` |
-| [getAssetInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1736) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-asset-info` |
-| [getAllCoinsBalance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1747) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-account-coins-balance` |
-| [getCoinBalance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1761) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-account-coin-balance` |
-| [getWithdrawableAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1773) | :closed_lock_with_key:  | GET | `/v5/asset/withdraw/withdrawable-amount` |
-| [getTransferableCoinList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1782) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-transfer-coin-list` |
-| [createInternalTransfer()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1798) | :closed_lock_with_key:  | POST | `/v5/asset/transfer/inter-transfer` |
-| [getInternalTransferRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1817) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-inter-transfer-list` |
-| [enableUniversalTransferForSubUIDs()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1837) | :closed_lock_with_key:  | POST | `/v5/asset/transfer/save-transfer-sub-member` |
-| [createUniversalTransfer()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1848) | :closed_lock_with_key:  | POST | `/v5/asset/transfer/universal-transfer` |
-| [getUniversalTransferRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1860) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-universal-transfer-list` |
-| [getAllowedDepositCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1873) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-allowed-list` |
-| [setDepositAccount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1887) | :closed_lock_with_key:  | POST | `/v5/asset/deposit/deposit-to-account` |
-| [getDepositRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1903) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-record` |
-| [getSubAccountDepositRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1918) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-sub-member-record` |
-| [getInternalDepositRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1934) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-internal-record` |
-| [getMasterDepositAddress()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1946) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-address` |
-| [getSubDepositAddress()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1964) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-sub-member-address` |
-| [querySubMemberAddress()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1989) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-sub-member-address` |
-| [getWithdrawalRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2009) | :closed_lock_with_key:  | GET | `/v5/asset/withdraw/query-record` |
-| [getExchangeEntities()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2020) | :closed_lock_with_key:  | GET | `/v5/asset/withdraw/vasp/list` |
-| [submitWithdrawal()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2033) | :closed_lock_with_key:  | POST | `/v5/asset/withdraw/create` |
-| [cancelWithdrawal()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2044) | :closed_lock_with_key:  | POST | `/v5/asset/withdraw/cancel` |
-| [getConvertCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2053) | :closed_lock_with_key:  | GET | `/v5/asset/exchange/query-coin-list` |
-| [requestConvertQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2064) | :closed_lock_with_key:  | POST | `/v5/asset/exchange/quote-apply` |
-| [confirmConvertQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2073) | :closed_lock_with_key:  | POST | `/v5/asset/exchange/convert-execute` |
-| [getConvertStatus()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2085) | :closed_lock_with_key:  | GET | `/v5/asset/exchange/convert-result-query` |
-| [getConvertHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2104) | :closed_lock_with_key:  | GET | `/v5/asset/exchange/query-convert-history` |
-| [createSubMember()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2124) | :closed_lock_with_key:  | POST | `/v5/user/create-sub-member` |
-| [createSubUIDAPIKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2136) | :closed_lock_with_key:  | POST | `/v5/user/create-sub-api` |
-| [getSubUIDList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2145) | :closed_lock_with_key:  | GET | `/v5/user/query-sub-members` |
-| [getSubUIDListUnlimited()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2154) | :closed_lock_with_key:  | GET | `/v5/user/submembers` |
-| [setSubUIDFrozenState()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2172) | :closed_lock_with_key:  | POST | `/v5/user/frozen-sub-member` |
-| [getQueryApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2185) | :closed_lock_with_key:  | GET | `/v5/user/query-api` |
-| [getSubAccountAllApiKeys()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2192) | :closed_lock_with_key:  | GET | `/v5/user/sub-apikeys` |
-| [getUIDWalletType()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2201) | :closed_lock_with_key:  | GET | `/v5/user/get-member-type` |
-| [updateMasterApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2218) | :closed_lock_with_key:  | POST | `/v5/user/update-api` |
-| [updateSubApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2232) | :closed_lock_with_key:  | POST | `/v5/user/update-sub-api` |
-| [deleteSubMember()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2245) | :closed_lock_with_key:  | POST | `/v5/user/del-submember` |
-| [deleteMasterApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2260) | :closed_lock_with_key:  | POST | `/v5/user/delete-api` |
-| [deleteSubApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2274) | :closed_lock_with_key:  | POST | `/v5/user/delete-sub-api` |
-| [getAffiliateUserList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2294) | :closed_lock_with_key:  | GET | `/v5/affiliate/aff-user-list` |
-| [getAffiliateUserInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2313) | :closed_lock_with_key:  | GET | `/v5/user/aff-customer-info` |
-| [getVIPMarginData()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2333) |  | GET | `/v5/spot-margin-trade/data` |
-| [getHistoricalInterestRate()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2344) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/interest-rate-history` |
-| [toggleSpotMarginTrade()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2371) | :closed_lock_with_key:  | POST | `/v5/spot-margin-trade/switch-mode` |
-| [setSpotMarginLeverage()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2383) | :closed_lock_with_key:  | POST | `/v5/spot-margin-trade/set-leverage` |
-| [getSpotMarginState()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2392) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/state` |
-| [getSpotMarginCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2405) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/pledge-token` |
-| [getSpotMarginBorrowableCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2422) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/borrow-token` |
-| [getSpotMarginInterestAndQuota()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2439) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/loan-info` |
-| [getSpotMarginLoanAccountInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2457) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/account` |
-| [spotMarginBorrow()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2481) | :closed_lock_with_key:  | POST | `/v5/spot-cross-margin-trade/loan` |
-| [spotMarginRepay()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2492) | :closed_lock_with_key:  | POST | `/v5/spot-cross-margin-trade/repay` |
-| [getSpotMarginBorrowOrderDetail()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2507) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/orders` |
-| [getSpotMarginRepaymentOrderDetail()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2536) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/repay-history` |
-| [toggleSpotCrossMarginTrade()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2565) | :closed_lock_with_key:  | POST | `/v5/spot-cross-margin-trade/switch` |
-| [getCollateralCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2585) |  | GET | `/v5/crypto-loan/collateral-data` |
-| [getBorrowableCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2602) |  | GET | `/v5/crypto-loan/loanable-data` |
-| [getAccountBorrowCollateralLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2620) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/borrowable-collateralisable-number` |
-| [borrowCryptoLoan()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2640) | :closed_lock_with_key:  | POST | `/v5/crypto-loan/borrow` |
-| [repayCryptoLoan()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2661) | :closed_lock_with_key:  | POST | `/v5/crypto-loan/repay` |
-| [getUnpaidLoanOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2677) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/ongoing-orders` |
-| [getRepaymentHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2698) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/repayment-history` |
-| [getCompletedLoanOrderHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2718) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/borrow-history` |
-| [getMaxAllowedReductionCollateralAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2737) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/max-collateral-amount` |
-| [adjustCollateralAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2756) | :closed_lock_with_key:  | POST | `/v5/crypto-loan/adjust-ltv` |
-| [getLoanLTVAdjustmentHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2780) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/adjustment-history` |
-| [getLoanBorrowableCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2801) |  | GET | `/v5/crypto-loan-common/loanable-data` |
-| [getLoanCollateralCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2813) |  | GET | `/v5/crypto-loan-common/collateral-data` |
-| [getMaxCollateralAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2823) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-common/max-collateral-amount` |
-| [updateCollateralAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2838) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-common/adjust-ltv` |
-| [getCollateralAdjustmentHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2849) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-common/adjustment-history` |
-| [getCryptoLoanPosition()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2864) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-common/position` |
-| [borrowFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2881) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-flexible/borrow` |
-| [repayFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2892) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-flexible/repay` |
-| [repayCollateralFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2902) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-flexible/repay-collateral` |
-| [getOngoingFlexibleLoans()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2916) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-flexible/ongoing-coin` |
-| [getBorrowHistoryFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2928) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-flexible/borrow-history` |
-| [getRepaymentHistoryFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2941) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-flexible/repayment-history` |
-| [getSupplyOrderQuoteFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2966) |  | GET | `/v5/crypto-loan-fixed/supply-order-quote` |
-| [getBorrowOrderQuoteFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2979) |  | GET | `/v5/crypto-loan-fixed/borrow-order-quote` |
-| [createBorrowOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2992) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/borrow` |
-| [createSupplyOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3003) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/supply` |
-| [cancelBorrowOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3013) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/borrow-order-cancel` |
-| [cancelSupplyOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3025) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/supply-order-cancel` |
-| [getBorrowContractInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3038) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/borrow-contract-info` |
-| [getSupplyContractInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3056) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/supply-contract-info` |
-| [getBorrowOrderInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3074) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/borrow-order-info` |
-| [getSupplyOrderInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3087) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/supply-order-info` |
-| [repayFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3101) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/fully-repay` |
-| [repayCollateralFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3112) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-flexible/repay-collateral` |
-| [getRepaymentHistoryFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3125) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/repayment-history` |
-| [getInstitutionalLendingProductInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3143) |  | GET | `/v5/ins-loan/product-infos` |
-| [getInstitutionalLendingMarginCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3153) |  | GET | `/v5/ins-loan/ensure-tokens` |
-| [getInstitutionalLendingMarginCoinInfoWithConversionRate()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3162) |  | GET | `/v5/ins-loan/ensure-tokens-convert` |
-| [getInstitutionalLendingLoanOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3171) | :closed_lock_with_key:  | GET | `/v5/ins-loan/loan-order` |
-| [getInstitutionalLendingRepayOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3183) | :closed_lock_with_key:  | GET | `/v5/ins-loan/repaid-history` |
-| [getInstitutionalLendingLTV()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3195) | :closed_lock_with_key:  | GET | `/v5/ins-loan/ltv` |
-| [getInstitutionalLendingLTVWithLadderConversionRate()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3204) | :closed_lock_with_key:  | GET | `/v5/ins-loan/ltv-convert` |
-| [bindOrUnbindUID()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3219) | :closed_lock_with_key:  | POST | `/v5/ins-loan/association-uid` |
-| [getExchangeBrokerEarnings()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3243) | :closed_lock_with_key:  | GET | `/v5/broker/earnings-info` |
-| [getExchangeBrokerAccountInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3256) | :closed_lock_with_key:  | GET | `/v5/broker/account-info` |
-| [getBrokerSubAccountDeposits()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3272) | :closed_lock_with_key:  | GET | `/v5/broker/asset/query-sub-member-deposit-record` |
-| [getBrokerVoucherSpec()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3287) | :closed_lock_with_key:  | POST | `/v5/broker/award/info` |
-| [issueBrokerVoucher()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3299) | :closed_lock_with_key:  | POST | `/v5/broker/award/distribute-award` |
-| [getBrokerIssuedVoucher()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3311) | :closed_lock_with_key:  | POST | `/v5/broker/award/distribution-record` |
-| [getEarnProduct()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3328) |  | GET | `/v5/earn/product` |
-| [submitStakeRedeem()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3346) | :closed_lock_with_key:  | POST | `/v5/earn/place-order` |
-| [getEarnOrderHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3363) | :closed_lock_with_key:  | GET | `/v5/earn/order` |
-| [getEarnPosition()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3378) | :closed_lock_with_key:  | GET | `/v5/earn/position` |
-| [createRFQ()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3396) | :closed_lock_with_key:  | POST | `/v5/rfq/create-rfq` |
-| [getRFQConfig()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3407) | :closed_lock_with_key:  | GET | `/v5/rfq/config` |
-| [cancelRFQ()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3416) | :closed_lock_with_key:  | POST | `/v5/rfq/cancel-rfq` |
-| [cancelAllRFQ()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3426) | :closed_lock_with_key:  | POST | `/v5/rfq/cancel-all-rfq` |
-| [createRFQQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3435) | :closed_lock_with_key:  | POST | `/v5/rfq/create-quote` |
-| [executeRFQQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3446) | :closed_lock_with_key:  | POST | `/v5/rfq/execute-quote` |
-| [cancelRFQQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3457) | :closed_lock_with_key:  | POST | `/v5/rfq/cancel-quote` |
-| [cancelAllRFQQuotes()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3467) | :closed_lock_with_key:  | POST | `/v5/rfq/cancel-all-quotes` |
-| [getRFQRealtimeInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3481) | :closed_lock_with_key:  | GET | `/v5/rfq/rfq-realtime` |
-| [getRFQHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3493) | :closed_lock_with_key:  | GET | `/v5/rfq/rfq-list` |
-| [getRFQRealtimeQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3507) | :closed_lock_with_key:  | GET | `/v5/rfq/quote-realtime` |
-| [getRFQHistoryQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3522) | :closed_lock_with_key:  | GET | `/v5/rfq/quote-list` |
-| [getRFQTrades()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3535) | :closed_lock_with_key:  | GET | `/v5/rfq/trade-list` |
-| [getRFQPublicTrades()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3548) | :closed_lock_with_key:  | GET | `/v5/rfq/public-trades` |
-| [getP2PAccountCoinsBalance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3573) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-account-coins-balance` |
-| [getP2POnlineAds()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3590) | :closed_lock_with_key:  | POST | `/v5/p2p/item/online` |
-| [createP2PAd()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3599) | :closed_lock_with_key:  | POST | `/v5/p2p/item/create` |
-| [cancelP2PAd()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3608) | :closed_lock_with_key:  | POST | `/v5/p2p/item/cancel` |
-| [updateP2PAd()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3622) | :closed_lock_with_key:  | POST | `/v5/p2p/item/update` |
-| [getP2PPersonalAds()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3632) | :closed_lock_with_key:  | POST | `/v5/p2p/item/personal/list` |
-| [getP2PAdDetail()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3641) | :closed_lock_with_key:  | POST | `/v5/p2p/item/info` |
-| [getP2POrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3656) | :closed_lock_with_key:  | POST | `/v5/p2p/order/simplifyList` |
-| [getP2POrderDetail()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3666) | :closed_lock_with_key:  | POST | `/v5/p2p/order/info` |
-| [getP2PPendingOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3675) | :closed_lock_with_key:  | POST | `/v5/p2p/order/pending/simplifyList` |
-| [markP2POrderAsPaid()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3684) | :closed_lock_with_key:  | POST | `/v5/p2p/order/pay` |
-| [releaseP2POrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3693) | :closed_lock_with_key:  | POST | `/v5/p2p/order/finish` |
-| [sendP2POrderMessage()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3702) | :closed_lock_with_key:  | POST | `/v5/p2p/order/message/send` |
-| [uploadP2PChatFile()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3711) | :closed_lock_with_key:  | POST | `/v5/p2p/oss/upload_file` |
-| [getP2POrderMessages()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3720) | :closed_lock_with_key:  | POST | `/v5/p2p/order/message/listpage` |
-| [getP2PUserInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3734) | :closed_lock_with_key:  | POST | `/v5/p2p/user/personal/info` |
-| [getP2PCounterpartyUserInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3741) | :closed_lock_with_key:  | POST | `/v5/p2p/user/order/personal/info` |
-| [getP2PUserPayments()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3750) | :closed_lock_with_key:  | POST | `/v5/p2p/user/payment/list` |
-| [setApiRateLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3770) | :closed_lock_with_key:  | POST | `/v5/apilimit/set` |
-| [queryApiRateLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3799) | :closed_lock_with_key:  | GET | `/v5/apilimit/query` |
-| [getRateLimitCap()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3818) | :closed_lock_with_key:  | GET | `/v5/apilimit/query-cap` |
-| [getAllRateLimits()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3837) | :closed_lock_with_key:  | GET | `/v5/apilimit/query-all` |
+| [getSystemStatus()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L412) | :closed_lock_with_key:  | GET | `/v5/system/status` |
+| [getServerTime()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L429) |  | GET | `/v5/market/time` |
+| [requestDemoTradingFunds()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L441) | :closed_lock_with_key:  | POST | `/v5/account/demo-apply-money` |
+| [createDemoAccount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L454) | :closed_lock_with_key:  | POST | `/v5/user/create-demo-member` |
+| [getSpreadInstrumentsInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L467) |  | GET | `/v5/spread/instrument` |
+| [getSpreadOrderbook()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L479) |  | GET | `/v5/spread/orderbook` |
+| [getSpreadTickers()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L489) |  | GET | `/v5/spread/tickers` |
+| [getSpreadRecentTrades()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L500) |  | GET | `/v5/spread/recent-trade` |
+| [submitSpreadOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L511) | :closed_lock_with_key:  | POST | `/v5/spread/order/create` |
+| [amendSpreadOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L524) | :closed_lock_with_key:  | POST | `/v5/spread/order/amend` |
+| [cancelSpreadOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L536) | :closed_lock_with_key:  | POST | `/v5/spread/order/cancel` |
+| [cancelAllSpreadOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L554) | :closed_lock_with_key:  | POST | `/v5/spread/order/cancel-all` |
+| [getSpreadOpenOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L573) | :closed_lock_with_key:  | GET | `/v5/spread/order/realtime` |
+| [getSpreadOrderHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L590) | :closed_lock_with_key:  | GET | `/v5/spread/order/history` |
+| [getSpreadTradeHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L606) | :closed_lock_with_key:  | GET | `/v5/spread/execution/list` |
+| [getKline()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L626) |  | GET | `/v5/market/kline` |
+| [getMarkPriceKline()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L641) |  | GET | `/v5/market/mark-price-kline` |
+| [getIndexPriceKline()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L656) |  | GET | `/v5/market/index-price-kline` |
+| [getPremiumIndexPriceKline()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L671) |  | GET | `/v5/market/premium-index-price-kline` |
+| [getInstrumentsInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L686) |  | GET | `/v5/market/instruments-info` |
+| [getOrderbook()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L697) |  | GET | `/v5/market/orderbook` |
+| [getRPIOrderbook()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L711) |  | GET | `/v5/market/rpi_orderbook` |
+| [getTickers()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L717) |  | GET | `/v5/market/tickers` |
+| [getFundingRateHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L755) |  | GET | `/v5/market/funding/history` |
+| [getPublicTradingHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L770) |  | GET | `/v5/market/recent-trade` |
+| [getOpenInterest()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L783) |  | GET | `/v5/market/open-interest` |
+| [getHistoricalVolatility()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L793) |  | GET | `/v5/market/historical-volatility` |
+| [getInsurance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L804) |  | GET | `/v5/market/insurance` |
+| [getRiskLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L815) |  | GET | `/v5/market/risk-limit` |
+| [getOptionDeliveryPrice()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L830) |  | GET | `/v5/market/delivery-price` |
+| [getDeliveryPrice()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L843) |  | GET | `/v5/market/delivery-price` |
+| [getNewDeliveryPrice()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L859) |  | GET | `/v5/market/new-delivery-price` |
+| [getLongShortRatio()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L875) |  | GET | `/v5/market/account-ratio` |
+| [getIndexPriceComponents()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L885) |  | GET | `/v5/market/index-price-components` |
+| [getOrderPriceLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L891) |  | GET | `/v5/market/price-limit` |
+| [getADLAlert()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L905) |  | GET | `/v5/market/adlAlert` |
+| [getFeeGroupStructure()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L918) |  | GET | `/v5/market/fee-group-info` |
+| [submitOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L930) | :closed_lock_with_key:  | POST | `/v5/order/create` |
+| [amendOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L936) | :closed_lock_with_key:  | POST | `/v5/order/amend` |
+| [cancelOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L942) | :closed_lock_with_key:  | POST | `/v5/order/cancel` |
+| [getActiveOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L951) | :closed_lock_with_key:  | GET | `/v5/order/realtime` |
+| [cancelAllOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L957) | :closed_lock_with_key:  | POST | `/v5/order/cancel-all` |
+| [getHistoricOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L970) | :closed_lock_with_key:  | GET | `/v5/order/history` |
+| [getExecutionList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L982) | :closed_lock_with_key:  | GET | `/v5/execution/list` |
+| [batchSubmitOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1000) | :closed_lock_with_key:  | POST | `/v5/order/create-batch` |
+| [batchAmendOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1025) | :closed_lock_with_key:  | POST | `/v5/order/amend-batch` |
+| [batchCancelOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1050) | :closed_lock_with_key:  | POST | `/v5/order/cancel-batch` |
+| [getSpotBorrowCheck()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1072) | :closed_lock_with_key:  | GET | `/v5/order/spot-borrow-check` |
+| [setDisconnectCancelAllWindow()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1093) | :closed_lock_with_key:  | POST | `/v5/order/disconnected-cancel-all` |
+| [setDisconnectCancelAllWindowV2()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1111) | :closed_lock_with_key:  | POST | `/v5/order/disconnected-cancel-all` |
+| [preCheckOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1126) | :closed_lock_with_key:  | POST | `/v5/order/pre-check` |
+| [getPositionInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1149) | :closed_lock_with_key:  | GET | `/v5/position/list` |
+| [setLeverage()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1164) | :closed_lock_with_key:  | POST | `/v5/position/set-leverage` |
+| [switchIsolatedMargin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1177) | :closed_lock_with_key:  | POST | `/v5/position/switch-isolated` |
+| [setTPSLMode()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1191) | :closed_lock_with_key:  | POST | `/v5/position/set-tpsl-mode` |
+| [switchPositionMode()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1206) | :closed_lock_with_key:  | POST | `/v5/position/switch-mode` |
+| [setRiskLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1220) | :closed_lock_with_key:  | POST | `/v5/position/set-risk-limit` |
+| [setTradingStop()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1235) | :closed_lock_with_key:  | POST | `/v5/position/trading-stop` |
+| [setAutoAddMargin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1246) | :closed_lock_with_key:  | POST | `/v5/position/set-auto-add-margin` |
+| [addOrReduceMargin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1258) | :closed_lock_with_key:  | POST | `/v5/position/add-margin` |
+| [getClosedPnL()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1270) | :closed_lock_with_key:  | GET | `/v5/position/closed-pnl` |
+| [getClosedOptionsPositions()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1284) | :closed_lock_with_key:  | GET | `/v5/position/get-closed-positions` |
+| [movePosition()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1309) | :closed_lock_with_key:  | POST | `/v5/position/move-positions` |
+| [getMovePositionHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1320) | :closed_lock_with_key:  | GET | `/v5/position/move-history` |
+| [confirmNewRiskLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1339) | :closed_lock_with_key:  | POST | `/v5/position/confirm-pending-mmr` |
+| [getPreUpgradeOrderHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1359) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/order/history` |
+| [getPreUpgradeTradeHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1374) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/execution/list` |
+| [getPreUpgradeClosedPnl()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1385) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/position/closed-pnl` |
+| [getPreUpgradeTransactions()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1399) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/account/transaction-log` |
+| [getPreUpgradeOptionDeliveryRecord()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1416) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/asset/delivery-record` |
+| [getPreUpgradeUSDCSessionSettlements()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1430) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/asset/settlement-record` |
+| [getWalletBalance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1451) | :closed_lock_with_key:  | GET | `/v5/account/wallet-balance` |
+| [getTransferableAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1462) | :closed_lock_with_key:  | GET | `/v5/account/withdrawal` |
+| [getAccountInstrumentsInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1478) | :closed_lock_with_key:  | GET | `/v5/account/instruments-info` |
+| [upgradeToUnifiedAccount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1489) | :closed_lock_with_key:  | POST | `/v5/account/upgrade-to-uta` |
+| [getBorrowHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1500) | :closed_lock_with_key:  | GET | `/v5/account/borrow-history` |
+| [repayLiability()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1514) | :closed_lock_with_key:  | POST | `/v5/account/quick-repayment` |
+| [manualRepay()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1531) | :closed_lock_with_key:  | POST | `/v5/account/repay` |
+| [setCollateralCoin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1540) | :closed_lock_with_key:  | POST | `/v5/account/set-collateral-switch` |
+| [batchSetCollateralCoin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1546) | :closed_lock_with_key:  | POST | `/v5/account/set-collateral-switch-batch` |
+| [getCollateralInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1556) | :closed_lock_with_key:  | GET | `/v5/account/collateral-info` |
+| [getCoinGreeks()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1565) | :closed_lock_with_key:  | GET | `/v5/asset/coin-greeks` |
+| [getFeeRate()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1578) | :closed_lock_with_key:  | GET | `/v5/account/fee-rate` |
+| [getAccountInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1587) | :closed_lock_with_key:  | GET | `/v5/account/info` |
+| [getDCPInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1600) | :closed_lock_with_key:  | GET | `/v5/account/query-dcp-info` |
+| [getTransactionLog()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1607) | :closed_lock_with_key:  | GET | `/v5/account/transaction-log` |
+| [getClassicTransactionLogs()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1618) | :closed_lock_with_key:  | GET | `/v5/account/contract-transaction-log` |
+| [getSMPGroup()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1629) | :closed_lock_with_key:  | GET | `/v5/account/smp-group` |
+| [setMarginMode()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1642) | :closed_lock_with_key:  | POST | `/v5/account/set-margin-mode` |
+| [setSpotHedging()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1659) | :closed_lock_with_key:  | POST | `/v5/account/set-hedging-mode` |
+| [setLimitPriceAction()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1672) | :closed_lock_with_key:  | POST | `/v5/account/set-limit-px-action` |
+| [getLimitPriceAction()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1682) | :closed_lock_with_key:  | GET | `/v5/account/user-setting-config` |
+| [setMMP()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1694) | :closed_lock_with_key:  | POST | `/v5/account/mmp-modify` |
+| [resetMMP()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1701) | :closed_lock_with_key:  | POST | `/v5/account/mmp-reset` |
+| [getMMPState()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1708) | :closed_lock_with_key:  | GET | `/v5/account/mmp-state` |
+| [getDeliveryRecord()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1725) | :closed_lock_with_key:  | GET | `/v5/asset/delivery-record` |
+| [getSettlementRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1736) | :closed_lock_with_key:  | GET | `/v5/asset/settlement-record` |
+| [getCoinExchangeRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1749) | :closed_lock_with_key:  | GET | `/v5/asset/exchange/order-record` |
+| [getCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1761) | :closed_lock_with_key:  | GET | `/v5/asset/coin/query-info` |
+| [getSubUID()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1775) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-sub-member-list` |
+| [getAssetInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1790) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-asset-info` |
+| [getAllCoinsBalance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1801) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-account-coins-balance` |
+| [getCoinBalance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1815) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-account-coin-balance` |
+| [getWithdrawableAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1827) | :closed_lock_with_key:  | GET | `/v5/asset/withdraw/withdrawable-amount` |
+| [getTransferableCoinList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1836) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-transfer-coin-list` |
+| [createInternalTransfer()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1852) | :closed_lock_with_key:  | POST | `/v5/asset/transfer/inter-transfer` |
+| [getInternalTransferRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1871) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-inter-transfer-list` |
+| [enableUniversalTransferForSubUIDs()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1891) | :closed_lock_with_key:  | POST | `/v5/asset/transfer/save-transfer-sub-member` |
+| [createUniversalTransfer()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1902) | :closed_lock_with_key:  | POST | `/v5/asset/transfer/universal-transfer` |
+| [getUniversalTransferRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1914) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-universal-transfer-list` |
+| [getAllowedDepositCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1927) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-allowed-list` |
+| [setDepositAccount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1941) | :closed_lock_with_key:  | POST | `/v5/asset/deposit/deposit-to-account` |
+| [getDepositRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1957) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-record` |
+| [getSubAccountDepositRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1972) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-sub-member-record` |
+| [getInternalDepositRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1988) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-internal-record` |
+| [getMasterDepositAddress()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2000) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-address` |
+| [getSubDepositAddress()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2018) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-sub-member-address` |
+| [querySubMemberAddress()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2043) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-sub-member-address` |
+| [getWithdrawalRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2063) | :closed_lock_with_key:  | GET | `/v5/asset/withdraw/query-record` |
+| [getWithdrawalAddressList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2075) | :closed_lock_with_key:  | GET | `/v5/asset/withdraw/query-address` |
+| [getExchangeEntities()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2089) | :closed_lock_with_key:  | GET | `/v5/asset/withdraw/vasp/list` |
+| [submitWithdrawal()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2102) | :closed_lock_with_key:  | POST | `/v5/asset/withdraw/create` |
+| [cancelWithdrawal()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2113) | :closed_lock_with_key:  | POST | `/v5/asset/withdraw/cancel` |
+| [getConvertCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2122) | :closed_lock_with_key:  | GET | `/v5/asset/exchange/query-coin-list` |
+| [requestConvertQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2133) | :closed_lock_with_key:  | POST | `/v5/asset/exchange/quote-apply` |
+| [confirmConvertQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2142) | :closed_lock_with_key:  | POST | `/v5/asset/exchange/convert-execute` |
+| [getConvertStatus()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2154) | :closed_lock_with_key:  | GET | `/v5/asset/exchange/convert-result-query` |
+| [getConvertHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2173) | :closed_lock_with_key:  | GET | `/v5/asset/exchange/query-convert-history` |
+| [createSubMember()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2193) | :closed_lock_with_key:  | POST | `/v5/user/create-sub-member` |
+| [createSubUIDAPIKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2205) | :closed_lock_with_key:  | POST | `/v5/user/create-sub-api` |
+| [getSubUIDList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2214) | :closed_lock_with_key:  | GET | `/v5/user/query-sub-members` |
+| [getSubUIDListUnlimited()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2223) | :closed_lock_with_key:  | GET | `/v5/user/submembers` |
+| [setSubUIDFrozenState()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2241) | :closed_lock_with_key:  | POST | `/v5/user/frozen-sub-member` |
+| [getQueryApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2254) | :closed_lock_with_key:  | GET | `/v5/user/query-api` |
+| [getSubAccountAllApiKeys()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2261) | :closed_lock_with_key:  | GET | `/v5/user/sub-apikeys` |
+| [getUIDWalletType()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2270) | :closed_lock_with_key:  | GET | `/v5/user/get-member-type` |
+| [updateMasterApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2287) | :closed_lock_with_key:  | POST | `/v5/user/update-api` |
+| [updateSubApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2301) | :closed_lock_with_key:  | POST | `/v5/user/update-sub-api` |
+| [deleteSubMember()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2314) | :closed_lock_with_key:  | POST | `/v5/user/del-submember` |
+| [deleteMasterApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2329) | :closed_lock_with_key:  | POST | `/v5/user/delete-api` |
+| [deleteSubApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2343) | :closed_lock_with_key:  | POST | `/v5/user/delete-sub-api` |
+| [getAffiliateUserList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2363) | :closed_lock_with_key:  | GET | `/v5/affiliate/aff-user-list` |
+| [getAffiliateUserInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2390) | :closed_lock_with_key:  | GET | `/v5/user/aff-customer-info` |
+| [getVIPMarginData()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2410) |  | GET | `/v5/spot-margin-trade/data` |
+| [getHistoricalInterestRate()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2421) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/interest-rate-history` |
+| [toggleSpotMarginTrade()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2448) | :closed_lock_with_key:  | POST | `/v5/spot-margin-trade/switch-mode` |
+| [setSpotMarginLeverage()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2460) | :closed_lock_with_key:  | POST | `/v5/spot-margin-trade/set-leverage` |
+| [getSpotMarginState()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2471) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/state` |
+| [manualBorrow()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2478) | :closed_lock_with_key:  | POST | `/v5/account/borrow` |
+| [getMaxBorrowableAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2487) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/max-borrowable` |
+| [getPositionTiers()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2496) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/position-tiers` |
+| [getCoinState()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2507) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/coinstate` |
+| [getAvailableAmountToRepay()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2518) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/repayment-available-amount` |
+| [manualRepayWithoutConversion()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2533) | :closed_lock_with_key:  | POST | `/v5/account/no-convert-repay` |
+| [getSpotMarginCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2548) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/pledge-token` |
+| [getSpotMarginBorrowableCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2565) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/borrow-token` |
+| [getSpotMarginInterestAndQuota()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2582) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/loan-info` |
+| [getSpotMarginLoanAccountInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2600) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/account` |
+| [spotMarginBorrow()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2624) | :closed_lock_with_key:  | POST | `/v5/spot-cross-margin-trade/loan` |
+| [spotMarginRepay()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2635) | :closed_lock_with_key:  | POST | `/v5/spot-cross-margin-trade/repay` |
+| [getSpotMarginBorrowOrderDetail()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2650) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/orders` |
+| [getSpotMarginRepaymentOrderDetail()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2679) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/repay-history` |
+| [toggleSpotCrossMarginTrade()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2708) | :closed_lock_with_key:  | POST | `/v5/spot-cross-margin-trade/switch` |
+| [getCollateralCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2728) |  | GET | `/v5/crypto-loan/collateral-data` |
+| [getBorrowableCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2745) |  | GET | `/v5/crypto-loan/loanable-data` |
+| [getAccountBorrowCollateralLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2763) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/borrowable-collateralisable-number` |
+| [borrowCryptoLoan()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2783) | :closed_lock_with_key:  | POST | `/v5/crypto-loan/borrow` |
+| [repayCryptoLoan()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2804) | :closed_lock_with_key:  | POST | `/v5/crypto-loan/repay` |
+| [getUnpaidLoanOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2820) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/ongoing-orders` |
+| [getRepaymentHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2841) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/repayment-history` |
+| [getCompletedLoanOrderHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2861) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/borrow-history` |
+| [getMaxAllowedReductionCollateralAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2880) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/max-collateral-amount` |
+| [adjustCollateralAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2899) | :closed_lock_with_key:  | POST | `/v5/crypto-loan/adjust-ltv` |
+| [getLoanLTVAdjustmentHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2923) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/adjustment-history` |
+| [getLoanBorrowableCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2944) |  | GET | `/v5/crypto-loan-common/loanable-data` |
+| [getLoanCollateralCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2956) |  | GET | `/v5/crypto-loan-common/collateral-data` |
+| [getMaxCollateralAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2966) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-common/max-collateral-amount` |
+| [updateCollateralAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2981) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-common/adjust-ltv` |
+| [getCollateralAdjustmentHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2992) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-common/adjustment-history` |
+| [getCryptoLoanPosition()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3007) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-common/position` |
+| [borrowFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3024) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-flexible/borrow` |
+| [repayFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3035) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-flexible/repay` |
+| [repayCollateralFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3045) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-flexible/repay-collateral` |
+| [getOngoingFlexibleLoans()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3059) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-flexible/ongoing-coin` |
+| [getBorrowHistoryFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3071) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-flexible/borrow-history` |
+| [getRepaymentHistoryFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3084) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-flexible/repayment-history` |
+| [getSupplyOrderQuoteFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3109) |  | GET | `/v5/crypto-loan-fixed/supply-order-quote` |
+| [getBorrowOrderQuoteFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3122) |  | GET | `/v5/crypto-loan-fixed/borrow-order-quote` |
+| [createBorrowOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3135) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/borrow` |
+| [createSupplyOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3146) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/supply` |
+| [cancelBorrowOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3156) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/borrow-order-cancel` |
+| [cancelSupplyOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3168) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/supply-order-cancel` |
+| [getBorrowContractInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3181) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/borrow-contract-info` |
+| [getSupplyContractInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3199) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/supply-contract-info` |
+| [getBorrowOrderInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3217) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/borrow-order-info` |
+| [getSupplyOrderInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3230) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/supply-order-info` |
+| [repayFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3244) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/fully-repay` |
+| [repayCollateralFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3255) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-flexible/repay-collateral` |
+| [getRepaymentHistoryFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3268) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/repayment-history` |
+| [getInstitutionalLendingProductInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3286) |  | GET | `/v5/ins-loan/product-infos` |
+| [getInstitutionalLendingMarginCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3296) |  | GET | `/v5/ins-loan/ensure-tokens` |
+| [getInstitutionalLendingMarginCoinInfoWithConversionRate()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3305) |  | GET | `/v5/ins-loan/ensure-tokens-convert` |
+| [getInstitutionalLendingLoanOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3314) | :closed_lock_with_key:  | GET | `/v5/ins-loan/loan-order` |
+| [getInstitutionalLendingRepayOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3326) | :closed_lock_with_key:  | GET | `/v5/ins-loan/repaid-history` |
+| [getInstitutionalLendingLTV()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3338) | :closed_lock_with_key:  | GET | `/v5/ins-loan/ltv` |
+| [getInstitutionalLendingLTVWithLadderConversionRate()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3347) | :closed_lock_with_key:  | GET | `/v5/ins-loan/ltv-convert` |
+| [bindOrUnbindUID()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3362) | :closed_lock_with_key:  | POST | `/v5/ins-loan/association-uid` |
+| [getExchangeBrokerEarnings()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3386) | :closed_lock_with_key:  | GET | `/v5/broker/earnings-info` |
+| [getExchangeBrokerAccountInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3399) | :closed_lock_with_key:  | GET | `/v5/broker/account-info` |
+| [getBrokerSubAccountDeposits()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3415) | :closed_lock_with_key:  | GET | `/v5/broker/asset/query-sub-member-deposit-record` |
+| [getBrokerVoucherSpec()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3430) | :closed_lock_with_key:  | POST | `/v5/broker/award/info` |
+| [issueBrokerVoucher()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3442) | :closed_lock_with_key:  | POST | `/v5/broker/award/distribute-award` |
+| [getBrokerIssuedVoucher()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3454) | :closed_lock_with_key:  | POST | `/v5/broker/award/distribution-record` |
+| [getEarnProduct()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3471) |  | GET | `/v5/earn/product` |
+| [submitStakeRedeem()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3489) | :closed_lock_with_key:  | POST | `/v5/earn/place-order` |
+| [getEarnOrderHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3508) | :closed_lock_with_key:  | GET | `/v5/earn/order` |
+| [getEarnPosition()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3524) | :closed_lock_with_key:  | GET | `/v5/earn/position` |
+| [getEarnYieldHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3537) | :closed_lock_with_key:  | GET | `/v5/earn/yield` |
+| [getEarnHourlyYieldHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3551) | :closed_lock_with_key:  | GET | `/v5/earn/hourly-yield` |
+| [createRFQ()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3570) | :closed_lock_with_key:  | POST | `/v5/rfq/create-rfq` |
+| [getRFQConfig()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3581) | :closed_lock_with_key:  | GET | `/v5/rfq/config` |
+| [cancelRFQ()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3590) | :closed_lock_with_key:  | POST | `/v5/rfq/cancel-rfq` |
+| [cancelAllRFQ()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3600) | :closed_lock_with_key:  | POST | `/v5/rfq/cancel-all-rfq` |
+| [createRFQQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3609) | :closed_lock_with_key:  | POST | `/v5/rfq/create-quote` |
+| [executeRFQQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3620) | :closed_lock_with_key:  | POST | `/v5/rfq/execute-quote` |
+| [cancelRFQQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3631) | :closed_lock_with_key:  | POST | `/v5/rfq/cancel-quote` |
+| [cancelAllRFQQuotes()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3641) | :closed_lock_with_key:  | POST | `/v5/rfq/cancel-all-quotes` |
+| [getRFQRealtimeInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3655) | :closed_lock_with_key:  | GET | `/v5/rfq/rfq-realtime` |
+| [getRFQHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3667) | :closed_lock_with_key:  | GET | `/v5/rfq/rfq-list` |
+| [getRFQRealtimeQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3681) | :closed_lock_with_key:  | GET | `/v5/rfq/quote-realtime` |
+| [getRFQHistoryQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3696) | :closed_lock_with_key:  | GET | `/v5/rfq/quote-list` |
+| [getRFQTrades()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3709) | :closed_lock_with_key:  | GET | `/v5/rfq/trade-list` |
+| [getRFQPublicTrades()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3722) | :closed_lock_with_key:  | GET | `/v5/rfq/public-trades` |
+| [getP2PAccountCoinsBalance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3747) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-account-coins-balance` |
+| [getP2POnlineAds()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3764) | :closed_lock_with_key:  | POST | `/v5/p2p/item/online` |
+| [createP2PAd()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3773) | :closed_lock_with_key:  | POST | `/v5/p2p/item/create` |
+| [cancelP2PAd()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3782) | :closed_lock_with_key:  | POST | `/v5/p2p/item/cancel` |
+| [updateP2PAd()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3796) | :closed_lock_with_key:  | POST | `/v5/p2p/item/update` |
+| [getP2PPersonalAds()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3806) | :closed_lock_with_key:  | POST | `/v5/p2p/item/personal/list` |
+| [getP2PAdDetail()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3815) | :closed_lock_with_key:  | POST | `/v5/p2p/item/info` |
+| [getP2POrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3830) | :closed_lock_with_key:  | POST | `/v5/p2p/order/simplifyList` |
+| [getP2POrderDetail()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3840) | :closed_lock_with_key:  | POST | `/v5/p2p/order/info` |
+| [getP2PPendingOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3849) | :closed_lock_with_key:  | POST | `/v5/p2p/order/pending/simplifyList` |
+| [markP2POrderAsPaid()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3858) | :closed_lock_with_key:  | POST | `/v5/p2p/order/pay` |
+| [releaseP2POrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3867) | :closed_lock_with_key:  | POST | `/v5/p2p/order/finish` |
+| [sendP2POrderMessage()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3876) | :closed_lock_with_key:  | POST | `/v5/p2p/order/message/send` |
+| [getP2POrderMessages()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3910) | :closed_lock_with_key:  | POST | `/v5/p2p/order/message/listpage` |
+| [getP2PUserInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3924) | :closed_lock_with_key:  | POST | `/v5/p2p/user/personal/info` |
+| [getP2PCounterpartyUserInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3931) | :closed_lock_with_key:  | POST | `/v5/p2p/user/order/personal/info` |
+| [getP2PUserPayments()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3940) | :closed_lock_with_key:  | POST | `/v5/p2p/user/payment/list` |
+| [setApiRateLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3960) | :closed_lock_with_key:  | POST | `/v5/apilimit/set` |
+| [queryApiRateLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3989) | :closed_lock_with_key:  | GET | `/v5/apilimit/query` |
+| [getRateLimitCap()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4008) | :closed_lock_with_key:  | GET | `/v5/apilimit/query-cap` |
+| [getAllRateLimits()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4027) | :closed_lock_with_key:  | GET | `/v5/apilimit/query-all` |
 
 # websocket-api-client.ts
 

--- a/llms.txt
+++ b/llms.txt
@@ -38,7 +38,7 @@ Notes:
 ------
 - Some files may have been excluded based on .gitignore rules and Repomix's configuration
 - Binary files are not included in this packed representation. Please refer to the Repository Structure section for a complete list of file paths, including binary files
-- Files matching these patterns are excluded: .github/, docs/images/, docs/endpointFunctionList.md, test/, src/util/
+- Files matching these patterns are excluded: .github/, examples/apidoc/, docs/images/, docs/endpointFunctionList.md, test/, src/util/
 - Files matching patterns in .gitignore are excluded
 - Files matching default ignore patterns are excluded
 - Content has been compressed - code blocks are separated by ⋮---- delimiter
@@ -49,269 +49,6 @@ Notes:
 Directory Structure
 ================================================================
 examples/
-  apidoc/
-    V5/
-      Account/
-        batch-set-collateral-coin.js
-        get-account-info.js
-        get-borrow-history.js
-        get-coin-greeks.js
-        get-collateral-info.js
-        get-dcp-info.js
-        get-fee-rate.js
-        get-limit-price-behaviour.js
-        get-mmp-state.js
-        get-smp-group-id.js
-        get-transaction-log-classic.js
-        get-transaction-log-UTA.js
-        get-transferable-amount-unified.js
-        get-wallet-balance.js
-        README.md
-        repay-liability.js
-        reset-mmp.js
-        set-collateral-coin.js
-        set-limit-price-behaviour.js
-        set-margin-mode.js
-        set-mmp.js
-        set-spot-hedging.js
-        upgrade-to-unified-account.js
-      Affiliate/
-        get-affiliate-user-info.js
-        get-affiliate-user-list.js
-      API-Limit/
-        get-all-rate-limits.js
-        get-rate-limit-cap.js
-        get-rate-limit.js
-        set-rate-limit.js
-      Asset/
-        cancel-withdrawal.js
-        confirm-convert-quote.js
-        create-internal-transfer.js
-        create-universal-transfer.js
-        enable-universal-transfer-for-sub-uid.js
-        get-all-coins-balance.js
-        get-allowed-deposit-coin-info.js
-        get-asset-info-spot.js
-        get-coin-exchange-records.js
-        get-coin-info.js
-        get-convert-coins.js
-        get-convert-history.js
-        get-convert-status.js
-        get-delivery-record.js
-        get-deposit-records.js
-        get-exchange-entity-list.js
-        get-internal-deposit-records.js
-        get-internal-transfer-records.js
-        get-master-deposit-address.js
-        get-single-coin-balance.js
-        get-sub-deposit-address.js
-        get-sub-deposit-records.js
-        get-sub-uid.js
-        get-transferable-coin.js
-        get-universal-transfer-records.js
-        get-usdc-session-settlement.js
-        get-withdrawable-amount.js
-        get-withdrawal-records.js
-        README.md
-        request-convert-quote.js
-        set-deposit-account.js
-        withdraw.js
-      Broker/
-        get-exchange-broker-account-info.js
-        get-exchange-broker-earning.js
-        get-subaccount-deposit-records.js
-        issue-voucher.js
-        query-issued-voucher.js
-        query-voucher-spec.js
-      Crypto-Loan-Legacy/
-        adjust-collateral-amount.js
-        borrow.js
-        get-account-borrow-collateral-limit.js
-        get-borrowable-coins.js
-        get-collateral-coins.js
-        get-completed-loan-order-history.js
-        get-loan-LTV-adjustment-history.js
-        get-max-allowed-reduction-collateral-amount.js
-        get-repayment-transaction-history.js
-        get-unpaid-loan-orders.js
-        repay.js
-      Crypto-Loan-New/
-        Fixed-Loan/
-          cancel-borrow-order.js
-          cancel-supply-order.js
-          collateral-repayment.js
-          create-borrow-order.js
-          create-supply-order.js
-          get-borrow-contract-info.js
-          get-borrow-order-info.js
-          get-borrow-order-quote.js
-          get-repayment-history.js
-          get-supply-contract-info.js
-          get-supply-order-info.js
-          get-supply-order-quote.js
-          repay.js
-        Flexible-Loan/
-          borrow.js
-          collateral-repayment.js
-          get-borrow-history.js
-          get-ongoing-flexible-loans.js
-          get-repayment-history.js
-          repay.js
-        adjust-collateral-amount.js
-        get-borrowable-coins.js
-        get-collateral-adjustment-history.js
-        get-collateral-coins.js
-        get-crypto-loan-position.js
-        get-max-collateral-amount.js
-      Earn/
-        get-product-info.js
-        get-stake-redeem-order-history.js
-        get-staked-position.js
-        stake-redeem.js
-      Institutional-Loan/
-        bind-or-unbind-uid.js
-        get-loan-orders.js
-        get-LTV.js
-        get-margin-coin-info.js
-        get-product-info.js
-        get-repayment-orders.js
-      Market/
-        get-adl-alert.js
-        get-Bybit-server-time.js
-        get-delivery-price.js
-        get-fee-group-structure.js
-        get-funding-rate-history.js
-        get-historical-volatility.js
-        get-index-price-components.js
-        get-instruments-info.js
-        get-insurance.js
-        get-kline-index-price.js
-        get-kline-mark-price.js
-        get-kline-premium-index-price.js
-        get-kline.js
-        get-long-short-ratio.js
-        get-new-delivery-price.js
-        get-open-interest.js
-        get-order-price-limit.js
-        get-orderbook.js
-        get-public-trading-history.js
-        get-risk-limit.js
-        get-rpi-orderbook.js
-        get-tickers.js
-        README.md
-      P2P/
-        get-account-information.js
-        get-ad-detail.js
-        get-all-orders.js
-        get-chat-message.js
-        get-coin-balance.js
-        get-counterparty-user-info.js
-        get-market-online-ads-list.js
-        get-my-ads-list.js
-        get-order-detail.js
-        get-pending-orders.js
-        get-user-payment.js
-        mark-order-as-paid.js
-        post-new-ad.js
-        release-digital-asset.js
-        remove-my-ad.js
-        send-chat-message.js
-        update-relist-my-ad.js
-        upload-chat-file.js
-      Position/
-        add-or-reduce-margin.js
-        confirm-new-risk-limit.js
-        get-closed-options-positions.js
-        get-closed-pnl.js
-        get-execution.js
-        get-move-position-history.js
-        get-position-info.js
-        move-position.js
-        README.md
-        set-auto-add-margin.js
-        set-leverage.js
-        set-risk-limit.js
-        set-tpsl-mode.js
-        set-trading-stop.js
-        switch-cross-isolated-margin.js
-        switch-position-mode.js
-      Preupgrade/
-        get-preupgrade-closed-pnl.js
-        get-preupgrade-option-delivery-record.js
-        get-preupgrade-order-history.js
-        get-preupgrade-trade-history.js
-        get-preupgrade-transaction-log.js
-        get-preupgrade-USDC-session-settlement.js
-      Spot-Leverage-Token/
-        get-leverage-token-info.js
-        get-leveraged-token-market.js
-        get-purchase-redemption-records.js
-        purchase.js
-        README.md
-        redeem.js
-      Spot-Margin-Trade-(Normal)/
-        borrow.js
-        get-borrow-order-detail.js
-        get-borrowable-coin-info.js
-        get-interest-and-quota.js
-        get-loan-account-info.js
-        get-margin-coin-info.js
-        get-repayment-order-detail.js
-        README.md
-        repay.js
-        toggle-margin-trade-normal.js
-      Spot-Margin-Trade-(UTA)/
-        get-historical-interest-rate.js
-        get-status-and-leverage.js
-        get-vip-margin-data.js
-        README.md
-        set-leverage.js
-        toggle-margin-trade.js
-      Spread-Trading/
-        amend-spread-order.js
-        cancel-all-spread-orders.js
-        cancel-spread-order.js
-        create-spread-order.js
-        get-spread-instruments-info.js
-        get-spread-open-orders.js
-        get-spread-order-history.js
-        get-spread-orderbook.js
-        get-spread-tickers.js
-        get-spread-trade-history.js
-      Trade/
-        amend-order.js
-        batch-amend-order.js
-        batch-cancel-order.js
-        batch-place-order.js
-        cancel-all-orders.js
-        cancel-order.js
-        confirm-new-risk-limit.js
-        get-move-position-history.js
-        get-open-orders.js
-        get-order-history.js
-        get-spot-borrow-quota.js
-        move-position.js
-        place-order.js
-        pre-check-order.js
-        README.md
-        set-dcp.js
-      User/
-        create-sub-uid-api-key.js
-        create-sub-uid.js
-        delete-master-api-key.js
-        delete-sub-api-key.js
-        delete-sub-uid.js
-        freeze-sub-uid.js
-        get-api-key-info.js
-        get-sub-all-api-keys.js
-        get-sub-uid-list-unlimited.js
-        get-sub-uid-list.js
-        get-uid-wallet-type.js
-        modify-master-api-key.js
-        modify-sub-api-key.js
-        README.md
-    README.md
-    typescripttest.ts
   deprecated/
     README.md
   demo-trading.ts
@@ -320,10 +57,13 @@ examples/
   rest-v5-all.ts
   rest-v5-custom-url.ts
   rest-v5-next-cursor.ts
+  rest-v5-p2p.ts
   rest-v5-private.ts
   rest-v5-proxies.ts
   rest-v5-proxies2.ts
   rest-v5-public.ts
+  RSA-sign.md
+  RSA-sign.ts
   ws-api-client.ts
   ws-api-raw-events.ts
   ws-api-raw-promises.ts
@@ -418,2641 +158,6 @@ tsconfig.test.json
 ================================================================
 Files
 ================================================================
-
-================
-File: examples/apidoc/V5/Account/batch-set-collateral-coin.js
-================
-const client = new RestClientV5({
-⋮----
-.batchSetCollateralCoin({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/get-account-info.js
-================
-const client = new RestClientV5({
-⋮----
-.getAccountInfo()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/get-borrow-history.js
-================
-const client = new RestClientV5({
-⋮----
-.getBorrowHistory({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/get-coin-greeks.js
-================
-const client = new RestClientV5({
-⋮----
-.getCoinGreeks('BTC')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/get-collateral-info.js
-================
-const client = new RestClientV5({
-⋮----
-.getCollateralInfo('BTC')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/get-dcp-info.js
-================
-const client = new RestClientV5({
-⋮----
-.getDCPInfo()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/get-fee-rate.js
-================
-const client = new RestClientV5({
-⋮----
-.getFeeRate({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/get-mmp-state.js
-================
-const client = new RestClientV5({
-⋮----
-.getMMPState('ETH')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/get-smp-group-id.js
-================
-const client = new RestClientV5({
-⋮----
-.getSMPGroup()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/get-transaction-log-classic.js
-================
-const client = new RestClientV5({
-⋮----
-.getClassicTransactionLogs({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/get-transaction-log-UTA.js
-================
-const client = new RestClientV5({
-⋮----
-.getTransactionLog({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/get-transferable-amount-unified.js
-================
-const client = new RestClientV5({
-⋮----
-.getTransferableAmount({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/get-wallet-balance.js
-================
-const client = new RestClientV5({
-⋮----
-.getWalletBalance({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/README.md
-================
-# V5 - REST - Account
-
-https://bybit-exchange.github.io/docs/v5/account/wallet-balance
-
-================
-File: examples/apidoc/V5/Account/repay-liability.js
-================
-const client = new RestClientV5({
-⋮----
-.repayLiability({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/reset-mmp.js
-================
-const client = new RestClientV5({
-⋮----
-.resetMMP('ETH')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/set-collateral-coin.js
-================
-const client = new RestClientV5({
-⋮----
-.setCollateralCoin({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/set-margin-mode.js
-================
-const client = new RestClientV5({
-⋮----
-.setMarginMode('PORTFOLIO_MARGIN')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/set-mmp.js
-================
-const client = new RestClientV5({
-⋮----
-.setMMP({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/set-spot-hedging.js
-================
-const client = new RestClientV5({
-⋮----
-.setSpotHedging({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/upgrade-to-unified-account.js
-================
-const client = new RestClientV5({
-⋮----
-.upgradeToUnifiedAccount()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Affiliate/get-affiliate-user-info.js
-================
-// https://api.bybit.com/v5/broker/account-info
-⋮----
-const client = new RestClientV5({
-⋮----
-.getAffiliateUserInfo({ uid: '1234567890' })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Affiliate/get-affiliate-user-list.js
-================
-// https://api.bybit.com/v5/broker/account-info
-⋮----
-const client = new RestClientV5({
-⋮----
-.getAffiliateUserList()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/API-Limit/get-all-rate-limits.js
-================
-const client = new RestClientV5({
-⋮----
-// Get all rate limits without filters
-⋮----
-.getAllRateLimits()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-⋮----
-// Get all rate limits with filters
-⋮----
-.getAllRateLimits({
-
-================
-File: examples/apidoc/V5/API-Limit/get-rate-limit-cap.js
-================
-const client = new RestClientV5({
-⋮----
-.getRateLimitCap()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/API-Limit/get-rate-limit.js
-================
-const client = new RestClientV5({
-⋮----
-.queryApiRateLimit({
-⋮----
-.then((response) => {
-console.log(response);
-// Response now contains 'rate' field instead of 'limit'
-console.log('Rate limits:', response.result.list);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/API-Limit/set-rate-limit.js
-================
-const client = new RestClientV5({
-⋮----
-.setApiRateLimit({
-⋮----
-rate: 100, // Changed from 'limit' to 'rate'
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/cancel-withdrawal.js
-================
-const client = new RestClientV5({
-⋮----
-.cancelWithdrawal('10197')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/confirm-convert-quote.js
-================
-const client = new RestClientV5({
-⋮----
-.confirmConvertQuote({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/create-internal-transfer.js
-================
-const client = new RestClientV5({
-⋮----
-.createInternalTransfer(
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/create-universal-transfer.js
-================
-const client = new RestClientV5({
-⋮----
-.createUniversalTransfer({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/enable-universal-transfer-for-sub-uid.js
-================
-const client = new RestClientV5({
-⋮----
-.enableUniversalTransferForSubUIDs(['554117', '592324', '592334'])
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-all-coins-balance.js
-================
-const client = new RestClientV5({
-⋮----
-.getAllCoinsBalance({ accountType: 'FUND', coin: 'USDC' })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-allowed-deposit-coin-info.js
-================
-const client = new RestClientV5({
-⋮----
-.getAllowedDepositCoinInfo({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-asset-info-spot.js
-================
-const client = new RestClientV5({
-⋮----
-.getAssetInfo({ accountType: 'FUND', coin: 'USDC' })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-coin-exchange-records.js
-================
-const client = new RestClientV5({
-⋮----
-.getCoinExchangeRecords({ limit: 10 })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-coin-info.js
-================
-const client = new RestClientV5({
-⋮----
-.getCoinInfo('ETH')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-convert-coins.js
-================
-const client = new RestClientV5({
-⋮----
-.getConvertCoins({ accountType: 'eb_convert_spot' })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-convert-history.js
-================
-const client = new RestClientV5({
-⋮----
-.getConvertHistory()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-convert-status.js
-================
-const client = new RestClientV5({
-⋮----
-.getConvertStatus({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-delivery-record.js
-================
-const client = new RestClientV5({
-⋮----
-.getDeliveryRecord({ category: 'option', expDate: '29DEC22' })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-deposit-records.js
-================
-const client = new RestClientV5({
-⋮----
-.getDepositRecords({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-exchange-entity-list.js
-================
-// https://api.bybit.com/v5/asset/withdraw/vasp/list
-⋮----
-const client = new RestClientV5({
-⋮----
-.getExchangeEntities()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-internal-deposit-records.js
-================
-const client = new RestClientV5({
-⋮----
-.getInternalDepositRecords({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-internal-transfer-records.js
-================
-const client = new RestClientV5({
-⋮----
-.getInternalTransferRecords({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-master-deposit-address.js
-================
-const client = new RestClientV5({
-⋮----
-.getMasterDepositAddress('USDT', 'ETH')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-single-coin-balance.js
-================
-const client = new RestClientV5({
-⋮----
-.getCoinBalance({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-sub-deposit-address.js
-================
-const client = new RestClientV5({
-⋮----
-.getSubDepositAddress('USDT', 'TRX', '592334')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-sub-deposit-records.js
-================
-const client = new RestClientV5({
-⋮----
-.getSubAccountDepositRecords({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-sub-uid.js
-================
-const client = new RestClientV5({
-⋮----
-.getSubUID()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-transferable-coin.js
-================
-const client = new RestClientV5({
-⋮----
-.getTransferableCoinList('UNIFIED', 'CONTRACT')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-universal-transfer-records.js
-================
-const client = new RestClientV5({
-⋮----
-.getUniversalTransferRecords({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-usdc-session-settlement.js
-================
-const client = new RestClientV5({
-⋮----
-.getSettlementRecords({ category: 'linear' })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-withdrawable-amount.js
-================
-const client = new RestClientV5({
-⋮----
-.getWithdrawableAmount({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/get-withdrawal-records.js
-================
-const client = new RestClientV5({
-⋮----
-.getWithdrawalRecords({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/README.md
-================
-# V5 - REST - Asset
-
-https://bybit-exchange.github.io/docs/v5/asset/exchange
-
-================
-File: examples/apidoc/V5/Asset/request-convert-quote.js
-================
-const client = new RestClientV5({
-⋮----
-.requestConvertQuote({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/set-deposit-account.js
-================
-const client = new RestClientV5({
-⋮----
-.setDepositAccount({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Asset/withdraw.js
-================
-const client = new RestClientV5({
-⋮----
-.submitWithdrawal({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Broker/get-exchange-broker-account-info.js
-================
-// https://api.bybit.com/v5/broker/account-info
-⋮----
-const client = new RestClientV5({
-⋮----
-.getExchangeBrokerAccountInfo()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Broker/get-exchange-broker-earning.js
-================
-// https://api.bybit.com/v5/broker/earnings-info
-⋮----
-const client = new RestClientV5({
-⋮----
-.getExchangeBrokerEarnings({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Broker/get-subaccount-deposit-records.js
-================
-// https://api.bybit.com/v5/broker/asset/query-sub-member-deposit-record
-⋮----
-const client = new RestClientV5({
-⋮----
-.getBrokerSubAccountDeposits({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Broker/issue-voucher.js
-================
-const client = new RestClientV5({
-⋮----
-.issueBrokerVoucher({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Broker/query-issued-voucher.js
-================
-const client = new RestClientV5({
-⋮----
-.getBrokerVoucherSpec({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Broker/query-voucher-spec.js
-================
-const client = new RestClientV5({
-⋮----
-.getBrokerIssuedVoucher({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Earn/get-product-info.js
-================
-const client = new RestClientV5({
-⋮----
-.getEarnProduct({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Earn/get-stake-redeem-order-history.js
-================
-const client = new RestClientV5({
-⋮----
-.getEarnOrderHistory({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Earn/get-staked-position.js
-================
-const client = new RestClientV5({
-⋮----
-.getEarnPosition({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Earn/stake-redeem.js
-================
-const client = new RestClientV5({
-⋮----
-.submitStakeRedeem({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Institutional-Loan/bind-or-unbind-uid.js
-================
-// https://api.bybit.com/v5/ins-loan/association-uid
-⋮----
-const client = new RestClientV5({
-⋮----
-.bindOrUnbindUID({
-⋮----
-operate: '0', // 0 for bind, 1 for unbind
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Institutional-Loan/get-loan-orders.js
-================
-// https://api.bybit.com/v5/ins-loan/loan-order
-⋮----
-const client = new RestClientV5({
-⋮----
-.getInstitutionalLendingLoanOrders({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Institutional-Loan/get-LTV.js
-================
-// https://api.bybit.com/v5/ins-loan/ltv-convert
-⋮----
-const client = new RestClientV5({
-⋮----
-.getInstitutionalLendingLTVWithLadderConversionRate()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Institutional-Loan/get-margin-coin-info.js
-================
-// https://api.bybit.com/v5/ins-loan/ensure-tokens-convert
-⋮----
-const client = new RestClientV5({
-⋮----
-.getInstitutionalLendingMarginCoinInfoWithConversionRate({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Institutional-Loan/get-product-info.js
-================
-// https://api.bybit.com/v5/ins-loan/product-infos
-⋮----
-const client = new RestClientV5({
-⋮----
-.getInstitutionalLendingProductInfo({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Institutional-Loan/get-repayment-orders.js
-================
-// https://api.bybit.com/v5/ins-loan/repaid-history
-⋮----
-const client = new RestClientV5({
-⋮----
-.getInstitutionalLendingRepayOrders({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-adl-alert.js
-================
-const client = new RestClientV5({
-⋮----
-// Get ADL alerts for all symbols
-⋮----
-.getADLAlert()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-⋮----
-// Get ADL alerts for a specific symbol
-⋮----
-.getADLAlert({
-
-================
-File: examples/apidoc/V5/Market/get-Bybit-server-time.js
-================
-const client = new RestClientV5({
-⋮----
-.getServerTime()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-delivery-price.js
-================
-const client = new RestClientV5({
-⋮----
-.getDeliveryPrice({ category: 'option', symbol: 'ETH-26DEC22-1400-C' })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-fee-group-structure.js
-================
-const client = new RestClientV5({
-⋮----
-// Get fee group structure for all groups
-⋮----
-.getFeeGroupStructure({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-⋮----
-// Get fee group structure for a specific group
-
-================
-File: examples/apidoc/V5/Market/get-funding-rate-history.js
-================
-const client = new RestClientV5({
-⋮----
-.getFundingRateHistory({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-historical-volatility.js
-================
-const client = new RestClientV5({
-⋮----
-.getHistoricalVolatility({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-index-price-components.js
-================
-const client = new RestClientV5({
-⋮----
-.getIndexPriceComponents({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-instruments-info.js
-================
-const client = new RestClientV5({
-⋮----
-// linear
-⋮----
-.getInstrumentsInfo({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-⋮----
-// option
-⋮----
-// spot
-
-================
-File: examples/apidoc/V5/Market/get-insurance.js
-================
-const client = new RestClientV5({
-⋮----
-.getInsurance({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-kline-index-price.js
-================
-const client = new RestClientV5({
-⋮----
-.getIndexPriceKline({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-kline-mark-price.js
-================
-const client = new RestClientV5({
-⋮----
-.getMarkPriceKline({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-kline-premium-index-price.js
-================
-const client = new RestClientV5({
-⋮----
-.getPremiumIndexPriceKline({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-kline.js
-================
-const client = new RestClientV5({
-⋮----
-.getKline({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-long-short-ratio.js
-================
-const client = new RestClientV5({
-⋮----
-.getLongShortRatio({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-open-interest.js
-================
-const client = new RestClientV5({
-⋮----
-.getOpenInterest({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-orderbook.js
-================
-const client = new RestClientV5({
-⋮----
-.getOrderbook({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-public-trading-history.js
-================
-const client = new RestClientV5({
-⋮----
-.getPublicTradingHistory({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-risk-limit.js
-================
-const client = new RestClientV5({
-⋮----
-.getRiskLimit({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-rpi-orderbook.js
-================
-const client = new RestClientV5({
-⋮----
-.getRPIOrderbook({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-tickers.js
-================
-const client = new RestClientV5({
-⋮----
-// inverse
-⋮----
-.getTickers({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-⋮----
-// option
-⋮----
-// spot
-
-================
-File: examples/apidoc/V5/Market/README.md
-================
-# V5 - REST - Market
-
-https://bybit-exchange.github.io/docs/v5/market/kline
-
-================
-File: examples/apidoc/V5/P2P/get-account-information.js
-================
-// Initialize the client with testnet mode
-const client = new RestClientV5({
-⋮----
-// Call the function
-⋮----
-.getP2PUserInfo()
-.then((response) => {
-console.log('Response:', response);
-⋮----
-.catch((error) => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/P2P/get-ad-detail.js
-================
-// Initialize the client with testnet mode
-const client = new RestClientV5({
-⋮----
-// Example parameters
-⋮----
-itemId: '1898988222063644672', // Replace with your ad ID
-⋮----
-// Call the function
-⋮----
-.getP2PAdDetail(params)
-.then((response) => {
-console.log('Response:', response);
-⋮----
-.catch((error) => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/P2P/get-all-orders.js
-================
-// Initialize the client with testnet mode
-const client = new RestClientV5({
-⋮----
-// Example parameters
-⋮----
-status: null, // Optional: filter by order status
-beginTime: null, // Optional: filter by start time
-endTime: null, // Optional: filter by end time
-tokenId: null, // Optional: filter by token ID
-side: null, // Optional: filter by side (0: Buy, 1: Sell)
-page: 1, // Required: page number
-size: 1, // Required: rows per page
-⋮----
-// Call the function
-⋮----
-.getP2POrders(params)
-.then((response) => {
-console.log('Response:', response);
-⋮----
-.catch((error) => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/P2P/get-chat-message.js
-================
-// Initialize the client with testnet mode
-const client = new RestClientV5({
-⋮----
-// Example parameters
-⋮----
-orderId: '1898976123321221120', // Replace with your order ID
-size: '1', // Number of messages per page
-currentPage: '1', // Optional: current page number
-⋮----
-// Call the function
-⋮----
-.getP2POrderMessages(params)
-.then((response) => {
-console.log('Response:', response);
-⋮----
-.catch((error) => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/P2P/get-coin-balance.js
-================
-// Create a client
-const client = new RestClientV5({
-⋮----
-// Get account coins balance
-⋮----
-.getP2PAccountCoinsBalance({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/P2P/get-counterparty-user-info.js
-================
-// Initialize the client with testnet mode
-const client = new RestClientV5({
-⋮----
-// Example parameters
-⋮----
-originalUid: '290118', // Replace with the counterparty user ID
-orderId: '1900004704665923584', // Replace with your order ID
-⋮----
-// Call the function
-⋮----
-.getP2PCounterpartyUserInfo(params)
-.then((response) => {
-console.log('Response:', response);
-⋮----
-.catch((error) => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/P2P/get-market-online-ads-list.js
-================
-// Create a client
-const client = new RestClientV5({
-⋮----
-// Get market online ads list
-⋮----
-.getP2POnlineAds({
-⋮----
-side: '0', // 0: buy; 1: sell
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/P2P/get-my-ads-list.js
-================
-// Initialize the client with testnet mode
-const client = new RestClientV5({
-⋮----
-// Example parameters for getting personal P2P ads
-⋮----
-itemId: '123456789', // Optional: Specific advertisement ID
-status: 1, // Optional: Advertisement status (1: active, 2: completed, 3: cancelled)
-side: 1, // Optional: 0: buy; 1: sell
-tokenId: 'USDT', // Optional: Token ID
-page: 1, // Optional: Page number
-size: 20, // Optional: Page size
-currencyId: 'USD' // Optional: Currency ID
-⋮----
-// Get personal P2P ads
-client.getP2PPersonalAds(params)
-.then(response => {
-console.log('Response:', response);
-⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/P2P/get-order-detail.js
-================
-// Initialize the client with testnet mode
-const client = new RestClientV5({
-⋮----
-// Example parameters
-⋮----
-orderId: '1900004704665923584', // Replace with your order ID
-⋮----
-// Call the function
-⋮----
-.getP2POrderDetail(params)
-.then((response) => {
-console.log('Response:', response);
-⋮----
-.catch((error) => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/P2P/get-pending-orders.js
-================
-// Initialize the client with testnet mode
-const client = new RestClientV5({
-⋮----
-// Example parameters
-⋮----
-status: 10, // waiting for buy pay
-beginTime: '1741831397000', // Optional: filter by start time
-endTime: '1741831424861', // Optional: filter by end time
-tokenId: 'USDT', // Optional: filter by token
-side: [0, 1], // Optional: filter by side (0: Buy, 1: Sell)
-⋮----
-// Call the function
-⋮----
-.getP2PPendingOrders(params)
-.then((response) => {
-console.log('Response:', response);
-⋮----
-.catch((error) => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/P2P/get-user-payment.js
-================
-// Initialize the client with testnet mode
-const client = new RestClientV5({
-⋮----
-// Call the function
-⋮----
-.getP2PUserPayments()
-.then((response) => {
-console.log('Response:', response);
-⋮----
-.catch((error) => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/P2P/mark-order-as-paid.js
-================
-// Initialize the client with testnet mode
-const client = new RestClientV5({
-⋮----
-// Example parameters
-⋮----
-orderId: '1899736339155943424', // Replace with your order ID
-paymentType: '14', // Payment method used
-paymentId: '7110', // Payment method ID used
-⋮----
-// Call the function
-⋮----
-.markP2POrderAsPaid(params)
-.then((response) => {
-console.log('Response:', response);
-⋮----
-.catch((error) => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/P2P/post-new-ad.js
-================
-// Create a client
-const client = new RestClientV5({
-⋮----
-// Create new P2P advertisement
-⋮----
-.createP2PAd({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/P2P/release-digital-asset.js
-================
-// Initialize the client with testnet mode
-const client = new RestClientV5({
-⋮----
-// Example parameters
-⋮----
-orderId: '1899736339155943424', // Replace with your order ID
-⋮----
-// Call the function
-⋮----
-.releaseP2POrder(params)
-.then((response) => {
-console.log('Response:', response);
-⋮----
-.catch((error) => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/P2P/remove-my-ad.js
-================
-// Create a client
-const client = new RestClientV5({
-⋮----
-// Cancel P2P advertisement
-⋮----
-.cancelP2PAd({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/P2P/send-chat-message.js
-================
-// Initialize the client with testnet mode
-const client = new RestClientV5({
-⋮----
-// Example parameters
-⋮----
-orderId: '1898976123321221120', // Replace with your order ID
-// Optional parameters:
-// msgUuid: 'your-message-uuid',
-// fileName: 'example.pdf'
-⋮----
-// Call the function
-⋮----
-.sendP2POrderMessage(params)
-.then((response) => {
-console.log('Response:', response);
-⋮----
-.catch((error) => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/P2P/update-relist-my-ad.js
-================
-// Create a client
-const client = new RestClientV5({
-⋮----
-// Update P2P advertisement
-⋮----
-.updateP2PAd({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/P2P/upload-chat-file.js
-================
-// Initialize the client with testnet mode
-const client = new RestClientV5({
-⋮----
-// Create form data
-const formData = new FormData();
-formData.append('upload_file', fs.createReadStream('path/to/your/file.jpg')); // Replace with your file path
-⋮----
-// Call the function
-⋮----
-.uploadP2PChatFile(formData)
-.then((response) => {
-console.log('Response:', response);
-⋮----
-.catch((error) => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Position/add-or-reduce-margin.js
-================
-const client = new RestClientV5({
-⋮----
-.addOrReduceMargin({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Position/confirm-new-risk-limit.js
-================
-const client = new RestClientV5({
-⋮----
-.confirmNewRiskLimit({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Position/get-closed-pnl.js
-================
-const client = new RestClientV5({
-⋮----
-.getClosedPnL({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Position/get-execution.js
-================
-const client = new RestClientV5({
-⋮----
-.addOrReduceMargin({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Position/get-move-position-history.js
-================
-const client = new RestClientV5({
-⋮----
-.getMovePositionHistory()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Position/get-position-info.js
-================
-const client = new RestClientV5({
-⋮----
-.getPositionInfo({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Position/move-position.js
-================
-const client = new RestClientV5({
-⋮----
-.movePosition({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Position/README.md
-================
-# V5 - REST - Position
-
-https://bybit-exchange.github.io/docs/v5/position
-
-================
-File: examples/apidoc/V5/Position/set-auto-add-margin.js
-================
-const client = new RestClientV5({
-⋮----
-.setAutoAddMargin({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Position/set-leverage.js
-================
-const client = new RestClientV5({
-⋮----
-.setLeverage({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Position/set-risk-limit.js
-================
-const client = new RestClientV5({
-⋮----
-.setRiskLimit({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Position/set-tpsl-mode.js
-================
-const client = new RestClientV5({
-⋮----
-.setTPSLMode({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Position/set-trading-stop.js
-================
-const client = new RestClientV5({
-⋮----
-.setTradingStop({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Position/switch-cross-isolated-margin.js
-================
-const client = new RestClientV5({
-⋮----
-.switchIsolatedMargin({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Position/switch-position-mode.js
-================
-const client = new RestClientV5({
-⋮----
-.switchPositionMode({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Preupgrade/get-preupgrade-closed-pnl.js
-================
-const client = new RestClientV5({
-⋮----
-.getPreUpgradeClosedPnl({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Preupgrade/get-preupgrade-option-delivery-record.js
-================
-const client = new RestClientV5({
-⋮----
-.getPreUpgradeOptionDeliveryRecord({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Preupgrade/get-preupgrade-order-history.js
-================
-const client = new RestClientV5({
-⋮----
-.getPreUpgradeOrderHistory({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Preupgrade/get-preupgrade-trade-history.js
-================
-const client = new RestClientV5({
-⋮----
-.getPreUpgradeTradeHistory({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Preupgrade/get-preupgrade-transaction-log.js
-================
-const client = new RestClientV5({
-⋮----
-.getPreUpgradeTransactionLog({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Preupgrade/get-preupgrade-USDC-session-settlement.js
-================
-const client = new RestClientV5({
-⋮----
-.getPreUpgradeUSDCSessionSettlement({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Leverage-Token/get-leverage-token-info.js
-================
-const client = new RestClientV5({
-⋮----
-.getLeveragedTokenInfo('BTC3L')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Leverage-Token/get-leveraged-token-market.js
-================
-const client = new RestClientV5({
-⋮----
-.getLeveragedTokenMarket('BTC3L')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Leverage-Token/get-purchase-redemption-records.js
-================
-const client = new RestClientV5({
-⋮----
-.getSpotLeveragedTokenOrderHistory({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Leverage-Token/purchase.js
-================
-const client = new RestClientV5({
-⋮----
-.purchaseSpotLeveragedToken({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Leverage-Token/README.md
-================
-# V5 - REST - Spot Leverage Token
-
-https://bybit-exchange.github.io/docs/v5/lt/leverage-token-info
-
-================
-File: examples/apidoc/V5/Spot-Leverage-Token/redeem.js
-================
-const client = new RestClientV5({
-⋮----
-.redeemSpotLeveragedToken({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Margin-Trade-(Normal)/borrow.js
-================
-const client = new RestClientV5({
-⋮----
-.spotMarginBorrow({ coin: 'ETH', qty: '10' })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-borrow-order-detail.js
-================
-const client = new RestClientV5({
-⋮----
-.getSpotMarginBorrowOrderDetail({ coin: 'ETH', limit: 1, status: 2 })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-borrowable-coin-info.js
-================
-const client = new RestClientV5({
-⋮----
-.getSpotMarginBorrowableCoinInfo('ETH')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-interest-and-quota.js
-================
-const client = new RestClientV5({
-⋮----
-.getSpotMarginInterestAndQuota('ETH')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-loan-account-info.js
-================
-const client = new RestClientV5({
-⋮----
-.getSpotMarginLoanAccountInfo()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-margin-coin-info.js
-================
-const client = new RestClientV5({
-⋮----
-.getSpotMarginCoinInfo('ETH')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-repayment-order-detail.js
-================
-const client = new RestClientV5({
-⋮----
-.getSpotMarginRepaymentOrderDetail({ coin: 'ETH', limit: 1 })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Margin-Trade-(Normal)/README.md
-================
-# V5 - REST - Spot Margin Trade (Normal)
-
-https://bybit-exchange.github.io/docs/v5/spot-margin-normal/margin-data
-
-================
-File: examples/apidoc/V5/Spot-Margin-Trade-(Normal)/repay.js
-================
-const client = new RestClientV5({
-⋮----
-.spotMarginRepay({ coin: 'ETH', completeRepayment: 1 })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Margin-Trade-(Normal)/toggle-margin-trade-normal.js
-================
-const client = new RestClientV5({
-⋮----
-.toggleSpotCrossMarginTrade({ switch: 0 })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Margin-Trade-(UTA)/get-historical-interest-rate.js
-================
-const client = new RestClientV5({
-⋮----
-.getHistoricalInterestRate({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Margin-Trade-(UTA)/get-status-and-leverage.js
-================
-// https://api.bybit.com/v5/spot-margin-trade/state
-⋮----
-const client = new RestClientV5({
-⋮----
-.getSpotMarginState()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Margin-Trade-(UTA)/get-vip-margin-data.js
-================
-// https://api.bybit.com/v5/spot-margin-trade/data
-⋮----
-const client = new RestClientV5({
-⋮----
-.getVIPMarginData({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Margin-Trade-(UTA)/README.md
-================
-# V5 - REST - Spot Margin Trade (UTA)
-
-https://bybit-exchange.github.io/docs/v5/spot-margin-uta/switch-mode
-
-================
-File: examples/apidoc/V5/Spot-Margin-Trade-(UTA)/set-leverage.js
-================
-const client = new RestClientV5({
-⋮----
-.setSpotMarginLeverage('4')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spot-Margin-Trade-(UTA)/toggle-margin-trade.js
-================
-const client = new RestClientV5({
-⋮----
-.toggleSpotMarginTrade('0')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spread-Trading/amend-spread-order.js
-================
-const client = new RestClientV5({
-⋮----
-.amendSpreadOrder({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spread-Trading/cancel-all-spread-orders.js
-================
-const client = new RestClientV5({
-⋮----
-.cancelAllSpreadOrders()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spread-Trading/cancel-spread-order.js
-================
-const client = new RestClientV5({
-⋮----
-.cancelSpreadOrder({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spread-Trading/create-spread-order.js
-================
-const client = new RestClientV5({
-⋮----
-.submitSpreadOrder({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spread-Trading/get-spread-instruments-info.js
-================
-const client = new RestClientV5({
-⋮----
-.getSpreadInstrumentsInfo()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spread-Trading/get-spread-open-orders.js
-================
-const client = new RestClientV5({
-⋮----
-.getSpreadOpenOrders()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spread-Trading/get-spread-order-history.js
-================
-const client = new RestClientV5({
-⋮----
-.getSpreadOrderHistory({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spread-Trading/get-spread-orderbook.js
-================
-const client = new RestClientV5({
-⋮----
-.getSpreadOrderbook({
-⋮----
-limit: 1, // Show 5 levels of depth
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spread-Trading/get-spread-tickers.js
-================
-const client = new RestClientV5({
-⋮----
-.getSpreadTickers({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Spread-Trading/get-spread-trade-history.js
-================
-const client = new RestClientV5({
-⋮----
-.getSpreadTradeHistory({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Trade/amend-order.js
-================
-const client = new RestClientV5({
-⋮----
-.submitOrder({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Trade/batch-amend-order.js
-================
-const client = new RestClientV5({
-⋮----
-.batchAmendOrders('option', [
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Trade/batch-cancel-order.js
-================
-const client = new RestClientV5({
-⋮----
-.batchCancelOrders('option', [
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Trade/batch-place-order.js
-================
-const client = new RestClientV5({
-⋮----
-.batchSubmitOrders('option', [
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Trade/cancel-all-orders.js
-================
-const client = new RestClientV5({
-⋮----
-.cancelAllOrders({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Trade/cancel-order.js
-================
-const client = new RestClientV5({
-⋮----
-.cancelOrder({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Trade/confirm-new-risk-limit.js
-================
-const client = new RestClientV5({
-⋮----
-.confirmNewRiskLimit({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Trade/get-move-position-history.js
-================
-const client = new RestClientV5({
-⋮----
-.getMovePositionHistory({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Trade/get-open-orders.js
-================
-const client = new RestClientV5({
-⋮----
-.getActiveOrders({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Trade/get-order-history.js
-================
-const client = new RestClientV5({
-⋮----
-.getHistoricOrders({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Trade/get-spot-borrow-quota.js
-================
-const client = new RestClientV5({
-⋮----
-.getSpotBorrowCheck('BTCUSDT', 'Buy')
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Trade/move-position.js
-================
-const client = new RestClientV5({
-⋮----
-.movePosition({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Trade/place-order.js
-================
-const client = new RestClientV5({
-⋮----
-// Submit a market order
-⋮----
-.submitOrder({
-⋮----
-.then((response) => {
-console.log('Market order result', response);
-⋮----
-.catch((error) => {
-console.error('Market order error', error);
-⋮----
-// Submit a limit order
-⋮----
-console.log('Limit order result', response);
-⋮----
-console.error('Limit order error', error);
-
-================
-File: examples/apidoc/V5/Trade/README.md
-================
-# V5 - REST - Trade
-
-https://bybit-exchange.github.io/docs/v5/order/create-order
-
-================
-File: examples/apidoc/V5/Trade/set-dcp.js
-================
-const client = new RestClientV5({
-⋮----
-.setDisconnectCancelAllWindow('option', 40)
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/User/create-sub-uid-api-key.js
-================
-const client = new RestClientV5({
-⋮----
-.createSubUIDAPIKey({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/User/create-sub-uid.js
-================
-const client = new RestClientV5({
-⋮----
-.createSubMember({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/User/delete-master-api-key.js
-================
-const client = new RestClientV5({
-⋮----
-.deleteMasterApiKey()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/User/delete-sub-api-key.js
-================
-const client = new RestClientV5({
-⋮----
-.deleteSubApiKey()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/User/delete-sub-uid.js
-================
-// https://api.bybit.com/v5/user/del-submember
-⋮----
-const client = new RestClientV5({
-⋮----
-.deleteSubMember({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/User/freeze-sub-uid.js
-================
-const client = new RestClientV5({
-⋮----
-.setSubUIDFrozenState(53888001, 1)
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/User/get-api-key-info.js
-================
-const client = new RestClientV5({
-⋮----
-.getQueryApiKey()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/User/get-sub-all-api-keys.js
-================
-// https://api.bybit.com/v5/user/sub-apikeys
-⋮----
-const client = new RestClientV5({
-⋮----
-.getSubAccountAllApiKeys({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/User/get-sub-uid-list-unlimited.js
-================
-const client = new RestClientV5({
-⋮----
-.getSubUIDListUnlimited()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/User/get-sub-uid-list.js
-================
-const client = new RestClientV5({
-⋮----
-.getSubUIDList()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/User/get-uid-wallet-type.js
-================
-// https://api.bybit.com/v5/user/get-member-type
-⋮----
-const client = new RestClientV5({
-⋮----
-.getUIDWalletType({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/User/modify-master-api-key.js
-================
-const client = new RestClientV5({
-⋮----
-.updateMasterApiKey({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/User/modify-sub-api-key.js
-================
-const client = new RestClientV5({
-⋮----
-.updateSubApiKey({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/User/README.md
-================
-# V5 - REST - User
-
-https://bybit-exchange.github.io/docs/v5/user/create-subuid
-
-================
-File: examples/apidoc/README.md
-================
-# API Doc Examples
-
-These are per-endpoint JavaScript examples also found in Bybit's API documentation website, demonstrating how to interact with each endpoint with the Node.js SDK.
-
-================
-File: examples/apidoc/typescripttest.ts
-================
-import { RestClientV5 } from '../../src';
 
 ================
 File: examples/deprecated/README.md
@@ -3323,6 +428,67 @@ import { RestClientV5 } from '../src/index';
 //   });
 // });
 // console.log('openInterest: ', openInterest.result.list);
+
+================
+File: examples/ws-api-client.ts
+================
+import { DefaultLogger, WebsocketAPIClient } from '../src';
+⋮----
+// or
+// import { DefaultLogger, WebsocketAPIClient } from 'bybit-api';
+// const { DefaultLogger, WebsocketAPIClient } = require('bybit-api');
+⋮----
+// function attachEventHandlers<TWSClient extends WebsocketClient>(
+//   wsClient: TWSClient,
+// ): void {
+//   wsClient.on('update', (data) => {
+//     console.log('raw message received ', JSON.stringify(data));
+//   });
+//   wsClient.on('open', (data) => {
+//     console.log('ws connected', data.wsKey);
+//   });
+//   wsClient.on('reconnect', ({ wsKey }) => {
+//     console.log('ws automatically reconnecting.... ', wsKey);
+//   });
+//   wsClient.on('reconnected', (data) => {
+//     console.log('ws has reconnected ', data?.wsKey);
+//   });
+//   wsClient.on('authenticated', (data) => {
+//     console.log('ws has authenticated ', data?.wsKey);
+//   });
+// }
+⋮----
+async function main()
+⋮----
+// Optional
+⋮----
+// For a more detailed view of the WebsocketClient, enable the `trace` level by uncommenting the below line:
+// trace: (...params) => console.log('trace', ...params),
+⋮----
+// testnet: true, // Whether to use the testnet environment: https://testnet.bybit.com/app/user/api-management
+⋮----
+// Whether to use the livenet demo trading environment
+// Note: As of Jan 2025, demo trading only supports consuming events, it does
+// NOT support the WS API.
+// demoTrading: false,
+⋮----
+// If you want your own event handlers instead of the default ones with logs,
+// disable this setting and see the `attachEventHandlers` example below:
+// attachEventListeners: false
+⋮----
+logger, // Optional: inject a custom logger
+⋮----
+// Optional, see above "attachEventListeners". Attach basic event handlers, so nothing is left unhandled
+// attachEventHandlers(wsClient.getWSClient());
+⋮----
+// Optional, if you see RECV Window errors, you can use this to manage time issues.
+// ! However, make sure you sync your system clock first!
+// https://github.com/tiagosiebler/awesome-crypto-examples/wiki/Timestamp-for-this-request-is-outside-of-the-recvWindow
+// wsClient.setTimeOffsetMs(-5000);
+⋮----
+// Optional: prepare the WebSocket API connection in advance.
+// This happens automatically but you can do this early before making any API calls, to prevent delays from a cold start.
+// await wsClient.getWSClient().connectWSAPI();
 
 ================
 File: src/constants/enum.ts
@@ -4706,6 +1872,44 @@ export interface USDCPositionsRequest {
 }
 
 ================
+File: src/types/request/v5-broker.ts
+================
+export interface GetExchangeBrokerEarningsParamsV5 {
+  bizType?: 'SPOT' | 'DERIVATIVES' | 'OPTIONS' | 'CONVERT';
+  begin?: string;
+  end?: string;
+  uid?: string;
+  limit?: number;
+  cursor?: string;
+}
+⋮----
+export interface GetBrokerSubAccountDepositsV5 {
+  id?: string;
+  txID?: string;
+  subMemberId?: string;
+  coin?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
+}
+⋮----
+export interface IssueVoucherParamsV5 {
+  accountId: string;
+  awardId: string;
+  specCode: string;
+  amount: string;
+  brokerId: string;
+}
+⋮----
+export interface GetBrokerIssuedVoucherParamsV5 {
+  accountId: string;
+  awardId: string;
+  specCode: string;
+  withUsedAmount?: boolean;
+}
+
+================
 File: src/types/request/v5-p2p-trading.ts
 ================
 export interface GetP2PAccountCoinsBalanceParamsV5 {
@@ -4936,6 +2140,38 @@ export interface GetSpotLeveragedTokenOrderHistoryParamsV5 {
 export interface GetVIPMarginDataParamsV5 {
   vipLevel?: string;
   currency?: string;
+}
+⋮----
+// Spot Margin Trade (UTA) endpoints
+export interface ManualBorrowParamsV5 {
+  coin: string;
+  amount: string;
+}
+⋮----
+export interface GetMaxBorrowableAmountParamsV5 {
+  currency: string;
+}
+⋮----
+export interface GetPositionTiersParamsV5 {
+  currency?: string;
+}
+⋮----
+export interface GetCoinStateParamsV5 {
+  currency?: string;
+}
+⋮----
+export interface GetAvailableAmountToRepayParamsV5 {
+  currency: string;
+}
+⋮----
+export interface SetSpotMarginLeverageParamsV5 {
+  leverage: string;
+  currency?: string;
+}
+⋮----
+export interface ManualRepayWithoutConversionParamsV5 {
+  coin: string;
+  amount?: string;
 }
 
 ================
@@ -5554,6 +2790,97 @@ export interface LinearOrder {
 }
 
 ================
+File: src/types/response/v5-broker.ts
+================
+interface EarningDetailV5 {
+  userId: string;
+  bizType: 'SPOT' | 'DERIVATIVES' | 'OPTIONS' | 'CONVERT';
+  symbol: string;
+  coin: string;
+  earning: string;
+  markupEarning: string;
+  baseFeeEarning: string;
+  orderId: string;
+  execTime: string;
+}
+⋮----
+interface TotalEarningCategoryV5 {
+  coin: string;
+  earning: string;
+}
+⋮----
+export interface ExchangeBrokerEarningResultV5 {
+  totalEarningCat: {
+    spot: TotalEarningCategoryV5[];
+    derivatives: TotalEarningCategoryV5[];
+    options: TotalEarningCategoryV5[];
+    convert: TotalEarningCategoryV5[];
+    total: TotalEarningCategoryV5[];
+  };
+  details: EarningDetailV5[];
+  nextPageCursor: string;
+}
+⋮----
+export interface ExchangeBrokerAccountInfoV5 {
+  subAcctQty: string;
+  maxSubAcctQty: string;
+  baseFeeRebateRate: {
+    spot: string;
+    derivatives: string;
+  };
+  markupFeeRebateRate: {
+    spot: string;
+    derivatives: string;
+    convert: string;
+  };
+  ts: string;
+}
+⋮----
+export interface ExchangeBrokerSubAccountDepositRecordV5 {
+  id: string;
+  subMemberId: string;
+  coin: string;
+  chain: string;
+  amount: string;
+  txID: string;
+  status: number;
+  toAddress: string;
+  tag: string;
+  depositFee: string;
+  successAt: string;
+  confirmations: string;
+  txIndex: string;
+  blockHash: string;
+  batchReleaseLimit: string;
+  depositType: string;
+}
+⋮----
+export interface BrokerVoucherSpecV5 {
+  id: string;
+  coin: string;
+  amountUnit: 'AWARD_AMOUNT_UNIT_USD' | 'AWARD_AMOUNT_UNIT_COIN';
+  productLine: string;
+  subProductLine: string;
+  totalAmount: {
+    [key: string]: string;
+  };
+  usedAmount: string;
+}
+⋮----
+export interface BrokerIssuedVoucherV5 {
+  accountId: string;
+  awardId: string;
+  specCode: string;
+  amount: string;
+  isClaimed: boolean;
+  startAt: string;
+  endAt: string;
+  effectiveAt: string;
+  ineffectiveAt: string;
+  usedAmount: string;
+}
+
+================
 File: src/types/response/v5-earn.ts
 ================
 export interface EarnProductV5 {
@@ -5577,6 +2904,9 @@ export interface EarnOrderHistoryV5 {
   createdAt: string;
   productId: string;
   updatedAt: string;
+  swapOrderValue: string;
+  estimateRedeemTime: string;
+  estimateStakeTime: string;
 }
 ⋮----
 export interface EarnPositionV5 {
@@ -5585,6 +2915,30 @@ export interface EarnPositionV5 {
   amount: string;
   totalPnl: string;
   claimableYield: string;
+}
+⋮----
+export interface EarnYieldHistoryV5 {
+  productId: string;
+  coin: string;
+  id: string;
+  amount: string;
+  yieldType: string;
+  distributionMode: string;
+  effectiveStakingAmount: string;
+  orderId: string;
+  status: 'Pending' | 'Success' | 'Fail';
+  createdAt: string;
+}
+⋮----
+export interface EarnHourlyYieldHistoryV5 {
+  productId: string;
+  coin: string;
+  id: string;
+  amount: string;
+  effectiveStakingAmount: string;
+  status: 'Pending' | 'Success' | 'Fail';
+  hourlyDate: string;
+  createdAt: string;
 }
 
 ================
@@ -6195,6 +3549,53 @@ export interface P2PUserPaymentV5 {
 }
 
 ================
+File: src/types/response/v5-preupgrade.ts
+================
+export interface PreUpgradeTransaction {
+  symbol: string;
+  category: string;
+  side: 'Buy' | 'Sell' | 'None';
+  transactionTime: string;
+  type: string;
+  qty: string;
+  size: string;
+  currency: 'USDC' | 'USDT' | 'BTC' | 'ETH';
+  tradePrice: string;
+  funding: string;
+  fee: string;
+  cashFlow: string;
+  change: string;
+  cashBalance: string;
+  feeRate: string;
+  bonusChange: string;
+  tradeId: string;
+  orderId: string;
+  orderLinkId: string;
+  extraFees: string;
+}
+⋮----
+export interface PreUpgradeOptionsDelivery {
+  deliveryTime: number;
+  symbol: string;
+  side: 'Buy' | 'Sell';
+  position: string;
+  deliveryPrice: string;
+  strike: string;
+  fee: string;
+  deliveryRpl: string;
+}
+⋮----
+export interface PreUpgradeUSDCSessionSettlement {
+  symbol: string;
+  side: 'Buy' | 'Sell';
+  size: string;
+  sessionAvgPrice: string;
+  markPrice: string;
+  realisedPnl: string;
+  createdTime: string;
+}
+
+================
 File: src/types/response/v5-user.ts
 ================
 import { PermissionsV5 } from '../shared-v5';
@@ -6307,6 +3708,19 @@ export interface AffiliateUserListItemV5 {
   source: string;
   remarks: string;
   isKyc: boolean;
+  takerVol30Day: string;
+  makerVol30Day: string;
+  tradeVol30Day: string;
+  depositAmount30Day: string;
+  takerVol365Day: string;
+  makerVol365Day: string;
+  tradeVol365Day: string;
+  depositAmount365Day: string;
+  takerVol: string;
+  makerVol: string;
+  tradeVol: string;
+  startDate: string;
+  endDate: string;
 }
 ⋮----
 export interface AffiliateUserInfoV5 {
@@ -6324,6 +3738,167 @@ export interface AffiliateUserInfoV5 {
   depositUpdateTime: string;
   volUpdateTime: string;
   KycLevel: 0 | 1 | 2;
+}
+
+================
+File: src/types/websockets/ws-api.ts
+================
+import { APIID, WS_KEY_MAP } from '../../util';
+import {
+  AmendOrderParamsV5,
+  BatchAmendOrderParamsV5,
+  BatchCancelOrderParamsV5,
+  BatchOrderParamsV5,
+  CancelOrderParamsV5,
+  OrderParamsV5,
+} from '../request';
+import {
+  BatchAmendOrderResultV5,
+  BatchCancelOrderResultV5,
+  BatchCreateOrderResultV5,
+  BatchOrdersRetExtInfoV5,
+  OrderResultV5,
+} from '../response';
+import { WsKey } from './ws-general';
+⋮----
+// When new WS API operations are added, make sure to also update WS_API_Operations[] below
+export type WSAPIOperation =
+  | 'order.create'
+  | 'order.amend'
+  | 'order.cancel'
+  | 'order.create-batch'
+  | 'order.amend-batch'
+  | 'order.cancel-batch';
+⋮----
+export type WsOperation =
+  | 'subscribe'
+  | 'unsubscribe'
+  | 'auth'
+  | 'ping'
+  | 'pong';
+⋮----
+export interface WsRequestOperationBybit<TWSTopic extends string> {
+  req_id: string;
+  op: WsOperation;
+  args?: (TWSTopic | string | number)[];
+}
+⋮----
+export interface WSAPIRequest<
+  TRequestParams = undefined,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TWSOperation extends WSAPIOperation = any,
+> {
+  reqId: string;
+  op: TWSOperation;
+  header: {
+    'X-BAPI-TIMESTAMP': string;
+    'X-BAPI-RECV-WINDOW': string;
+    Referer: typeof APIID;
+  };
+  args: [TRequestParams];
+}
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+⋮----
+export interface WSAPIResponse<
+  TResponseData extends object = object,
+  TOperation extends WSAPIOperation = WSAPIOperation,
+  TResponseExtInfo = {}, // added as optional for batch calls
+> {
+  wsKey: WsKey;
+  /** Auto-generated */
+  reqId: string;
+  retCode: 0 | number;
+  retMsg: 'OK' | string;
+  op: TOperation;
+  data: TResponseData;
+  retExtInfo: TResponseExtInfo;
+  header?: {
+    'X-Bapi-Limit': string;
+    'X-Bapi-Limit-Status': string;
+    'X-Bapi-Limit-Reset-Timestamp': string;
+    Traceid: string;
+    Timenow: string;
+  };
+  connId: string;
+}
+⋮----
+TResponseExtInfo = {}, // added as optional for batch calls
+⋮----
+/** Auto-generated */
+⋮----
+export type Exact<T> = {
+  // This part says: if there's any key that's not in T, it's an error
+  [K: string]: never;
+} & {
+  [K in keyof T]: T[K];
+};
+⋮----
+// This part says: if there's any key that's not in T, it's an error
+⋮----
+/**
+ * List of operations supported for this WsKey (connection)
+ */
+export interface WsAPIWsKeyTopicMap {
+  [WS_KEY_MAP.v5PrivateTrade]: WSAPIOperation;
+}
+⋮----
+/**
+ * Request parameters expected per operation
+ */
+export interface WsAPITopicRequestParamMap {
+  'order.create': OrderParamsV5;
+  'order.amend': AmendOrderParamsV5;
+  'order.cancel': CancelOrderParamsV5;
+
+  'order.create-batch': {
+    category: 'option' | 'linear';
+    request: BatchOrderParamsV5[];
+  };
+  'order.amend-batch': {
+    category: 'option' | 'linear';
+    request: BatchAmendOrderParamsV5[];
+  };
+  'order.cancel-batch': {
+    category: 'option' | 'linear';
+    request: BatchCancelOrderParamsV5[];
+  };
+}
+⋮----
+/**
+ * Response structure expected for each operation
+ */
+export interface WsAPIOperationResponseMap {
+  'order.create': WSAPIResponse<OrderResultV5, 'order.create'>;
+  'order.amend': WSAPIResponse<OrderResultV5, 'order.amend'>;
+  'order.cancel': WSAPIResponse<OrderResultV5, 'order.cancel'>;
+
+  'order.create-batch': WSAPIResponse<
+    { list: BatchCreateOrderResultV5[] },
+    'order.create-batch'
+  > & {
+    retExtInfo: BatchOrdersRetExtInfoV5;
+  };
+  'order.amend-batch': WSAPIResponse<
+    { list: BatchAmendOrderResultV5[] },
+    'order.amend-batch'
+  > & {
+    retExtInfo: BatchOrdersRetExtInfoV5;
+  };
+  'order.cancel-batch': WSAPIResponse<
+    { list: BatchCancelOrderResultV5[] },
+    'order.cancel-batch'
+  > & {
+    retExtInfo: BatchOrdersRetExtInfoV5;
+  };
+
+  ping: {
+    retCode: 0 | number;
+    retMsg: 'OK' | string;
+    op: 'pong';
+    data: [string];
+    connId: string;
+  };
 }
 
 ================
@@ -7156,255 +4731,6 @@ File: tsconfig.test.json
 }
 
 ================
-File: examples/apidoc/V5/Account/get-limit-price-behaviour.js
-================
-const client = new RestClientV5({
-⋮----
-.getLimitPriceAction()
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Account/set-limit-price-behaviour.js
-================
-const client = new RestClientV5({
-⋮----
-.setLimitPriceAction({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-Legacy/adjust-collateral-amount.js
-================
-const client = new RestClientV5({
-⋮----
-.adjustCollateralAmount({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-Legacy/borrow.js
-================
-const client = new RestClientV5({
-⋮----
-.borrowCryptoLoan({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-Legacy/get-account-borrow-collateral-limit.js
-================
-const client = new RestClientV5({
-⋮----
-.getAccountBorrowCollateralLimit({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-Legacy/get-borrowable-coins.js
-================
-const client = new RestClientV5({
-⋮----
-.getBorrowableCoins({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-Legacy/get-collateral-coins.js
-================
-const client = new RestClientV5({
-⋮----
-.getCollateralCoins({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-Legacy/get-completed-loan-order-history.js
-================
-const client = new RestClientV5({
-⋮----
-.getCompletedLoanOrderHistory({ orderId: '1794267532472646144' })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-Legacy/get-loan-LTV-adjustment-history.js
-================
-const client = new RestClientV5({
-⋮----
-.getLoanLTVAdjustmentHistory({ adjustId: '1794271131730737664' })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-Legacy/get-max-allowed-reduction-collateral-amount.js
-================
-const client = new RestClientV5({
-⋮----
-.getMaxAllowedReductionCollateralAmount({ orderId: '1794267532472646144' })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-Legacy/get-repayment-transaction-history.js
-================
-const client = new RestClientV5({
-⋮----
-.getRepaymentHistory({ repayId: '1794271131730737664' })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-Legacy/get-unpaid-loan-orders.js
-================
-const client = new RestClientV5({
-⋮----
-.getUnpaidLoanOrders({ orderId: '1793683005081680384' })
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-Legacy/repay.js
-================
-const client = new RestClientV5({
-⋮----
-.repayCryptoLoan({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Fixed-Loan/collateral-repayment.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
-⋮----
-const client = new RestClientV5({
-⋮----
-client.repayCollateralFixed({
-⋮----
-.then(response => {
-console.log(response);
-⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Flexible-Loan/collateral-repayment.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
-⋮----
-const client = new RestClientV5({
-⋮----
-client.repayCollateralFlexible({
-⋮----
-.then(response => {
-console.log(response);
-⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Market/get-new-delivery-price.js
-================
-const client = new RestClientV5({
-⋮----
-.getLongShortRatio({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Market/get-order-price-limit.js
-================
-const client = new RestClientV5({
-⋮----
-.getOrderPriceLimit({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Position/get-closed-options-positions.js
-================
-const client = new RestClientV5({
-⋮----
-.getClosedOptionsPositions({
-⋮----
-.then((response) => {
-console.log(response);
-⋮----
-.catch((error) => {
-console.error(error);
-
-================
-File: examples/apidoc/V5/Trade/pre-check-order.js
-================
-const client = new RestClientV5({
-⋮----
-// Submit a market order
-⋮----
-.preCheckOrder({
-⋮----
-.then((response) => {
-console.log('Market order result', response);
-⋮----
-.catch((error) => {
-console.error('Market order error', error);
-
-================
 File: examples/fasterHmacSign.ts
 ================
 import { createHmac } from 'crypto';
@@ -7485,6 +4811,162 @@ import { RestClientV5 } from '../src/index';
 /** Simple examples for private REST API calls with bybit's V5 REST APIs */
 ⋮----
 // Trade USDT linear perps
+
+================
+File: examples/ws-api-raw-events.ts
+================
+import { DefaultLogger, WebsocketClient, WS_KEY_MAP } from '../src';
+⋮----
+// or
+// import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from 'bybit-api';
+⋮----
+// For a more detailed view of the WebsocketClient, enable the `trace` level by uncommenting the below line:
+// trace: (...params) => console.log('trace', ...params),
+⋮----
+// testnet: true, // Whether to use the testnet environment: https://testnet.bybit.com/app/user/api-management
+// demoTrading: false, // note: As of Jan 2025, demo trading does NOT support the WS API
+⋮----
+logger, // Optional: inject a custom logger
+⋮----
+/**
+ * General event handlers for monitoring the WebsocketClient
+ */
+⋮----
+async function main()
+⋮----
+/**
+   *
+   * This SDK's WebSocket API integration is event-driven at its core. You can treat the sentWSAPIRquest(...) method as
+   * a fire-and-forget method, to submit commands (create/amend/cancel order) via a WebSocket Connection.
+   *
+   * Replies to commands will show in the `response` event from the WebsocketClient's EventEmitter. Exceptions, however,
+   * will show in the `error` event from the WebsocketClient's EventEmitter.
+   *
+   * - Fire-and-forget a command.
+   * - Handle command results in the `response` event handler asynchronously as desired.
+   * - Handle any exceptions in a catch block.
+   *
+   * This is a more "raw" workflow in how WebSockets behave. For a more convenient & REST-like approach, using the
+   * promise-driven interface is recommended. See the `ws-api-raw-promises.ts` and `ws-api-client.ts` examples for a
+   * demonstration you can compare.
+   *
+   * Note: even without using promises, you should still tie on a .catch handler to each sendWSAPIRequest call, to prevent
+   * any unnecessary "unhandled promise rejection" exceptions.
+   *
+   */
+⋮----
+// To make it easier to watch, wait a few seconds before sending the amend order
+⋮----
+// Then wait a few more before sending the cancel order
+⋮----
+// Exceptions including rejected commands will show here (as well as the catch handler used below)
+⋮----
+// Replies to commands will show here
+⋮----
+/**
+   *
+   * If you haven't connected yet, the WebsocketClient will automatically connect and authenticate you as soon as you send
+   * your first command. That connection will then be reused for every command you send, unless the connection drops - then
+   * it will automatically be replaced with a healthy connection.
+   *
+   * This "not connected yet" scenario can add an initial delay to your first command. If you want to prepare a connection
+   * in advance, you can ask the WebsocketClient to prepare it before you start submitting commands. This is optional.
+   *
+   * Repeated note: even without using promises, you should still tie on a .catch handler to each sendWSAPIRequest call, to prevent
+   * any unnecessary "unhandled promise rejection" exceptions.
+   *
+   */
+⋮----
+// Optional, see above. Can be used to prepare a connection before sending commands
+⋮----
+// Fire and forget the create.order command
+// Even without using promises, you should still "catch" exceptions (although no need to await anything you send)
+⋮----
+//
+⋮----
+// Fire and forget the order.amend command
+// For simplicity, the orderId is hardcoded here (and will probably not work)
+⋮----
+//
+⋮----
+// Fire and forget the order.cancel command
+// For simplicity, the orderId is hardcoded here (and will probably not work)
+⋮----
+// Start executing the example workflow
+
+================
+File: examples/ws-api-raw-promises.ts
+================
+import { DefaultLogger, WebsocketClient, WS_KEY_MAP } from '../src';
+⋮----
+// or
+// import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from 'bybit-api';
+⋮----
+// For a more detailed view of the WebsocketClient, enable the `trace` level by uncommenting the below line:
+// trace: (...params) => console.log('trace', ...params),
+⋮----
+// testnet: true, // Whether to use the testnet environment: https://testnet.bybit.com/app/user/api-management
+// demoTrading: false, // note: As of Jan 2025, demo trading does NOT support the WS API
+⋮----
+logger, // Optional: inject a custom logger
+⋮----
+/**
+ * General event handlers for monitoring the WebsocketClient
+ */
+⋮----
+async function main()
+⋮----
+/**
+   *
+   * This SDK's WebSocket API integration can connect WS API responses to the request that caused them. Each call
+   * to the `sendWSAPIRequest(...)` method returns a promise.
+   *
+   * This promise will resolve when the matching response is detected, and reject if an exception for that request
+   * is detected. This allows using Bybit's Websocket API in the same way that a REST API normally works.
+   *
+   * Send a command and immediately await the result. Handle any exceptions in a catch block.
+   *
+   * TypeScript users can benefit from smart type flowing for increased type safety & convenience:
+   * - Request parameters are fully typed, depending on the operation in the second parameter to the call. E.g.
+   * the `order.create` operation will automatically require the params to match the `OrderParamsV5` interface.
+   *
+   * - Response parameters are fully typed, depending on the operation in the second parameter. E.g the `order.create`
+   * operation will automatically map the returned value to `WSAPIResponse<OrderResultV5, "order.create">`.
+   *
+   */
+⋮----
+// To make it easier to watch, wait a few seconds before sending the amend order
+⋮----
+// Then wait a few more before sending the cancel order
+⋮----
+/**
+   *
+   * If you haven't connected yet, the WebsocketClient will automatically connect and authenticate you as soon as you send
+   * your first command. That connection will then be reused for every command you send, unless the connection drops - then
+   * it will automatically be replaced with a healthy connection.
+   *
+   * This "not connected yet" scenario can add an initial delay to your first command. If you want to prepare a connection
+   * in advance, you can ask the WebsocketClient to prepare it before you start submitting commands. This is optional.
+   *
+   */
+⋮----
+// Optional, see above. Can be used to prepare a connection before sending commands
+⋮----
+/**
+   * Create a new order
+   */
+⋮----
+// The type for `wsAPISubmitOrderResult` is automatically resolved to `WSAPIResponse<OrderResultV5, "order.create">`
+⋮----
+// Save the orderId for the next call
+⋮----
+// The type for `wsAPIAmendOrderResult` is automatically resolved to `WSAPIResponse<OrderResultV5, "order.amend">`
+⋮----
+// Save the orderId for the next call
+⋮----
+// The type for `wsAPICancelOrderResult` is automatically resolved to `WSAPIResponse<OrderResultV5, "order.cancel">`
+⋮----
+// Start executing the example workflow
 
 ================
 File: examples/ws-private-v5.ts
@@ -7678,11 +5160,19 @@ export interface GetTransactionLogParamsV5 {
   currency?: string;
   baseCoin?: string;
   type?: TransactionTypeV5;
+  /**
+   * Transaction sub type, "movePosition", used to filter trans logs of Move Position only
+   */
+  transSubType?: string;
   startTime?: number;
   endTime?: number;
   limit?: number;
   cursor?: string;
 }
+⋮----
+/**
+   * Transaction sub type, "movePosition", used to filter trans logs of Move Position only
+   */
 ⋮----
 export interface MMPModifyParamsV5 {
   baseCoin: string;
@@ -7715,23 +5205,113 @@ export interface SetLimitPriceActionParamsV5 {
   category: CategoryV5;
   modifyEnable: boolean;
 }
-
-================
-File: src/types/request/v5-broker.ts
-================
-export interface GetExchangeBrokerEarningsParamsV5 {
-  bizType?: 'SPOT' | 'DERIVATIVES' | 'OPTIONS' | 'CONVERT';
-  begin?: string;
-  end?: string;
-  uid?: string;
+⋮----
+export interface GetAccountInstrumentsInfoParamsV5 {
+  category: 'spot' | 'linear' | 'inverse';
+  symbol?: string;
   limit?: number;
   cursor?: string;
 }
 ⋮----
-export interface GetBrokerSubAccountDepositsV5 {
+export interface ManualRepayParamsV5 {
+  coin?: string;
+  amount?: string;
+}
+
+================
+File: src/types/request/v5-asset.ts
+================
+import { AccountTypeV5, CategoryV5 } from '../shared-v5';
+⋮----
+export interface GetCoinExchangeRecordParamsV5 {
+  fromCoin?: string;
+  toCoin?: string;
+  limit?: number;
+  cursor?: string;
+}
+⋮----
+export interface GetDeliveryRecordParamsV5 {
+  category: CategoryV5;
+  symbol?: string;
+  startTime?: number;
+  endTime?: number;
+  expDate?: string;
+  limit?: number;
+  cursor?: string;
+}
+⋮----
+export interface GetSettlementRecordParamsV5 {
+  category: CategoryV5;
+  symbol?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
+}
+⋮----
+export interface GetAssetInfoParamsV5 {
+  accountType: AccountTypeV5;
+  coin?: string;
+}
+⋮----
+export interface GetAllCoinsBalanceParamsV5 {
+  memberId?: string;
+  accountType: AccountTypeV5;
+  coin?: string;
+  withBonus?: number;
+}
+⋮----
+export interface GetAccountCoinBalanceParamsV5 {
+  memberId?: string;
+  toMemberId?: string;
+  accountType: AccountTypeV5;
+  coin: string;
+  toAccountType?: AccountTypeV5;
+  withBonus?: number;
+  withTransferSafeAmount?: 0 | 1;
+  withLtvTransferSafeAmount?: 0 | 1;
+}
+⋮----
+export interface GetInternalTransferParamsV5 {
+  transferId?: string;
+  coin?: string;
+  status?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
+}
+⋮----
+export interface UniversalTransferParamsV5 {
+  transferId: string;
+  coin: string;
+  amount: string;
+  fromMemberId: number;
+  toMemberId: number;
+  fromAccountType: AccountTypeV5;
+  toAccountType: AccountTypeV5;
+}
+⋮----
+export interface GetUniversalTransferRecordsParamsV5 {
+  transferId?: string;
+  coin?: string;
+  status?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
+}
+⋮----
+export interface GetAllowedDepositCoinInfoParamsV5 {
+  coin?: string;
+  chain?: string;
+  limit?: number;
+  cursor?: string;
+}
+⋮----
+export interface GetDepositRecordParamsV5 {
   id?: string;
   txID?: string;
-  subMemberId?: string;
   coin?: string;
   startTime?: number;
   endTime?: number;
@@ -7739,19 +5319,100 @@ export interface GetBrokerSubAccountDepositsV5 {
   cursor?: string;
 }
 ⋮----
-export interface IssueVoucherParamsV5 {
-  accountId: string;
-  awardId: string;
-  specCode: string;
-  amount: string;
-  brokerId: string;
+export interface GetSubAccountDepositRecordParamsV5 {
+  id?: string;
+  txID?: string;
+  subMemberId: string;
+  coin?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
 }
 ⋮----
-export interface GetBrokerIssuedVoucherParamsV5 {
-  accountId: string;
-  awardId: string;
-  specCode: string;
-  withUsedAmount?: boolean;
+export interface GetInternalDepositRecordParamsV5 {
+  txID?: string;
+  startTime?: number;
+  endTime?: number;
+  coin?: string;
+  cursor?: string;
+  limit?: number;
+}
+⋮----
+export interface GetWithdrawalRecordsParamsV5 {
+  withdrawID?: string;
+  txID?: string;
+  coin?: string;
+  withdrawType?: number;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
+}
+⋮----
+export interface GetWithdrawalAddressListParamsV5 {
+  coin?: string;
+  chain?: string;
+  addressType?: 0 | 1 | 2;
+  limit?: number;
+  cursor?: string;
+}
+⋮----
+export interface WithdrawParamsV5 {
+  coin: string;
+  chain: string;
+  address: string;
+  tag?: string;
+  amount: string;
+  timestamp: number;
+  forceChain?: number;
+  accountType: 'SPOT' | 'FUND';
+  feeType?: 0 | 1;
+  requestId?: string;
+  beneficiary?: {
+    vaspEntityId?: string;
+    beneficiaryName?: string;
+    beneficiaryLegalType?: string;
+    beneficiaryWalletType?: string;
+    beneficiaryUnhostedWalletType?: string;
+    beneficiaryPoiNumber?: string;
+    beneficiaryPoiType?: string;
+    beneficiaryPoiIssuingCountry?: string;
+    beneficiaryPoiExpiredDate?: string;
+  };
+}
+⋮----
+export interface ConvertCoinsParamsV5 {
+  coin?: string;
+  side?: number;
+  accountType:
+    | 'eb_convert_funding'
+    | 'eb_convert_uta'
+    | 'eb_convert_spot'
+    | 'eb_convert_contract'
+    | 'eb_convert_inverse';
+}
+⋮----
+export interface RequestConvertQuoteParamsV5 {
+  fromCoin: string;
+  toCoin: string;
+  fromCoinType?: string;
+  toCoinType?: string;
+  requestCoin: string;
+  requestAmount: string;
+  accountType:
+    | 'eb_convert_funding'
+    | 'eb_convert_uta'
+    | 'eb_convert_spot'
+    | 'eb_convert_contract'
+    | 'eb_convert_inverse';
+  requestId?: string;
+}
+⋮----
+export interface GetConvertHistoryParamsV5 {
+  accountType?: string;
+  index?: number;
+  limit?: number;
 }
 
 ================
@@ -7772,12 +5433,35 @@ export interface GetEarnOrderHistoryParamsV5 {
   category: string;
   orderId?: string;
   orderLinkId?: string;
+  productId?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
 }
 ⋮----
 export interface GetEarnPositionParamsV5 {
   category: string;
   productId?: string;
   coin?: string;
+}
+⋮----
+export interface GetEarnYieldHistoryParamsV5 {
+  category: string;
+  productId?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
+}
+⋮----
+export interface GetEarnHourlyYieldHistoryParamsV5 {
+  category: string;
+  productId?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
 }
 
 ================
@@ -7825,6 +5509,7 @@ export interface GetPremiumIndexPriceKlineParamsV5 {
 export interface GetInstrumentsInfoParamsV5 {
   category: CategoryV5;
   symbol?: string;
+  symbolType?: string;
   status?: InstrumentStatusV5;
   baseCoin?: string;
   limit?: number;
@@ -8186,6 +5871,8 @@ export interface OrderParamsV5 {
   slLimitPrice?: string;
   tpOrderType?: OrderTypeV5;
   slOrderType?: OrderTypeV5;
+  bboSideType?: 'Queue' | 'Counterparty';
+  bboLevel?: '1' | '2' | '3' | '4' | '5';
 }
 ⋮----
 export interface AmendOrderParamsV5 {
@@ -8303,1554 +5990,6 @@ export interface BatchCancelOrderParamsV5 {
   symbol: string;
   orderId?: string;
   orderLinkId?: string;
-}
-
-================
-File: src/types/response/v5-broker.ts
-================
-interface EarningDetailV5 {
-  userId: string;
-  bizType: 'SPOT' | 'DERIVATIVES' | 'OPTIONS' | 'CONVERT';
-  symbol: string;
-  coin: string;
-  earning: string;
-  markupEarning: string;
-  baseFeeEarning: string;
-  orderId: string;
-  execTime: string;
-}
-⋮----
-interface TotalEarningCategoryV5 {
-  coin: string;
-  earning: string;
-}
-⋮----
-export interface ExchangeBrokerEarningResultV5 {
-  totalEarningCat: {
-    spot: TotalEarningCategoryV5[];
-    derivatives: TotalEarningCategoryV5[];
-    options: TotalEarningCategoryV5[];
-    convert: TotalEarningCategoryV5[];
-    total: TotalEarningCategoryV5[];
-  };
-  details: EarningDetailV5[];
-  nextPageCursor: string;
-}
-⋮----
-export interface ExchangeBrokerAccountInfoV5 {
-  subAcctQty: string;
-  maxSubAcctQty: string;
-  baseFeeRebateRate: {
-    spot: string;
-    derivatives: string;
-  };
-  markupFeeRebateRate: {
-    spot: string;
-    derivatives: string;
-    convert: string;
-  };
-  ts: string;
-}
-⋮----
-export interface ExchangeBrokerSubAccountDepositRecordV5 {
-  id: string;
-  subMemberId: string;
-  coin: string;
-  chain: string;
-  amount: string;
-  txID: string;
-  status: number;
-  toAddress: string;
-  tag: string;
-  depositFee: string;
-  successAt: string;
-  confirmations: string;
-  txIndex: string;
-  blockHash: string;
-  batchReleaseLimit: string;
-  depositType: string;
-}
-⋮----
-export interface BrokerVoucherSpecV5 {
-  id: string;
-  coin: string;
-  amountUnit: 'AWARD_AMOUNT_UNIT_USD' | 'AWARD_AMOUNT_UNIT_COIN';
-  productLine: string;
-  subProductLine: string;
-  totalAmount: {
-    [key: string]: string;
-  };
-  usedAmount: string;
-}
-⋮----
-export interface BrokerIssuedVoucherV5 {
-  accountId: string;
-  awardId: string;
-  specCode: string;
-  amount: string;
-  isClaimed: boolean;
-  startAt: string;
-  endAt: string;
-  effectiveAt: string;
-  ineffectiveAt: string;
-  usedAmount: string;
-}
-
-================
-File: src/types/response/v5-preupgrade.ts
-================
-export interface PreUpgradeTransaction {
-  symbol: string;
-  category: string;
-  side: 'Buy' | 'Sell' | 'None';
-  transactionTime: string;
-  type: string;
-  qty: string;
-  size: string;
-  currency: 'USDC' | 'USDT' | 'BTC' | 'ETH';
-  tradePrice: string;
-  funding: string;
-  fee: string;
-  cashFlow: string;
-  change: string;
-  cashBalance: string;
-  feeRate: string;
-  bonusChange: string;
-  tradeId: string;
-  orderId: string;
-  orderLinkId: string;
-  extraFees: string;
-}
-⋮----
-export interface PreUpgradeOptionsDelivery {
-  deliveryTime: number;
-  symbol: string;
-  side: 'Buy' | 'Sell';
-  position: string;
-  deliveryPrice: string;
-  strike: string;
-  fee: string;
-  deliveryRpl: string;
-}
-⋮----
-export interface PreUpgradeUSDCSessionSettlement {
-  symbol: string;
-  side: 'Buy' | 'Sell';
-  size: string;
-  sessionAvgPrice: string;
-  markPrice: string;
-  realisedPnl: string;
-  createdTime: string;
-}
-
-================
-File: src/types/response/v5-spot-leverage-token.ts
-================
-import {
-  LeverageTokenStatusV5,
-  LTOrderStatusV5,
-  LTOrderTypeV5,
-} from '../shared-v5';
-⋮----
-export interface LeverageTokenInfoV5 {
-  ltCoin: string;
-  ltName: string;
-  maxPurchase: string;
-  minPurchase: string;
-  maxPurchaseDaily: string;
-  maxRedeem: string;
-  minRedeem: string;
-  maxRedeemDaily: string;
-  purchaseFeeRate: string;
-  redeemFeeRate: string;
-  ltStatus: LeverageTokenStatusV5;
-  fundFee: string;
-  fundFeeTime: string;
-  manageFeeRate: string;
-  manageFeeTime: string;
-  value: string;
-  netValue: string;
-  total: string;
-}
-⋮----
-export interface LeveragedTokenMarketResultV5 {
-  ltCoin: string;
-  nav: string;
-  navTime: string;
-  circulation: string;
-  basket: string;
-  leverage: string;
-}
-⋮----
-export interface PurchaseSpotLeveragedTokenResultV5 {
-  ltCoin: string;
-  ltOrderStatus: LTOrderStatusV5;
-  execQty: string;
-  execAmt: string;
-  amount: string;
-  purchaseId: string;
-  serialNo: string;
-  valueCoin: string;
-}
-export interface RedeemSpotLeveragedTokenResultV5 {
-  ltCoin: string;
-  ltOrderStatus: LTOrderStatusV5;
-  quantity: string;
-  execQty: string;
-  execAmt: string;
-  redeemId: string;
-  serialNo: string;
-  valueCoin: string;
-}
-⋮----
-export interface SpotLeveragedTokenOrderHistoryV5 {
-  ltCoin: string;
-  orderId: string;
-  ltOrderType: LTOrderTypeV5;
-  orderTime: number;
-  updateTime: number;
-  ltOrderStatus: LTOrderStatusV5;
-  fee: string;
-  amount: string;
-  value: string;
-  valueCoin: string;
-  serialNo: string;
-}
-⋮----
-export interface VIPMarginDataV5 {
-  vipCoinList: {
-    list: {
-      borrowable: boolean;
-      collateralRatio: string;
-      currency: string;
-      hourlyBorrowRate: string;
-      liquidationOrder: string;
-      marginCollateral: boolean;
-      maxBorrowingAmount: string;
-    }[];
-    vipLevel: string;
-  }[];
-}
-⋮----
-export interface SpotMarginStateV5 {
-  spotLeverage: string;
-  spotMarginMode: '1' | '0';
-  effectiveLeverage: string;
-}
-
-================
-File: src/types/websockets/index.ts
-================
-
-
-================
-File: src/types/websockets/ws-api.ts
-================
-import { APIID, WS_KEY_MAP } from '../../util';
-import {
-  AmendOrderParamsV5,
-  BatchAmendOrderParamsV5,
-  BatchCancelOrderParamsV5,
-  BatchOrderParamsV5,
-  CancelOrderParamsV5,
-  OrderParamsV5,
-} from '../request';
-import {
-  BatchAmendOrderResultV5,
-  BatchCancelOrderResultV5,
-  BatchCreateOrderResultV5,
-  BatchOrdersRetExtInfoV5,
-  OrderResultV5,
-} from '../response';
-import { WsKey } from './ws-general';
-⋮----
-// When new WS API operations are added, make sure to also update WS_API_Operations[] below
-export type WSAPIOperation =
-  | 'order.create'
-  | 'order.amend'
-  | 'order.cancel'
-  | 'order.create-batch'
-  | 'order.amend-batch'
-  | 'order.cancel-batch';
-⋮----
-export type WsOperation =
-  | 'subscribe'
-  | 'unsubscribe'
-  | 'auth'
-  | 'ping'
-  | 'pong';
-⋮----
-export interface WsRequestOperationBybit<TWSTopic extends string> {
-  req_id: string;
-  op: WsOperation;
-  args?: (TWSTopic | string | number)[];
-}
-⋮----
-export interface WSAPIRequest<
-  TRequestParams = undefined,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  TWSOperation extends WSAPIOperation = any,
-> {
-  reqId: string;
-  op: TWSOperation;
-  header: {
-    'X-BAPI-TIMESTAMP': string;
-    'X-BAPI-RECV-WINDOW': string;
-    Referer: typeof APIID;
-  };
-  args: [TRequestParams];
-}
-⋮----
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-⋮----
-export interface WSAPIResponse<
-  TResponseData extends object = object,
-  TOperation extends WSAPIOperation = WSAPIOperation,
-  TResponseExtInfo = {}, // added as optional for batch calls
-> {
-  wsKey: WsKey;
-  /** Auto-generated */
-  reqId: string;
-  retCode: 0 | number;
-  retMsg: 'OK' | string;
-  op: TOperation;
-  data: TResponseData;
-  retExtInfo: TResponseExtInfo;
-  header?: {
-    'X-Bapi-Limit': string;
-    'X-Bapi-Limit-Status': string;
-    'X-Bapi-Limit-Reset-Timestamp': string;
-    Traceid: string;
-    Timenow: string;
-  };
-  connId: string;
-}
-⋮----
-TResponseExtInfo = {}, // added as optional for batch calls
-⋮----
-/** Auto-generated */
-⋮----
-export type Exact<T> = {
-  // This part says: if there's any key that's not in T, it's an error
-  [K: string]: never;
-} & {
-  [K in keyof T]: T[K];
-};
-⋮----
-// This part says: if there's any key that's not in T, it's an error
-⋮----
-/**
- * List of operations supported for this WsKey (connection)
- */
-export interface WsAPIWsKeyTopicMap {
-  [WS_KEY_MAP.v5PrivateTrade]: WSAPIOperation;
-}
-⋮----
-/**
- * Request parameters expected per operation
- */
-export interface WsAPITopicRequestParamMap {
-  'order.create': OrderParamsV5;
-  'order.amend': AmendOrderParamsV5;
-  'order.cancel': CancelOrderParamsV5;
-
-  'order.create-batch': {
-    category: 'option' | 'linear';
-    request: BatchOrderParamsV5[];
-  };
-  'order.amend-batch': {
-    category: 'option' | 'linear';
-    request: BatchAmendOrderParamsV5[];
-  };
-  'order.cancel-batch': {
-    category: 'option' | 'linear';
-    request: BatchCancelOrderParamsV5[];
-  };
-}
-⋮----
-/**
- * Response structure expected for each operation
- */
-export interface WsAPIOperationResponseMap {
-  'order.create': WSAPIResponse<OrderResultV5, 'order.create'>;
-  'order.amend': WSAPIResponse<OrderResultV5, 'order.amend'>;
-  'order.cancel': WSAPIResponse<OrderResultV5, 'order.cancel'>;
-
-  'order.create-batch': WSAPIResponse<
-    { list: BatchCreateOrderResultV5[] },
-    'order.create-batch'
-  > & {
-    retExtInfo: BatchOrdersRetExtInfoV5;
-  };
-  'order.amend-batch': WSAPIResponse<
-    { list: BatchAmendOrderResultV5[] },
-    'order.amend-batch'
-  > & {
-    retExtInfo: BatchOrdersRetExtInfoV5;
-  };
-  'order.cancel-batch': WSAPIResponse<
-    { list: BatchCancelOrderResultV5[] },
-    'order.cancel-batch'
-  > & {
-    retExtInfo: BatchOrdersRetExtInfoV5;
-  };
-
-  ping: {
-    retCode: 0 | number;
-    retMsg: 'OK' | string;
-    op: 'pong';
-    data: [string];
-    connId: string;
-  };
-}
-
-================
-File: src/types/index.ts
-================
-
-
-================
-File: src/types/shared-v5.ts
-================
-export type CategoryV5 = 'spot' | 'linear' | 'inverse' | 'option';
-export type ContractTypeV5 =
-  | 'InversePerpetual'
-  | 'LinearPerpetual'
-  | 'InverseFutures';
-export type CopyTradingV5 = 'none' | 'both' | 'utaOnly' | 'normalOnly';
-⋮----
-export type InstrumentStatusV5 =
-  | 'PreLaunch'
-  | 'Trading'
-  | 'Settling'
-  | 'Delivering'
-  | 'Closed';
-⋮----
-export type MarginTradingV5 = 'none' | 'both' | 'utaOnly' | 'normalSpotOnly';
-⋮----
-export type OrderFilterV5 = 'Order' | 'tpslOrder' | 'StopOrder';
-export type OrderSideV5 = 'Buy' | 'Sell';
-export type OrderTypeV5 = 'Market' | 'Limit';
-export type OrderTimeInForceV5 = 'GTC' | 'IOC' | 'FOK' | 'PostOnly' | 'RPI';
-export type OrderTriggerByV5 = 'LastPrice' | 'IndexPrice' | 'MarkPrice';
-export type OCOTriggerTypeV5 =
-  | 'OcoTriggerByUnknown'
-  | 'OcoTriggerTp'
-  | 'OcoTriggerBySl';
-⋮----
-export type OrderSMPTypeV5 =
-  | 'None'
-  | 'CancelMaker'
-  | 'CancelTaker'
-  | 'CancelBoth';
-⋮----
-export type OrderStatusV5 =
-  | 'Created'
-  | 'New'
-  | 'Rejected'
-  | 'PartiallyFilled'
-  | 'PartiallyFilledCanceled'
-  | 'Filled'
-  | 'Cancelled'
-  | 'Untriggered'
-  | 'Triggered'
-  | 'Deactivated'
-  | 'Active';
-⋮----
-/**
- * Defines the types of order creation mechanisms.
- */
-export type OrderCreateTypeV5 =
-  /** Represents an order created by a user. */
-  | 'CreateByUser'
-  /** Represents an order created by an admin closing. */
-  | 'CreateByAdminClosing'
-  /** Futures conditional order. */
-  | 'CreateByStopOrder'
-  /** Futures take profit order. */
-  | 'CreateByTakeProfit'
-  /** Futures partial take profit order. */
-  | 'CreateByPartialTakeProfit'
-  /** Futures stop loss order. */
-  | 'CreateByStopLoss'
-  /** Futures partial stop loss order. */
-  | 'CreateByPartialStopLoss'
-  /** Futures trailing stop order. */
-  | 'CreateByTrailingStop'
-  /** Laddered liquidation to reduce the required maintenance margin. */
-  | 'CreateByLiq'
-  /**
-   * If the position is still subject to liquidation (i.e., does not meet the required maintenance margin level),
-   * the position shall be taken over by the liquidation engine and closed at the bankruptcy price.
-   */
-  | 'CreateByTakeOver_PassThrough'
-  /** Auto-Deleveraging(ADL) */
-  | 'CreateByAdl_PassThrough'
-  /** Order placed via Paradigm. */
-  | 'CreateByBlock_PassThrough'
-  /** Order created by move position. */
-  | 'CreateByBlockTradeMovePosition_PassThrough'
-  /** The close order placed via web or app position area - web/app. */
-  | 'CreateByClosing'
-  /** Order created via grid bot - web/app. */
-  | 'CreateByFGridBot'
-  /** Order closed via grid bot - web/app. */
-  | 'CloseByFGridBot'
-  /** Order created by TWAP - web/app. */
-  | 'CreateByTWAP'
-  /** Order created by TV webhook - web/app. */
-  | 'CreateByTVSignal'
-  /** Order created by Mm rate close function - web/app. */
-  | 'CreateByMmRateClose'
-  /** Order created by Martingale bot - web/app. */
-  | 'CreateByMartingaleBot'
-  /** Order closed by Martingale bot - web/app. */
-  | 'CloseByMartingaleBot'
-  /** Order created by Ice berg strategy - web/app. */
-  | 'CreateByIceBerg'
-  /** Order created by arbitrage - web/app. */
-  | 'CreateByArbitrage'
-  /** Option dynamic delta hedge order - web/app */
-  | 'CreateByDdh';
-⋮----
-/** Represents an order created by a user. */
-⋮----
-/** Represents an order created by an admin closing. */
-⋮----
-/** Futures conditional order. */
-⋮----
-/** Futures take profit order. */
-⋮----
-/** Futures partial take profit order. */
-⋮----
-/** Futures stop loss order. */
-⋮----
-/** Futures partial stop loss order. */
-⋮----
-/** Futures trailing stop order. */
-⋮----
-/** Laddered liquidation to reduce the required maintenance margin. */
-⋮----
-/**
-   * If the position is still subject to liquidation (i.e., does not meet the required maintenance margin level),
-   * the position shall be taken over by the liquidation engine and closed at the bankruptcy price.
-   */
-⋮----
-/** Auto-Deleveraging(ADL) */
-⋮----
-/** Order placed via Paradigm. */
-⋮----
-/** Order created by move position. */
-⋮----
-/** The close order placed via web or app position area - web/app. */
-⋮----
-/** Order created via grid bot - web/app. */
-⋮----
-/** Order closed via grid bot - web/app. */
-⋮----
-/** Order created by TWAP - web/app. */
-⋮----
-/** Order created by TV webhook - web/app. */
-⋮----
-/** Order created by Mm rate close function - web/app. */
-⋮----
-/** Order created by Martingale bot - web/app. */
-⋮----
-/** Order closed by Martingale bot - web/app. */
-⋮----
-/** Order created by Ice berg strategy - web/app. */
-⋮----
-/** Order created by arbitrage - web/app. */
-⋮----
-/** Option dynamic delta hedge order - web/app */
-⋮----
-export type OrderCancelTypeV5 =
-  | 'CancelByUser'
-  | 'CancelByReduceOnly'
-  | 'CancelByPrepareLiq'
-  | 'CancelAllBeforeLiq'
-  | 'CancelByPrepareAdl'
-  | 'CancelAllBeforeAdl'
-  | 'CancelByAdmin'
-  | 'CancelByTpSlTsClear'
-  | 'CancelByPzSideCh'
-  | 'UNKNOWN';
-⋮----
-export type OrderRejectReasonV5 =
-  | 'EC_NoError'
-  | 'EC_Others'
-  | 'EC_UnknownMessageType'
-  | 'EC_MissingClOrdID'
-  | 'EC_MissingOrigClOrdID'
-  | 'EC_ClOrdIDOrigClOrdIDAreTheSame'
-  | 'EC_DuplicatedClOrdID'
-  | 'EC_OrigClOrdIDDoesNotExist'
-  | 'EC_TooLateToCancel'
-  | 'EC_UnknownOrderType'
-  | 'EC_UnknownSide'
-  | 'EC_UnknownTimeInForce'
-  | 'EC_WronglyRouted'
-  | 'EC_MarketOrderPriceIsNotZero'
-  | 'EC_LimitOrderInvalidPrice'
-  | 'EC_NoEnoughQtyToFill'
-  | 'EC_NoImmediateQtyToFill'
-  | 'EC_PerCancelRequest'
-  | 'EC_MarketOrderCannotBePostOnly'
-  | 'EC_PostOnlyWillTakeLiquidity'
-  | 'EC_CancelReplaceOrder'
-  | 'EC_InvalidSymbolStatus';
-⋮----
-export type StopOrderTypeV5 =
-  | 'TakeProfit'
-  | 'StopLoss'
-  | 'TrailingStop'
-  | 'Stop'
-  | 'PartialTakeProfit'
-  | 'PartialStopLoss'
-  | 'tpslOrder'
-  | 'OcoOrder'
-  | 'MmRateClose'
-  | 'BidirectionalTpslOrder';
-⋮----
-/**
- * Position index. Used to identify positions in different position modes.
- *
- * - 0 one-way mode position
- * - 1 Buy side of hedge-mode position
- * - 2 Sell side of hedge-mode position
- */
-export type PositionIdx = 0 | 1 | 2;
-⋮----
-/**
- * Position status.
- *
- * - 'Normal'
- * - 'Liq' in the liquidation progress
- * - 'Adl' in the auto-deleverage progress
- */
-export type PositionStatusV5 = 'Normal' | 'Liq' | 'Adl';
-export type PositionSideV5 = 'Buy' | 'Sell' | 'None' | '';
-⋮----
-export type OptionTypeV5 = 'Call' | 'Put';
-⋮----
-/**
- * Trade mode.
- *
- * - 0 cross-margin,
- * - 1 isolated margin
- */
-export type TradeModeV5 = 0 | 1;
-⋮----
-export type TPSLModeV5 = 'Full' | 'Partial';
-export type AccountMarginModeV5 =
-  | 'ISOLATED_MARGIN'
-  | 'REGULAR_MARGIN'
-  | 'PORTFOLIO_MARGIN';
-export type UnifiedUpdateStatusV5 = 'FAIL' | 'PROCESS' | 'SUCCESS';
-⋮----
-export type AccountTypeV5 =
-  | 'CONTRACT'
-  | 'SPOT'
-  | 'INVESTMENT'
-  | 'OPTION'
-  | 'UNIFIED'
-  | 'FUND';
-⋮----
-export type TransactionTypeV5 =
-  | 'TRANSFER_IN'
-  | 'TRANSFER_OUT'
-  | 'TRADE'
-  | 'SETTLEMENT'
-  | 'DELIVERY'
-  | 'LIQUIDATION'
-  | 'ADL'
-  | 'AIRDROP'
-  | 'BONUS_RECOLLECT'
-  | 'BONUS_RECOLLECT'
-  | 'FEE_REFUND'
-  | 'INTEREST'
-  | 'CURRENCY_BUY'
-  | 'CURRENCY_SELL'
-  | 'BORROWED_AMOUNT_INS_LOAN'
-  | 'PRINCIPLE_REPAYMENT_INS_LOAN'
-  | 'INTEREST_REPAYMENT_INS_LOAN'
-  | 'AUTO_SOLD_COLLATERAL_INS_LOAN'
-  | 'AUTO_BUY_LIABILITY_INS_LOAN'
-  | 'AUTO_PRINCIPLE_REPAYMENT_INS_LOAN'
-  | 'AUTO_INTEREST_REPAYMENT_INS_LOAN'
-  | 'TRANSFER_IN_INS_LOAN'
-  | 'TRANSFER_OUT_INS_LOAN'
-  | 'SPOT_REPAYMENT_SELL'
-  | 'SPOT_REPAYMENT_BUY'
-  | 'TOKENS_SUBSCRIPTION'
-  | 'TOKENS_REDEMPTION'
-  | 'AUTO_DEDUCTION'
-  | 'FLEXIBLE_STAKING_SUBSCRIPTION'
-  | 'FLEXIBLE_STAKING_REDEMPTION'
-  | 'FIXED_STAKING_SUBSCRIPTION'
-  | 'BORROWED_AMOUNT_INS_LOAN'
-  | 'PRINCIPLE_REPAYMENT_INS_LOAN'
-  | 'INTEREST_REPAYMENT_INS_LOAN'
-  | 'AUTO_SOLD_COLLATERAL_INS_LOAN'
-  | 'AUTO_BUY_LIABILITY_INS_LOAN'
-  | 'AUTO_PRINCIPLE_REPAYMENT_INS_LOAN'
-  | 'AUTO_INTEREST_REPAYMENT_INS_LOAN'
-  | 'TRANSFER_IN_INS_LOAN'
-  | 'TRANSFER_OUT_INS_LOAN'
-  | 'SPOT_REPAYMENT_SELL'
-  | 'SPOT_REPAYMENT_BUY'
-  | 'TOKENS_SUBSCRIPTION'
-  | 'TOKENS_REDEMPTION'
-  | 'AUTO_DEDUCTION'
-  | 'FLEXIBLE_STAKING_SUBSCRIPTION'
-  | 'FLEXIBLE_STAKING_REDEMPTION'
-  | 'FIXED_STAKING_SUBSCRIPTION'
-  | 'FLEXIBLE_STAKING_REFUND'
-  | 'FIXED_STAKING_REFUND'
-  | 'PREMARKET_TRANSFER_OUT'
-  | 'PREMARKET_DELIVERY_SELL_NEW_COIN'
-  | 'PREMARKET_DELIVERY_BUY_NEW_COIN'
-  | 'PREMARKET_DELIVERY_PLEDGE_PAY_SELLER'
-  | 'PREMARKET_DELIVERY_PLEDGE_BACK'
-  | 'PREMARKET_ROLLBACK_PLEDGE_BACK'
-  | 'PREMARKET_ROLLBACK_PLEDGE_PENALTY_TO_BUYER'
-  | 'CUSTODY_NETWORK_FEE'
-  | 'CUSTODY_SETTLE_FEE'
-  | 'CUSTODY_LOCK'
-  | 'CUSTODY_UNLOCK'
-  | 'CUSTODY_UNLOCK_REFUND'
-  | 'LOANS_BORROW_FUNDS'
-  | 'LOANS_PLEDGE_ASSET'
-  | 'BONUS_TRANSFER_IN'
-  | 'BONUS_TRANSFER_OUT'
-  | 'PEF_TRANSFER_IN'
-  | 'PEF_TRANSFER_OUT'
-  | 'PEF_PROFIT_SHARE'
-  | 'ONCHAINEARN_SUBSCRIPTION'
-  | 'ONCHAINEARN_REDEMPTION'
-  | 'ONCHAINEARN_REFUND'
-  | 'STRUCTURE_PRODUCT_SUBSCRIPTION'
-  | 'STRUCTURE_PRODUCT_REFUND'
-  | 'CLASSIC_WEALTH_MANAGEMENT_SUBSCRIPTION'
-  | 'PREMIMUM_WEALTH_MANAGEMENT_SUBSCRIPTION'
-  | 'PREMIMUM_WEALTH_MANAGEMENT_REFUND'
-  | 'LIQUIDITY_MINING_SUBSCRIPTION'
-  | 'LIQUIDITY_MINING_REFUND'
-  | 'PWM_SUBSCRIPTION'
-  | 'PWM_REFUND'
-  | 'DEFI_INVESTMENT_SUBSCRIPTION'
-  | 'DEFI_INVESTMENT_REFUND'
-  | 'DEFI_INVESTMENT_REDEMPTION'
-  | 'INSTITUTION_LOAN_IN'
-  | 'INSTITUTION_PAYBACK_PRINCIPAL_OUT'
-  | 'INSTITUTION_PAYBACK_INTEREST_OUT'
-  | 'INSTITUTION_EXCHANGE_SELL'
-  | 'INSTITUTION_EXCHANGE_BUY'
-  | 'INSTITUTION_LIQ_PRINCIPAL_OUT'
-  | 'INSTITUTION_LIQ_INTEREST_OUT'
-  | 'INSTITUTION_LOAN_TRANSFER_IN'
-  | 'INSTITUTION_LOAN_TRANSFER_OUT'
-  | 'INSTITUTION_LOAN_WITHOUT_WITHDRAW'
-  | 'INSTITUTION_LOAN_RESERVE_IN'
-  | 'INSTITUTION_LOAN_RESERVE_OUT'
-  | 'PLATFORM_TOKEN_MNT_LIQRECALLEDMMNT'
-  | 'PLATFORM_TOKEN_MNT_LIQRETURNEDMNT';
-⋮----
-export type PermissionTypeV5 =
-  | 'ContractTrade'
-  | 'Spot'
-  | 'Wallet'
-  | 'Options'
-  | 'Derivatives'
-  | 'Exchange'
-  | 'NFT';
-⋮----
-/**
- * Leveraged token status:
- *
- * - '1' LT can be purchased and redeemed
- * - '2' LT can be purchased, but not redeemed
- * - '3' LT can be redeemed, but not purchased
- * - '4' LT cannot be purchased nor redeemed
- * - '5' Adjusting position
- */
-export type LeverageTokenStatusV5 = '1' | '2' | '3' | '4' | '5';
-⋮----
-/**
- * Leveraged token order type: '1': purchase, '2': redeem
- */
-export type LTOrderTypeV5 = '1' | '2';
-⋮----
-/**
- * Leveraged token order status: '1': completed, '2': in progress, '3': failed
- */
-export type LTOrderStatusV5 = '1' | '2' | '3';
-⋮----
-export type ExecTypeV5 =
-  | 'Trade'
-  | 'AdlTrade'
-  | 'Funding'
-  | 'BustTrade'
-  | 'Settle'
-  | 'BlockTrade'
-  | 'MovePosition'
-  | 'UNKNOWN';
-⋮----
-/**
- * Withdraw type. 0(default): on chain. 1: off chain. 2: all.
- */
-export type WithdrawalTypeV5 = '0' | '1' | '2';
-⋮----
-export interface PermissionsV5 {
-  ContractTrade?: string[];
-  Spot?: string[];
-  Wallet?: string[];
-  Options?: string[];
-  Derivatives?: string[];
-  CopyTrading?: string[];
-  BlockTrade?: string[];
-  Exchange?: string[];
-  /** @deprecated , always returns []*/
-  NFT?: string[];
-}
-⋮----
-/** @deprecated , always returns []*/
-⋮----
-export interface CategoryCursorListV5<
-  T extends unknown[],
-  TCategory extends CategoryV5 = CategoryV5,
-> {
-  category: TCategory;
-  list: T;
-  nextPageCursor?: string;
-}
-⋮----
-/**
- * Next page cursor does not exist for spot!
- */
-export interface CursorListV5<T extends unknown[]> {
-  nextPageCursor: string;
-  list: T;
-}
-⋮----
-/**
- * A wrapper type for any responses that have a "nextPageCursor" property, and a "rows" property with an array of elements
- *
- * ```{ nextPageCursor: "something", rows: someData[] }```
- */
-export interface CursorRowsV5<T extends unknown[]> {
-  nextPageCursor: string;
-  rows: T;
-}
-⋮----
-export interface CategoryListV5<
-  T extends unknown[],
-  TCategory extends CategoryV5,
-> {
-  category: TCategory;
-  list: T;
-}
-⋮----
-export interface CategorySymbolListV5<
-  T extends unknown[],
-  TCategory extends CategoryV5,
-> {
-  category: TCategory;
-  symbol: string;
-  list: T;
-}
-⋮----
-export interface GetSystemStatusParamsV5 {
-  id?: string;
-  state?: string;
-}
-⋮----
-export interface SystemStatusItemV5 {
-  id: string;
-  title: string;
-  state: string;
-  begin: string;
-  end: string;
-  href: string;
-  serviceTypes: number[];
-  product: number[];
-  uidSuffix: number[];
-  maintainType: string;
-  env: string;
-}
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Flexible-Loan/repay.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
-⋮----
-const client = new RestClientV5({
-⋮----
-client.repayFlexible({
-⋮----
-.then(response => {
-console.log(response);
-⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/ws-api-raw-events.ts
-================
-import { DefaultLogger, WebsocketClient, WS_KEY_MAP } from '../src';
-⋮----
-// or
-// import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from 'bybit-api';
-⋮----
-// For a more detailed view of the WebsocketClient, enable the `trace` level by uncommenting the below line:
-// trace: (...params) => console.log('trace', ...params),
-⋮----
-// testnet: true, // Whether to use the testnet environment: https://testnet.bybit.com/app/user/api-management
-// demoTrading: false, // note: As of Jan 2025, demo trading does NOT support the WS API
-⋮----
-logger, // Optional: inject a custom logger
-⋮----
-/**
- * General event handlers for monitoring the WebsocketClient
- */
-⋮----
-async function main()
-⋮----
-/**
-   *
-   * This SDK's WebSocket API integration is event-driven at its core. You can treat the sentWSAPIRquest(...) method as
-   * a fire-and-forget method, to submit commands (create/amend/cancel order) via a WebSocket Connection.
-   *
-   * Replies to commands will show in the `response` event from the WebsocketClient's EventEmitter. Exceptions, however,
-   * will show in the `error` event from the WebsocketClient's EventEmitter.
-   *
-   * - Fire-and-forget a command.
-   * - Handle command results in the `response` event handler asynchronously as desired.
-   * - Handle any exceptions in a catch block.
-   *
-   * This is a more "raw" workflow in how WebSockets behave. For a more convenient & REST-like approach, using the
-   * promise-driven interface is recommended. See the `ws-api-raw-promises.ts` and `ws-api-client.ts` examples for a
-   * demonstration you can compare.
-   *
-   * Note: even without using promises, you should still tie on a .catch handler to each sendWSAPIRequest call, to prevent
-   * any unnecessary "unhandled promise rejection" exceptions.
-   *
-   */
-⋮----
-// To make it easier to watch, wait a few seconds before sending the amend order
-⋮----
-// Then wait a few more before sending the cancel order
-⋮----
-// Exceptions including rejected commands will show here (as well as the catch handler used below)
-⋮----
-// Replies to commands will show here
-⋮----
-/**
-   *
-   * If you haven't connected yet, the WebsocketClient will automatically connect and authenticate you as soon as you send
-   * your first command. That connection will then be reused for every command you send, unless the connection drops - then
-   * it will automatically be replaced with a healthy connection.
-   *
-   * This "not connected yet" scenario can add an initial delay to your first command. If you want to prepare a connection
-   * in advance, you can ask the WebsocketClient to prepare it before you start submitting commands. This is optional.
-   *
-   * Repeated note: even without using promises, you should still tie on a .catch handler to each sendWSAPIRequest call, to prevent
-   * any unnecessary "unhandled promise rejection" exceptions.
-   *
-   */
-⋮----
-// Optional, see above. Can be used to prepare a connection before sending commands
-⋮----
-// Fire and forget the create.order command
-// Even without using promises, you should still "catch" exceptions (although no need to await anything you send)
-⋮----
-//
-⋮----
-// Fire and forget the order.amend command
-// For simplicity, the orderId is hardcoded here (and will probably not work)
-⋮----
-//
-⋮----
-// Fire and forget the order.cancel command
-// For simplicity, the orderId is hardcoded here (and will probably not work)
-⋮----
-// Start executing the example workflow
-
-================
-File: examples/ws-api-raw-promises.ts
-================
-import { DefaultLogger, WebsocketClient, WS_KEY_MAP } from '../src';
-⋮----
-// or
-// import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from 'bybit-api';
-⋮----
-// For a more detailed view of the WebsocketClient, enable the `trace` level by uncommenting the below line:
-// trace: (...params) => console.log('trace', ...params),
-⋮----
-// testnet: true, // Whether to use the testnet environment: https://testnet.bybit.com/app/user/api-management
-// demoTrading: false, // note: As of Jan 2025, demo trading does NOT support the WS API
-⋮----
-logger, // Optional: inject a custom logger
-⋮----
-/**
- * General event handlers for monitoring the WebsocketClient
- */
-⋮----
-async function main()
-⋮----
-/**
-   *
-   * This SDK's WebSocket API integration can connect WS API responses to the request that caused them. Each call
-   * to the `sendWSAPIRequest(...)` method returns a promise.
-   *
-   * This promise will resolve when the matching response is detected, and reject if an exception for that request
-   * is detected. This allows using Bybit's Websocket API in the same way that a REST API normally works.
-   *
-   * Send a command and immediately await the result. Handle any exceptions in a catch block.
-   *
-   * TypeScript users can benefit from smart type flowing for increased type safety & convenience:
-   * - Request parameters are fully typed, depending on the operation in the second parameter to the call. E.g.
-   * the `order.create` operation will automatically require the params to match the `OrderParamsV5` interface.
-   *
-   * - Response parameters are fully typed, depending on the operation in the second parameter. E.g the `order.create`
-   * operation will automatically map the returned value to `WSAPIResponse<OrderResultV5, "order.create">`.
-   *
-   */
-⋮----
-// To make it easier to watch, wait a few seconds before sending the amend order
-⋮----
-// Then wait a few more before sending the cancel order
-⋮----
-/**
-   *
-   * If you haven't connected yet, the WebsocketClient will automatically connect and authenticate you as soon as you send
-   * your first command. That connection will then be reused for every command you send, unless the connection drops - then
-   * it will automatically be replaced with a healthy connection.
-   *
-   * This "not connected yet" scenario can add an initial delay to your first command. If you want to prepare a connection
-   * in advance, you can ask the WebsocketClient to prepare it before you start submitting commands. This is optional.
-   *
-   */
-⋮----
-// Optional, see above. Can be used to prepare a connection before sending commands
-⋮----
-/**
-   * Create a new order
-   */
-⋮----
-// The type for `wsAPISubmitOrderResult` is automatically resolved to `WSAPIResponse<OrderResultV5, "order.create">`
-⋮----
-// Save the orderId for the next call
-⋮----
-// The type for `wsAPIAmendOrderResult` is automatically resolved to `WSAPIResponse<OrderResultV5, "order.amend">`
-⋮----
-// Save the orderId for the next call
-⋮----
-// The type for `wsAPICancelOrderResult` is automatically resolved to `WSAPIResponse<OrderResultV5, "order.cancel">`
-⋮----
-// Start executing the example workflow
-
-================
-File: src/types/request/v5-asset.ts
-================
-import { AccountTypeV5, CategoryV5 } from '../shared-v5';
-⋮----
-export interface GetCoinExchangeRecordParamsV5 {
-  fromCoin?: string;
-  toCoin?: string;
-  limit?: number;
-  cursor?: string;
-}
-⋮----
-export interface GetDeliveryRecordParamsV5 {
-  category: CategoryV5;
-  symbol?: string;
-  startTime?: number;
-  endTime?: number;
-  expDate?: string;
-  limit?: number;
-  cursor?: string;
-}
-⋮----
-export interface GetSettlementRecordParamsV5 {
-  category: CategoryV5;
-  symbol?: string;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-  cursor?: string;
-}
-⋮----
-export interface GetAssetInfoParamsV5 {
-  accountType: AccountTypeV5;
-  coin?: string;
-}
-⋮----
-export interface GetAllCoinsBalanceParamsV5 {
-  memberId?: string;
-  accountType: AccountTypeV5;
-  coin?: string;
-  withBonus?: number;
-}
-⋮----
-export interface GetAccountCoinBalanceParamsV5 {
-  memberId?: string;
-  toMemberId?: string;
-  accountType: AccountTypeV5;
-  coin: string;
-  toAccountType?: AccountTypeV5;
-  withBonus?: number;
-  withTransferSafeAmount?: 0 | 1;
-  withLtvTransferSafeAmount?: 0 | 1;
-}
-⋮----
-export interface GetInternalTransferParamsV5 {
-  transferId?: string;
-  coin?: string;
-  status?: string;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-  cursor?: string;
-}
-⋮----
-export interface UniversalTransferParamsV5 {
-  transferId: string;
-  coin: string;
-  amount: string;
-  fromMemberId: number;
-  toMemberId: number;
-  fromAccountType: AccountTypeV5;
-  toAccountType: AccountTypeV5;
-}
-⋮----
-export interface GetUniversalTransferRecordsParamsV5 {
-  transferId?: string;
-  coin?: string;
-  status?: string;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-  cursor?: string;
-}
-⋮----
-export interface GetAllowedDepositCoinInfoParamsV5 {
-  coin?: string;
-  chain?: string;
-  limit?: number;
-  cursor?: string;
-}
-⋮----
-export interface GetDepositRecordParamsV5 {
-  id?: string;
-  txID?: string;
-  coin?: string;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-  cursor?: string;
-}
-⋮----
-export interface GetSubAccountDepositRecordParamsV5 {
-  id?: string;
-  txID?: string;
-  subMemberId: string;
-  coin?: string;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-  cursor?: string;
-}
-⋮----
-export interface GetInternalDepositRecordParamsV5 {
-  txID?: string;
-  startTime?: number;
-  endTime?: number;
-  coin?: string;
-  cursor?: string;
-  limit?: number;
-}
-⋮----
-export interface GetWithdrawalRecordsParamsV5 {
-  withdrawID?: string;
-  txID?: string;
-  coin?: string;
-  withdrawType?: number;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-  cursor?: string;
-}
-⋮----
-export interface WithdrawParamsV5 {
-  coin: string;
-  chain: string;
-  address: string;
-  tag?: string;
-  amount: string;
-  timestamp: number;
-  forceChain?: number;
-  accountType: 'SPOT' | 'FUND';
-  feeType?: 0 | 1;
-  requestId?: string;
-  beneficiary?: {
-    vaspEntityId?: string;
-    beneficiaryName?: string;
-    beneficiaryLegalType?: string;
-    beneficiaryWalletType?: string;
-    beneficiaryUnhostedWalletType?: string;
-    beneficiaryPoiNumber?: string;
-    beneficiaryPoiType?: string;
-    beneficiaryPoiIssuingCountry?: string;
-    beneficiaryPoiExpiredDate?: string;
-  };
-}
-⋮----
-export interface ConvertCoinsParamsV5 {
-  coin?: string;
-  side?: number;
-  accountType:
-    | 'eb_convert_funding'
-    | 'eb_convert_uta'
-    | 'eb_convert_spot'
-    | 'eb_convert_contract'
-    | 'eb_convert_inverse';
-}
-⋮----
-export interface RequestConvertQuoteParamsV5 {
-  fromCoin: string;
-  toCoin: string;
-  fromCoinType?: string;
-  toCoinType?: string;
-  requestCoin: string;
-  requestAmount: string;
-  accountType:
-    | 'eb_convert_funding'
-    | 'eb_convert_uta'
-    | 'eb_convert_spot'
-    | 'eb_convert_contract'
-    | 'eb_convert_inverse';
-  requestId?: string;
-}
-⋮----
-export interface GetConvertHistoryParamsV5 {
-  accountType?: string;
-  index?: number;
-  limit?: number;
-}
-
-================
-File: src/types/request/v5-position.ts
-================
-import {
-  CategoryV5,
-  ExecTypeV5,
-  OrderTriggerByV5,
-  OrderTypeV5,
-  PositionIdx,
-  TPSLModeV5,
-} from '../shared-v5';
-⋮----
-export interface PositionInfoParamsV5 {
-  category: CategoryV5;
-  symbol?: string;
-  baseCoin?: string;
-  settleCoin?: string;
-  limit?: number;
-  cursor?: string;
-}
-⋮----
-export interface SetLeverageParamsV5 {
-  category: 'linear' | 'inverse';
-  symbol: string;
-  buyLeverage: string;
-  sellLeverage: string;
-}
-⋮----
-export interface SwitchIsolatedMarginParamsV5 {
-  category: 'linear' | 'inverse';
-  symbol: string;
-  tradeMode: 0 | 1;
-  buyLeverage: string;
-  sellLeverage: string;
-}
-⋮----
-export interface SetTPSLModeParamsV5 {
-  category: 'linear' | 'inverse';
-  symbol: string;
-  tpSlMode: TPSLModeV5;
-}
-⋮----
-export interface SwitchPositionModeParamsV5 {
-  category: 'linear' | 'inverse';
-  symbol?: string;
-  coin?: string;
-  mode: 0 | 3;
-}
-⋮----
-export interface SetRiskLimitParamsV5 {
-  category: 'linear' | 'inverse';
-  symbol: string;
-  riskId: number;
-  positionIdx?: PositionIdx;
-}
-⋮----
-export interface SetTradingStopParamsV5 {
-  category: CategoryV5;
-  symbol: string;
-  takeProfit?: string;
-  stopLoss?: string;
-  trailingStop?: string;
-  tpTriggerBy?: OrderTriggerByV5;
-  slTriggerBy?: OrderTriggerByV5;
-  activePrice?: string;
-  tpslMode?: TPSLModeV5;
-  tpSize?: string;
-  slSize?: string;
-  tpLimitPrice?: string;
-  slLimitPrice?: string;
-  tpOrderType?: OrderTypeV5;
-  slOrderType?: OrderTypeV5;
-  positionIdx: PositionIdx;
-}
-⋮----
-export interface SetAutoAddMarginParamsV5 {
-  category: 'linear';
-  symbol: string;
-  autoAddMargin: 0 | 1;
-  positionIdx?: PositionIdx;
-}
-⋮----
-export interface AddOrReduceMarginParamsV5 {
-  category: 'linear' | 'inverse';
-  symbol: string;
-  margin: string;
-  positionIDex?: PositionIdx;
-}
-⋮----
-export interface GetExecutionListParamsV5 {
-  category: CategoryV5;
-  symbol?: string;
-  orderId?: string;
-  orderLinkId?: string;
-  baseCoin?: string;
-  startTime?: number;
-  endTime?: number;
-  execType?: ExecTypeV5;
-  limit?: number;
-  cursor?: string;
-}
-⋮----
-export interface GetClosedPnLParamsV5 {
-  category: CategoryV5;
-  symbol?: string;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-  cursor?: string;
-}
-⋮----
-export interface MovePositionParamsV5 {
-  fromUid: string;
-  toUid: string;
-  list: {
-    category: 'linear' | 'spot' | 'option' | 'inverse';
-    symbol: string;
-    price: string;
-    side: 'Buy' | 'Sell';
-    qty: string;
-  }[];
-}
-⋮----
-export interface GetMovePositionHistoryParamsV5 {
-  category?: 'linear' | 'spot' | 'option';
-  symbol?: string;
-  startTime?: number;
-  endTime?: number;
-  status?: 'Processing' | 'Filled' | 'Rejected';
-  blockTradeId?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface ConfirmNewRiskLimitParamsV5 {
-  category: 'linear' | 'inverse';
-  symbol: string;
-}
-⋮----
-export interface GetClosedOptionsPositionsParamsV5 {
-  category: 'option';
-  symbol?: string;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-  cursor?: string;
-}
-
-================
-File: src/types/response/index.ts
-================
-
-
-================
-File: src/types/response/v5-account.ts
-================
-import {
-  AccountMarginModeV5,
-  AccountTypeV5,
-  CategoryV5,
-  TransactionTypeV5,
-  UnifiedUpdateStatusV5,
-} from '../shared-v5';
-⋮----
-export interface WalletBalanceV5Coin {
-  coin: string;
-  equity: string;
-  usdValue: string;
-  walletBalance: string;
-  free: string; // spot only
-  locked: string; // spot only
-  borrowAmount: string;
-  availableToBorrow: string; // deprecated field
-  availableToWithdraw: string;
-  accruedInterest: string;
-  totalOrderIM: string;
-  totalPositionIM: string;
-  totalPositionMM: string;
-  unrealisedPnl: string;
-  cumRealisedPnl: string;
-  bonus: string;
-  marginCollateral: boolean;
-  collateralSwitch: boolean;
-  spotBorrow: string;
-}
-⋮----
-free: string; // spot only
-locked: string; // spot only
-⋮----
-availableToBorrow: string; // deprecated field
-⋮----
-export interface WalletBalanceV5 {
-  accountType: AccountTypeV5;
-  accountLTV: string;
-  accountIMRate: string;
-  accountMMRate: string;
-  accountIMRateByMp: string;
-  accountMMRateByMp: string;
-  totalInitialMarginByMp: string;
-  totalMaintenanceMarginByMp: string;
-  totalEquity: string;
-  totalWalletBalance: string;
-  totalMarginBalance: string;
-  totalAvailableBalance: string;
-  totalPerpUPL: string;
-  totalInitialMargin: string;
-  totalMaintenanceMargin: string;
-  coin: WalletBalanceV5Coin[];
-}
-⋮----
-export interface UnifiedAccountUpgradeResultV5 {
-  unifiedUpdateStatus: UnifiedUpdateStatusV5;
-  unifiedUpdateMsg: {
-    msg: string[] | null;
-  };
-}
-⋮----
-export interface BorrowHistoryRecordV5 {
-  currency: string;
-  createdTime: number;
-  borrowCost: string;
-  hourlyBorrowRate: string;
-  InterestBearingBorrowSize: string;
-  costExemption: string;
-  borrowAmount: string;
-  unrealisedLoss: string;
-  freeBorrowedAmount: string;
-}
-⋮----
-export interface CollateralInfoV5 {
-  currency: string;
-  hourlyBorrowRate: string;
-  maxBorrowingAmount: string;
-  freeBorrowAmount: string;
-  freeBorrowingLimit: string;
-  borrowAmount: string;
-  availableToBorrow: string;
-  borrowable: boolean;
-  borrowUsageRate: string;
-  marginCollateral: boolean;
-  collateralSwitch: boolean;
-  collateralRatio: string;
-}
-⋮----
-export interface CoinGreeksV5 {
-  baseCoin: string;
-  totalDelta: string;
-  totalGamma: string;
-  totalVega: string;
-  totalTheta: string;
-}
-⋮----
-export interface FeeRateV5 {
-  symbol: string;
-  baseCoin: string;
-  takerFeeRate: string;
-  makerFeeRate: string;
-}
-⋮----
-export interface AccountInfoV5 {
-  unifiedMarginStatus: number;
-  marginMode: AccountMarginModeV5;
-  isMasterTrader: boolean;
-  spotHedgingStatus: string;
-  updatedTime: string;
-}
-⋮----
-export interface TransactionLogV5 {
-  symbol: string;
-  category: CategoryV5;
-  side: string;
-  transactionTime: string;
-  type: TransactionTypeV5;
-  qty: string;
-  size: string;
-  currency: string;
-  tradePrice: string;
-  funding: string;
-  fee: string;
-  cashFlow: string;
-  change: string;
-  cashBalance: string;
-  feeRate: string;
-  bonusChange: string;
-  tradeId: string;
-  orderId: string;
-  orderLinkId: string;
-  extraFees: string;
-  transSubType: string;
-}
-⋮----
-export interface MMPStateV5 {
-  baseCoin: string;
-  mmpEnabled: boolean;
-  window: string;
-  frozenPeriod: string;
-  qtyLimit: string;
-  deltaLimit: string;
-  mmpFrozenUntil: string;
-  mmpFrozen: boolean;
-}
-⋮----
-export interface RepayLiabilityResultV5 {
-  coin: string;
-  repaymentQty: string;
-}
-⋮----
-export interface DCPInfoV5 {
-  product: 'SPOT' | 'DERIVATIVES' | 'OPTIONS';
-  dcpStatus: 'ON';
-  timeWindow: string;
 }
 
 ================
@@ -10040,6 +6179,18 @@ export interface WithdrawalRecordV5 {
   updateTime: string;
 }
 ⋮----
+export interface WithdrawalAddressV5 {
+  coin: string;
+  chain: string;
+  address: string;
+  tag: string;
+  remark: string;
+  status: number;
+  addressType: number;
+  verified: number;
+  createdAt: string;
+}
+⋮----
 export interface WithdrawableAmountV5 {
   limitAmountUsd: string;
   withdrawableAmount: {
@@ -10130,483 +6281,714 @@ export interface ConvertHistoryRecordV5 {
 }
 
 ================
-File: src/types/response/v5-market.ts
+File: src/types/response/v5-spot-leverage-token.ts
 ================
 import {
-  CategoryCursorListV5,
-  CategoryV5,
-  ContractTypeV5,
-  CopyTradingV5,
-  InstrumentStatusV5,
-  MarginTradingV5,
-  OptionTypeV5,
-  OrderSideV5,
+  LeverageTokenStatusV5,
+  LTOrderStatusV5,
+  LTOrderTypeV5,
 } from '../shared-v5';
 ⋮----
-/**
- * OHLCVT candle used by v5 APIs
- *
- * - list[0]: startTime	string	Start time of the candle (ms)
- * - list[1]: openPrice	string	Open price
- * - list[2]: highPrice	string	Highest price
- * - list[3]: lowPrice	string	Lowest price
- * - list[4]: closePrice	string	Close price. Is the last traded price when the candle is not closed
- * - list[5]: volume	string	Trade volume. Unit of contract: pieces of contract. Unit of spot: quantity of coins
- * - list[6]: turnover	string	Turnover. Unit of figure: quantity of quota coin
- */
-export type OHLCVKlineV5 = [
-  string,
-  string,
-  string,
-  string,
-  string,
-  string,
-  string,
-];
+export interface LeverageTokenInfoV5 {
+  ltCoin: string;
+  ltName: string;
+  maxPurchase: string;
+  minPurchase: string;
+  maxPurchaseDaily: string;
+  maxRedeem: string;
+  minRedeem: string;
+  maxRedeemDaily: string;
+  purchaseFeeRate: string;
+  redeemFeeRate: string;
+  ltStatus: LeverageTokenStatusV5;
+  fundFee: string;
+  fundFeeTime: string;
+  manageFeeRate: string;
+  manageFeeTime: string;
+  value: string;
+  netValue: string;
+  total: string;
+}
 ⋮----
-/**
- * OHLC candle used by v5 APIs
- *
- * - list[0]: startTime	string	Start time of the candle (ms)
- * - list[1]: openPrice	string	Open price
- * - list[2]: highPrice	string	Highest price
- * - list[3]: lowPrice	string	Lowest price
- * - list[4]: closePrice	string	Close price. Is the last traded price when the candle is not closed
- */
-export type OHLCKlineV5 = [string, string, string, string, string];
+export interface LeveragedTokenMarketResultV5 {
+  ltCoin: string;
+  nav: string;
+  navTime: string;
+  circulation: string;
+  basket: string;
+  leverage: string;
+}
 ⋮----
-export interface LinearInverseInstrumentInfoV5 {
-  symbol: string;
-  contractType: ContractTypeV5;
-  status: InstrumentStatusV5;
-  baseCoin: string;
-  quoteCoin: string;
-  symbolType: string; // The region to which the trading pair belongs
-  launchTime: string;
-  deliveryTime?: string;
-  deliveryFeeRate?: string;
-  priceScale: string;
-  leverageFilter: {
-    minLeverage: string;
-    maxLeverage: string;
-    leverageStep: string;
-  };
-  priceFilter: {
-    minPrice: string;
-    maxPrice: string;
-    tickSize: string;
-  };
-  lotSizeFilter: {
-    maxOrderQty: string;
-    maxMktOrderQty: string;
-    minOrderQty: string;
-    qtyStep: string;
-    postOnlyMaxOrderQty?: string;
-    minNotionalValue?: string;
-  };
-  unifiedMarginTrade: boolean;
-  fundingInterval: number;
-  settleCoin: string;
-  copyTrading: CopyTradingV5;
-  upperFundingRate: string;
-  lowerFundingRate: string;
-  riskParameters: {
-    priceLimitRatioX: string;
-    priceLimitRatioY: string;
-  };
-  isPreListing: boolean;
-  preListingInfo: {
-    curAuctionPhase: string;
-    phases: {
-      phase: string;
-      startTime: string;
-      endTime: string;
+export interface PurchaseSpotLeveragedTokenResultV5 {
+  ltCoin: string;
+  ltOrderStatus: LTOrderStatusV5;
+  execQty: string;
+  execAmt: string;
+  amount: string;
+  purchaseId: string;
+  serialNo: string;
+  valueCoin: string;
+}
+export interface RedeemSpotLeveragedTokenResultV5 {
+  ltCoin: string;
+  ltOrderStatus: LTOrderStatusV5;
+  quantity: string;
+  execQty: string;
+  execAmt: string;
+  redeemId: string;
+  serialNo: string;
+  valueCoin: string;
+}
+⋮----
+export interface SpotLeveragedTokenOrderHistoryV5 {
+  ltCoin: string;
+  orderId: string;
+  ltOrderType: LTOrderTypeV5;
+  orderTime: number;
+  updateTime: number;
+  ltOrderStatus: LTOrderStatusV5;
+  fee: string;
+  amount: string;
+  value: string;
+  valueCoin: string;
+  serialNo: string;
+}
+⋮----
+export interface VIPMarginDataV5 {
+  vipCoinList: {
+    list: {
+      borrowable: boolean;
+      collateralRatio: string;
+      currency: string;
+      hourlyBorrowRate: string;
+      liquidationOrder: string;
+      marginCollateral: boolean;
+      maxBorrowingAmount: string;
     }[];
-    auctionFeeInfo: {
-      auctionFeeRate: string;
-      takerFeeRate: string;
-      makerFeeRate: string;
-    };
-  } | null;
-  displayName: string;
+    vipLevel: string;
+  }[];
 }
 ⋮----
-symbolType: string; // The region to which the trading pair belongs
-⋮----
-export interface OptionInstrumentInfoV5 {
-  symbol: string;
-  optionsType: OptionTypeV5;
-  status: InstrumentStatusV5;
-  baseCoin: string;
-  quoteCoin: string;
-  settleCoin: string;
-  symbolType: string; // The region to which the trading pair belongs
-  launchTime: string;
-  deliveryTime: string;
-  deliveryFeeRate: string;
-  priceFilter: {
-    minPrice: string;
-    maxPrice: string;
-    tickSize: string;
-  };
-  lotSizeFilter: {
-    maxOrderQty: string;
-    minOrderQty: string;
-    qtyStep: string;
-  };
-  displayName: string;
+export interface SpotMarginStateV5 {
+  spotLeverage: string;
+  spotMarginMode: '1' | '0';
+  effectiveLeverage: string;
 }
 ⋮----
-symbolType: string; // The region to which the trading pair belongs
-⋮----
-export interface SpotInstrumentInfoV5 {
-  symbol: string;
-  baseCoin: string;
-  quoteCoin: string;
-  symbolType: string; // The region to which the trading pair belongs
-  innovation: '0' | '1'; // Deprecated, always 0
-  status: InstrumentStatusV5;
-  marginTrading: MarginTradingV5;
-  stTag: '0' | '1';
-  lotSizeFilter: {
-    basePrecision: string;
-    quotePrecision: string;
-    minOrderQty: string;
-    maxOrderQty: string;
-    minOrderAmt: string;
-    maxOrderAmt: string;
-  };
-  priceFilter: {
-    tickSize: string;
-  };
-  riskParameters: {
-    priceLimitRatioX: string;
-    priceLimitRatioY: string;
-  };
+// Spot Margin Trade (UTA) response types
+export interface ManualBorrowResultV5 {
+  coin: string;
+  amount: string;
 }
 ⋮----
-symbolType: string; // The region to which the trading pair belongs
-innovation: '0' | '1'; // Deprecated, always 0
+export interface MaxBorrowableAmountV5 {
+  currency: string;
+  maxLoan: string;
+}
 ⋮----
-type InstrumentInfoV5Mapping = {
-  linear: LinearInverseInstrumentInfoV5[];
-  inverse: LinearInverseInstrumentInfoV5[];
-  option: OptionInstrumentInfoV5[];
-  spot: SpotInstrumentInfoV5[];
-};
+export interface PositionTierV5 {
+  tier: string;
+  borrowLimit: string;
+  positionMMR: string;
+  positionIMR: string;
+  maxLeverage: string;
+}
 ⋮----
-export type InstrumentInfoResponseV5<C extends CategoryV5> =
-  CategoryCursorListV5<InstrumentInfoV5Mapping[C], C>;
+export interface CurrencyPositionTiersV5 {
+  currency: string;
+  positionTiersRatioList: PositionTierV5[];
+}
 ⋮----
-/**
- * [price, size]
- */
-export type OrderbookLevelV5 = [string, string];
+export interface CoinStateV5 {
+  currency: string;
+  spotLeverage: string;
+}
 ⋮----
-export interface OrderbookResponseV5 {
-  s: string;
-  b: OrderbookLevelV5[];
-  a: OrderbookLevelV5[];
-  ts: number;
-  u: number;
-  seq: number;
-  cts: number;
+export interface AvailableAmountToRepayV5 {
+  currency: string;
+  lossLessRepaymentAmount: string;
+}
+⋮----
+export interface ManualRepayWithoutConversionResultV5 {
+  /**
+   * Result status:
+   * - P: Processing
+   * - SU: Success
+   * - FA: Failed
+   */
+  resultStatus: 'P' | 'SU' | 'FA';
 }
 ⋮----
 /**
- * RPI Orderbook level: [price, nonRpiSize, rpiSize]
- */
-export type RPIOrderbookLevelV5 = [string, string, string];
+   * Result status:
+   * - P: Processing
+   * - SU: Success
+   * - FA: Failed
+   */
+
+================
+File: src/types/response/v5-trade.ts
+================
+import {
+  CategoryV5,
+  OrderCancelTypeV5,
+  OrderCreateTypeV5,
+  OrderRejectReasonV5,
+  OrderSideV5,
+  OrderStatusV5,
+  OrderTimeInForceV5,
+  OrderTriggerByV5,
+  OrderTypeV5,
+  PositionIdx,
+  StopOrderTypeV5,
+} from '../shared-v5';
 ⋮----
-export interface RPIOrderbookResponseV5 {
-  s: string; // Symbol name
-  b: RPIOrderbookLevelV5[]; // Bids. Sorted by price in descending order
-  a: RPIOrderbookLevelV5[]; // Asks. Sorted by price in ascending order
-  ts: number; // The timestamp (ms) that the system generates the data
-  u: number; // Update ID, is always in sequence corresponds to u in the 50-level WebSocket RPI orderbook stream
-  seq: number; // Cross sequence
-  cts: number; // The timestamp from the matching engine when this orderbook data is produced
+export interface OrderResultV5 {
+  orderId: string;
+  orderLinkId: string;
 }
 ⋮----
-s: string; // Symbol name
-b: RPIOrderbookLevelV5[]; // Bids. Sorted by price in descending order
-a: RPIOrderbookLevelV5[]; // Asks. Sorted by price in ascending order
-ts: number; // The timestamp (ms) that the system generates the data
-u: number; // Update ID, is always in sequence corresponds to u in the 50-level WebSocket RPI orderbook stream
-seq: number; // Cross sequence
-cts: number; // The timestamp from the matching engine when this orderbook data is produced
-⋮----
-export interface TickerLinearInverseV5 {
-  symbol: string;
-  lastPrice: string;
-  indexPrice: string;
-  markPrice: string;
-  prevPrice24h: string;
-  price24hPcnt: string;
-  highPrice24h: string;
-  lowPrice24h: string;
-  prevPrice1h: string;
-  openInterest: string;
-  openInterestValue: string;
-  turnover24h: string;
-  volume24h: string;
-  fundingRate: string;
-  nextFundingTime: string;
-  predictedDeliveryPrice: string;
-  basisRate: string;
-  deliveryFeeRate: string;
-  deliveryTime: string;
-  ask1Size: string;
-  bid1Price: string;
-  ask1Price: string;
-  bid1Size: string;
-  preOpenPrice: string;
-  preQty: string;
-  curPreListingPhase: string;
-  basis: string;
-}
-⋮----
-export interface TickerOptionV5 {
-  symbol: string;
-  bid1Price: string;
-  bid1Size: string;
-  bid1Iv: string;
-  ask1Price: string;
-  ask1Size: string;
-  ask1Iv: string;
-  lastPrice: string;
-  highPrice24h: string;
-  lowPrice24h: string;
-  markPrice: string;
-  indexPrice: string;
-  markIv: string;
-  underlyingPrice: string;
-  openInterest: string;
-  turnover24h: string;
-  volume24h: string;
-  totalVolume: string;
-  totalTurnover: string;
-  delta: string;
-  gamma: string;
-  vega: string;
-  theta: string;
-  predictedDeliveryPrice: string;
-  change24h: string;
-}
-⋮----
-export interface TickerSpotV5 {
-  symbol: string;
-  bid1Price: string;
-  bid1Size: string;
-  ask1Price: string;
-  ask1Size: string;
-  lastPrice: string;
-  prevPrice24h: string;
-  price24hPcnt: string;
-  highPrice24h: string;
-  lowPrice24h: string;
-  turnover24h: string;
-  volume24h: string;
-  usdIndexPrice: string;
-}
-⋮----
-export interface FundingRateHistoryResponseV5 {
-  symbol: string;
-  fundingRate: string;
-  fundingRateTimestamp: string;
-}
-⋮----
-export interface PublicTradeV5 {
-  execId: string;
+export interface AccountOrderV5 {
+  orderId: string;
+  orderLinkId: string;
+  blockTradeId: string;
   symbol: string;
   price: string;
-  size: string;
+  qty: string;
   side: OrderSideV5;
-  time: string;
-  isBlockTrade: boolean;
-  isRPITrade: boolean;
-  mP?: string;
-  iP?: string;
-  mIv?: string;
-  iv?: string;
-  seq?: string;
+  isLeverage: '0' | '1';
+  positionIdx: PositionIdx;
+  orderStatus: OrderStatusV5;
+  createType: OrderCreateTypeV5;
+  cancelType: OrderCancelTypeV5;
+  rejectReason: OrderRejectReasonV5;
+  avgPrice: string;
+  leavesQty: string;
+  leavesValue: string;
+  cumExecQty: string;
+  cumExecValue: string;
+  cumExecFee: string;
+  timeInForce: OrderTimeInForceV5;
+  orderType: OrderTypeV5;
+  stopOrderType: StopOrderTypeV5;
+  orderIv: string;
+  marketUnit: 'baseCoin' | 'quoteCoin';
+  slippageToleranceType: string;
+  slippageTolerance: string;
+  triggerPrice: string;
+  takeProfit: string;
+  stopLoss: string;
+  tpslMode: 'Full' | 'Partial' | '';
+  ocoTriggerType:
+    | 'OcoTriggerByUnknown'
+    | 'OcoTriggerTp'
+    | 'OcoTriggerBySl'
+    | '';
+  tpLimitPrice: string;
+  slLimitPrice: string;
+  tpTriggerBy: OrderTriggerByV5;
+  slTriggerBy: OrderTriggerByV5;
+  triggerDirection: 1 | 2;
+  triggerBy: OrderTriggerByV5;
+  lastPriceOnCreated: string;
+  reduceOnly: boolean;
+  closeOnTrigger: boolean;
+  placeType: 'iv' | 'price' | '';
+  smpType: string;
+  smpGroup: number;
+  smpOrderId: string;
+  createdTime: string;
+  updatedTime: string;
+  extraFees: string;
+  cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee
+}
+⋮----
+cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee
+⋮----
+export interface BatchCreateOrderResultV5 {
+  category: CategoryV5;
+  symbol: string;
+  orderId: string;
+  orderLinkId: string;
+  createAt?: string;
+}
+⋮----
+export interface BatchOrdersRetExtInfoV5 {
+  list: {
+    code: number;
+    msg: string;
+  }[];
+}
+⋮----
+export interface BatchAmendOrderResultV5 {
+  category: CategoryV5;
+  symbol: string;
+  orderId: string;
+  orderLinkId: string;
+}
+⋮----
+export interface BatchCancelOrderResultV5 {
+  category: CategoryV5;
+  symbol: string;
+  orderId: string;
+  orderLinkId: string;
+}
+⋮----
+export interface SpotBorrowCheckResultV5 {
+  symbol: string;
+  side: OrderSideV5;
+  maxTradeQty: string;
+  maxTradeAmount: string;
+  spotMaxTradeQty: string;
+  spotMaxTradeAmount: string;
+  borrowCoin: string;
+}
+⋮----
+export interface PreCheckOrderResultV5 {
+  orderId: string;
+  orderLinkId: string;
+  preImrE4: number; // Initial margin rate before checking (in basis points)
+  preMmrE4: number; // Maintenance margin rate before checking (in basis points)
+  postImrE4: number; // Initial margin rate after checking (in basis points)
+  postMmrE4: number; // Maintenance margin rate after checking (in basis points)
+}
+⋮----
+preImrE4: number; // Initial margin rate before checking (in basis points)
+preMmrE4: number; // Maintenance margin rate before checking (in basis points)
+postImrE4: number; // Initial margin rate after checking (in basis points)
+postMmrE4: number; // Maintenance margin rate after checking (in basis points)
+
+================
+File: src/types/websockets/index.ts
+================
+
+
+================
+File: src/types/index.ts
+================
+
+
+================
+File: src/index.ts
+================
+
+
+================
+File: src/websocket-api-client.ts
+================
+import {
+  AmendOrderParamsV5,
+  BatchAmendOrderParamsV5,
+  BatchAmendOrderResultV5,
+  BatchCancelOrderParamsV5,
+  BatchCancelOrderResultV5,
+  BatchCreateOrderResultV5,
+  BatchOrderParamsV5,
+  BatchOrdersRetExtInfoV5,
+  CancelOrderParamsV5,
+  OrderParamsV5,
+  OrderResultV5,
+} from './types';
+import { WSAPIResponse } from './types/websockets/ws-api';
+import { WSClientConfigurableOptions } from './types/websockets/ws-general';
+import { DefaultLogger } from './util';
+import { WS_KEY_MAP } from './util/websockets/websocket-util';
+import { WebsocketClient } from './websocket-client';
+⋮----
+/**
+ * Configurable options specific to only the REST-like WebsocketAPIClient
+ */
+export interface WSAPIClientConfigurableOptions {
+  /**
+   * Default: true
+   *
+   * Attach default event listeners, which will console log any high level
+   * events (opened/reconnecting/reconnected/etc).
+   *
+   * If you disable this, you should set your own event listeners
+   * on the embedded WS Client `wsApiClient.getWSClient().on(....)`.
+   */
+  attachEventListeners: boolean;
 }
 ⋮----
 /**
- *
- * - openInterest	string	Open interest
- * - timestamp	string	The timestamp (ms)
- */
-export type OpenInterestV5 = {
-  openInterest: string;
-  timestamp: string;
-};
+   * Default: true
+   *
+   * Attach default event listeners, which will console log any high level
+   * events (opened/reconnecting/reconnected/etc).
+   *
+   * If you disable this, you should set your own event listeners
+   * on the embedded WS Client `wsApiClient.getWSClient().on(....)`.
+   */
 ⋮----
-export interface OpenInterestResponseV5 {
+/**
+ * This is a minimal Websocket API wrapper around the WebsocketClient.
+ *
+ * Some methods support passing in a custom "wsKey". This is a reference to which WS connection should
+ * be used to transmit that message. This is only useful if you wish to use an alternative wss
+ * domain that is supported by the SDK.
+ *
+ * Note: To use testnet, don't set the wsKey - use `testnet: true` in
+ * the constructor instead.
+ *
+ * Note: You can also directly use the sendWSAPIRequest() method to make WS API calls, but some
+ * may find the below methods slightly more intuitive.
+ *
+ * Refer to the WS API promises example for a more detailed example on using sendWSAPIRequest() directly:
+ * https://github.com/tiagosiebler/bybit-api/blob/master/examples/ws-api-raw-promises.ts
+ */
+export class WebsocketAPIClient
+⋮----
+constructor(
+    options?: WSClientConfigurableOptions &
+      Partial<WSAPIClientConfigurableOptions>,
+    logger?: DefaultLogger,
+)
+⋮----
+public getWSClient(): WebsocketClient
+⋮----
+public setTimeOffsetMs(newOffset: number): void
+⋮----
+/*
+   * Bybit WebSocket API Methods
+   * https://bybit-exchange.github.io/docs/v5/websocket/trade/guideline
+   */
+⋮----
+/**
+   * Submit a new order
+   *
+   * @param params
+   * @returns
+   */
+submitNewOrder(
+    params: OrderParamsV5,
+): Promise<WSAPIResponse<OrderResultV5, 'order.create'>>
+⋮----
+/**
+   * Amend an order
+   *
+   * @param params
+   * @returns
+   */
+amendOrder(
+    params: AmendOrderParamsV5,
+): Promise<WSAPIResponse<OrderResultV5, 'order.amend'>>
+⋮----
+/**
+   * Cancel an order
+   *
+   * @param params
+   * @returns
+   */
+cancelOrder(
+    params: CancelOrderParamsV5,
+): Promise<WSAPIResponse<OrderResultV5, 'order.cancel'>>
+⋮----
+/**
+   * Batch submit orders
+   *
+   * @param params
+   * @returns
+   */
+batchSubmitOrders(
+    category: 'option' | 'linear',
+    orders: BatchOrderParamsV5[],
+  ): Promise<
+    WSAPIResponse<
+      {
+        list: BatchCreateOrderResultV5[];
+      },
+      'order.create-batch',
+      BatchOrdersRetExtInfoV5
+    >
+  > {
+    return this.wsClient.sendWSAPIRequest(
+      WS_KEY_MAP.v5PrivateTrade,
+      'order.create-batch',
+      {
+        category,
+        request: orders,
+      },
+    );
+⋮----
+/**
+   * Batch amend orders
+   *
+   * @param params
+   * @returns
+   */
+batchAmendOrder(
+    category: 'option' | 'linear',
+    orders: BatchAmendOrderParamsV5[],
+  ): Promise<
+    WSAPIResponse<
+      {
+        list: BatchAmendOrderResultV5[];
+      },
+      'order.amend-batch',
+      BatchOrdersRetExtInfoV5
+    >
+  > {
+    return this.wsClient.sendWSAPIRequest(
+      WS_KEY_MAP.v5PrivateTrade,
+      'order.amend-batch',
+      {
+        category,
+        request: orders,
+      },
+    );
+⋮----
+/**
+   * Batch cancel orders
+   *
+   * @param params
+   * @returns
+   */
+batchCancelOrder(
+    category: 'option' | 'linear',
+    orders: BatchCancelOrderParamsV5[],
+  ): Promise<
+    WSAPIResponse<
+      {
+        list: BatchCancelOrderResultV5[];
+      },
+      'order.cancel-batch',
+      BatchOrdersRetExtInfoV5
+    >
+  > {
+    return this.wsClient.sendWSAPIRequest(
+      WS_KEY_MAP.v5PrivateTrade,
+      'order.cancel-batch',
+      {
+        category,
+        request: orders,
+      },
+    );
+⋮----
+/**
+   *
+   *
+   *
+   *
+   *
+   *
+   *
+   * Private methods for handling some of the convenience/automation provided by the WS API Client
+   *
+   *
+   *
+   *
+   *
+   *
+   *
+   */
+⋮----
+private setupDefaultEventListeners()
+⋮----
+/**
+       * General event handlers for monitoring the WebsocketClient
+       */
+⋮----
+// Blind JSON.stringify can fail on circular references
+⋮----
+// JSON.stringify({ ...data, target: 'WebSocket' }),
+
+================
+File: examples/rest-v5-p2p.ts
+================
+import fs from 'fs';
+import path from 'path';
+⋮----
+import { RestClientV5 } from '../src';
+⋮----
+// ENDPOINT: /v5/p2p/oss/upload_file
+// METHOD: POST
+// PUBLIC: NO
+// NOTE: Node.js only (Buffer required)
+⋮----
+async function uploadP2PChatFile()
+⋮----
+// You must read the file yourself and pass the Buffer + filename
+⋮----
+/**
+     *
+     *
+     *
+     *
+     *
+     *
+     */
+⋮----
+// Test basic P2P API connectivity
+⋮----
+// Example 1: Upload from file path
+⋮----
+fileName: path.basename(filePath), // Extract filename from path
+⋮----
+// Example 2: Upload with custom filename
+// You control the filename sent to Bybit
+⋮----
+fileName: 'custom-name.png', // Use any filename you want
+⋮----
+// Example 3: Upload different file
+⋮----
+// Supported file types (determined by filename extension):
+// - Images: jpg, jpeg, png
+// - Documents: pdf
+// - Videos: mp4
+
+================
+File: src/types/request/v5-position.ts
+================
+import {
+  CategoryV5,
+  ExecTypeV5,
+  OrderTriggerByV5,
+  OrderTypeV5,
+  PositionIdx,
+  TPSLModeV5,
+} from '../shared-v5';
+⋮----
+export interface PositionInfoParamsV5 {
+  category: CategoryV5;
+  symbol?: string;
+  baseCoin?: string;
+  settleCoin?: string;
+  limit?: number;
+  cursor?: string;
+}
+⋮----
+export interface SetLeverageParamsV5 {
   category: 'linear' | 'inverse';
   symbol: string;
-  list: OpenInterestV5[];
-  nextPageCursor?: string;
+  buyLeverage: string;
+  sellLeverage: string;
 }
 ⋮----
-export interface HistoricalVolatilityV5 {
-  period: number;
-  value: string;
-  time: string;
-}
-⋮----
-export interface InsuranceDataV5 {
-  coin: string;
-  symbols: string;
-  balance: string;
-  value: string;
-}
-⋮----
-export interface InsuranceResponseV5 {
-  updatedTime: string;
-  list: InsuranceDataV5[];
-}
-⋮----
-export interface RiskLimitV5 {
-  id: number;
+export interface SwitchIsolatedMarginParamsV5 {
+  category: 'linear' | 'inverse';
   symbol: string;
-  riskLimitValue: string;
-  maintenanceMargin: number;
-  initialMargin: number;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  section: any;
-  isLowestRisk: 0 | 1;
-  maxLeverage: string;
-  mmDeduction: string;
-  nextPageCursor?: string;
+  tradeMode: 0 | 1;
+  buyLeverage: string;
+  sellLeverage: string;
 }
 ⋮----
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-⋮----
-/** @deprecated use DeliveryPriceV5 instead */
-export interface OptionDeliveryPriceV5 {
+export interface SetTPSLModeParamsV5 {
+  category: 'linear' | 'inverse';
   symbol: string;
-  deliveryPrice: string;
-  deliveryTime: string;
+  tpSlMode: TPSLModeV5;
 }
 ⋮----
-export interface DeliveryPriceV5 {
+export interface SwitchPositionModeParamsV5 {
+  category: 'linear' | 'inverse';
+  symbol?: string;
+  coin?: string;
+  mode: 0 | 3;
+}
+⋮----
+export interface SetRiskLimitParamsV5 {
+  category: 'linear' | 'inverse';
   symbol: string;
-  deliveryPrice: string;
-  deliveryTime: string;
+  riskId: number;
+  positionIdx?: PositionIdx;
 }
 ⋮----
-export interface LongShortRatioV5 {
+export interface SetTradingStopParamsV5 {
+  category: CategoryV5;
   symbol: string;
-  buyRatio: string;
-  sellRatio: string;
-  timestamp: string;
+  takeProfit?: string;
+  stopLoss?: string;
+  trailingStop?: string;
+  tpTriggerBy?: OrderTriggerByV5;
+  slTriggerBy?: OrderTriggerByV5;
+  activePrice?: string;
+  tpslMode?: TPSLModeV5;
+  tpSize?: string;
+  slSize?: string;
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
+  tpOrderType?: OrderTypeV5;
+  slOrderType?: OrderTypeV5;
+  positionIdx: PositionIdx;
 }
 ⋮----
-export interface OrderPriceLimitV5 {
+export interface SetAutoAddMarginParamsV5 {
+  category: 'linear';
   symbol: string;
-  buyLmt: string;
-  sellLmt: string;
-  ts: string;
+  autoAddMargin: 0 | 1;
+  positionIdx?: PositionIdx;
 }
 ⋮----
-export interface IndexPriceComponentV5 {
-  exchange: string; // Name of the exchange
-  spotPair: string; // Spot trading pair on the exchange (e.g., BTCUSDT)
-  equivalentPrice: string; // Equivalent price
-  multiplier: string; // Multiplier used for the component price
-  price: string; // Actual price
-  weight: string; // Weight in the index calculation
+export interface AddOrReduceMarginParamsV5 {
+  category: 'linear' | 'inverse';
+  symbol: string;
+  margin: string;
+  positionIDex?: PositionIdx;
 }
 ⋮----
-exchange: string; // Name of the exchange
-spotPair: string; // Spot trading pair on the exchange (e.g., BTCUSDT)
-equivalentPrice: string; // Equivalent price
-multiplier: string; // Multiplier used for the component price
-price: string; // Actual price
-weight: string; // Weight in the index calculation
-⋮----
-export interface IndexPriceComponentsResponseV5 {
-  indexName: string; // Name of the index (e.g., BTCUSDT)
-  lastPrice: string; // Last price of the index
-  updateTime: string; // Timestamp of the last update in milliseconds
-  components: IndexPriceComponentV5[]; // List of components contributing to the index price
+export interface GetExecutionListParamsV5 {
+  category: CategoryV5;
+  symbol?: string;
+  orderId?: string;
+  orderLinkId?: string;
+  baseCoin?: string;
+  startTime?: number;
+  endTime?: number;
+  execType?: ExecTypeV5;
+  limit?: number;
+  cursor?: string;
 }
 ⋮----
-indexName: string; // Name of the index (e.g., BTCUSDT)
-lastPrice: string; // Last price of the index
-updateTime: string; // Timestamp of the last update in milliseconds
-components: IndexPriceComponentV5[]; // List of components contributing to the index price
-⋮----
-export interface ADLAlertItemV5 {
-  coin: string; // Token of the insurance pool
-  symbol: string; // Trading pair name
-  balance: string; // Balance of the insurance fund. Used to determine if ADL is triggered
-  maxBalance: string; // Maximum balance of the insurance pool in the last 8 hours
-  insurancePnlRatio: string; // PnL ratio threshold for triggering contract PnL drawdown ADL
-  pnlRatio: string; // Symbol's PnL drawdown ratio in the last 8 hours. Used to determine whether ADL is triggered or stopped
-  adlTriggerThreshold: string; // Trigger threshold for contract PnL drawdown ADL
-  adlStopRatio: string; // Stop ratio threshold for contract PnL drawdown ADL
+export interface GetClosedPnLParamsV5 {
+  category: CategoryV5;
+  symbol?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
 }
 ⋮----
-coin: string; // Token of the insurance pool
-symbol: string; // Trading pair name
-balance: string; // Balance of the insurance fund. Used to determine if ADL is triggered
-maxBalance: string; // Maximum balance of the insurance pool in the last 8 hours
-insurancePnlRatio: string; // PnL ratio threshold for triggering contract PnL drawdown ADL
-pnlRatio: string; // Symbol's PnL drawdown ratio in the last 8 hours. Used to determine whether ADL is triggered or stopped
-adlTriggerThreshold: string; // Trigger threshold for contract PnL drawdown ADL
-adlStopRatio: string; // Stop ratio threshold for contract PnL drawdown ADL
-⋮----
-export interface ADLAlertResponseV5 {
-  updateTime: string; // Latest data update timestamp (ms)
-  list: ADLAlertItemV5[]; // List of ADL alert items
+export interface MovePositionParamsV5 {
+  fromUid: string;
+  toUid: string;
+  list: {
+    category: 'linear' | 'spot' | 'option' | 'inverse';
+    symbol: string;
+    price: string;
+    side: 'Buy' | 'Sell';
+    qty: string;
+  }[];
 }
 ⋮----
-updateTime: string; // Latest data update timestamp (ms)
-list: ADLAlertItemV5[]; // List of ADL alert items
-⋮----
-export interface FeeGroupLevelV5 {
-  level: string; // Pro level name or Market Maker level name
-  takerFeeRate: string; // Taker fee rate
-  makerFeeRate: string; // Maker fee rate
-  makerRebate: string; // Maker rebate fee rate
+export interface GetMovePositionHistoryParamsV5 {
+  category?: 'linear' | 'spot' | 'option';
+  symbol?: string;
+  startTime?: number;
+  endTime?: number;
+  status?: 'Processing' | 'Filled' | 'Rejected';
+  blockTradeId?: string;
+  limit?: string;
+  cursor?: string;
 }
 ⋮----
-level: string; // Pro level name or Market Maker level name
-takerFeeRate: string; // Taker fee rate
-makerFeeRate: string; // Maker fee rate
-makerRebate: string; // Maker rebate fee rate
-⋮----
-export interface FeeGroupRatesV5 {
-  pro: FeeGroupLevelV5[]; // Pro-level fee structures
-  marketMaker: FeeGroupLevelV5[]; // Market Maker-level fee structures
+export interface ConfirmNewRiskLimitParamsV5 {
+  category: 'linear' | 'inverse';
+  symbol: string;
 }
 ⋮----
-pro: FeeGroupLevelV5[]; // Pro-level fee structures
-marketMaker: FeeGroupLevelV5[]; // Market Maker-level fee structures
-⋮----
-export interface FeeGroupItemV5 {
-  groupName: string; // Fee group name
-  weightingFactor: number; // Group weighting factor
-  symbolsNumbers: number; // Symbols number
-  symbols: string[]; // Symbol names
-  feeRates: FeeGroupRatesV5; // Fee rate details for different categories
-  updateTime: string; // Latest data update timestamp (ms)
+export interface GetClosedOptionsPositionsParamsV5 {
+  category: 'option';
+  symbol?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
 }
-⋮----
-groupName: string; // Fee group name
-weightingFactor: number; // Group weighting factor
-symbolsNumbers: number; // Symbols number
-symbols: string[]; // Symbol names
-feeRates: FeeGroupRatesV5; // Fee rate details for different categories
-updateTime: string; // Latest data update timestamp (ms)
-⋮----
-export interface FeeGroupStructureResponseV5 {
-  list: FeeGroupItemV5[]; // List of fee group objects
-}
-⋮----
-list: FeeGroupItemV5[]; // List of fee group objects
+
+================
+File: src/types/response/index.ts
+================
+
 
 ================
 File: src/types/response/v5-rfq.ts
@@ -10936,303 +7318,478 @@ updatedAt: number; // Time when trade is updated in epoch
 legs: RFQPublicTradeLegV5[]; // Combination transaction
 
 ================
-File: src/types/response/v5-spreadtrading.ts
+File: src/types/shared-v5.ts
 ================
-export interface SpreadInstrumentInfoV5 {
+export type CategoryV5 = 'spot' | 'linear' | 'inverse' | 'option';
+export type ContractTypeV5 =
+  | 'InversePerpetual'
+  | 'LinearPerpetual'
+  | 'InverseFutures';
+export type CopyTradingV5 = 'none' | 'both' | 'utaOnly' | 'normalOnly';
+⋮----
+export type InstrumentStatusV5 =
+  | 'PreLaunch'
+  | 'Trading'
+  | 'Settling'
+  | 'Delivering'
+  | 'Closed';
+⋮----
+export type MarginTradingV5 = 'none' | 'both' | 'utaOnly' | 'normalSpotOnly';
+⋮----
+export type OrderFilterV5 = 'Order' | 'tpslOrder' | 'StopOrder';
+export type OrderSideV5 = 'Buy' | 'Sell';
+export type OrderTypeV5 = 'Market' | 'Limit';
+export type OrderTimeInForceV5 = 'GTC' | 'IOC' | 'FOK' | 'PostOnly' | 'RPI';
+export type OrderTriggerByV5 = 'LastPrice' | 'IndexPrice' | 'MarkPrice';
+export type OCOTriggerTypeV5 =
+  | 'OcoTriggerByUnknown'
+  | 'OcoTriggerTp'
+  | 'OcoTriggerBySl';
+⋮----
+export type OrderSMPTypeV5 =
+  | 'None'
+  | 'CancelMaker'
+  | 'CancelTaker'
+  | 'CancelBoth';
+⋮----
+export type OrderStatusV5 =
+  | 'Created'
+  | 'New'
+  | 'Rejected'
+  | 'PartiallyFilled'
+  | 'PartiallyFilledCanceled'
+  | 'Filled'
+  | 'Cancelled'
+  | 'Untriggered'
+  | 'Triggered'
+  | 'Deactivated'
+  | 'Active';
+⋮----
+/**
+ * Defines the types of order creation mechanisms.
+ */
+export type OrderCreateTypeV5 =
+  /** Represents an order created by a user. */
+  | 'CreateByUser'
+  /** Represents an order created by an admin closing. */
+  | 'CreateByAdminClosing'
+  /** Futures conditional order. */
+  | 'CreateByStopOrder'
+  /** Futures take profit order. */
+  | 'CreateByTakeProfit'
+  /** Futures partial take profit order. */
+  | 'CreateByPartialTakeProfit'
+  /** Futures stop loss order. */
+  | 'CreateByStopLoss'
+  /** Futures partial stop loss order. */
+  | 'CreateByPartialStopLoss'
+  /** Futures trailing stop order. */
+  | 'CreateByTrailingStop'
+  /** Laddered liquidation to reduce the required maintenance margin. */
+  | 'CreateByLiq'
+  /**
+   * If the position is still subject to liquidation (i.e., does not meet the required maintenance margin level),
+   * the position shall be taken over by the liquidation engine and closed at the bankruptcy price.
+   */
+  | 'CreateByTakeOver_PassThrough'
+  /** Auto-Deleveraging(ADL) */
+  | 'CreateByAdl_PassThrough'
+  /** Order placed via Paradigm. */
+  | 'CreateByBlock_PassThrough'
+  /** Order created by move position. */
+  | 'CreateByBlockTradeMovePosition_PassThrough'
+  /** The close order placed via web or app position area - web/app. */
+  | 'CreateByClosing'
+  /** Order created via grid bot - web/app. */
+  | 'CreateByFGridBot'
+  /** Order closed via grid bot - web/app. */
+  | 'CloseByFGridBot'
+  /** Order created by TWAP - web/app. */
+  | 'CreateByTWAP'
+  /** Order created by TV webhook - web/app. */
+  | 'CreateByTVSignal'
+  /** Order created by Mm rate close function - web/app. */
+  | 'CreateByMmRateClose'
+  /** Order created by Martingale bot - web/app. */
+  | 'CreateByMartingaleBot'
+  /** Order closed by Martingale bot - web/app. */
+  | 'CloseByMartingaleBot'
+  /** Order created by Ice berg strategy - web/app. */
+  | 'CreateByIceBerg'
+  /** Order created by arbitrage - web/app. */
+  | 'CreateByArbitrage'
+  /** Option dynamic delta hedge order - web/app */
+  | 'CreateByDdh'
+  /** BBO Order - Best Bid/Offer order */
+  | 'CreateByBboOrder';
+⋮----
+/** Represents an order created by a user. */
+⋮----
+/** Represents an order created by an admin closing. */
+⋮----
+/** Futures conditional order. */
+⋮----
+/** Futures take profit order. */
+⋮----
+/** Futures partial take profit order. */
+⋮----
+/** Futures stop loss order. */
+⋮----
+/** Futures partial stop loss order. */
+⋮----
+/** Futures trailing stop order. */
+⋮----
+/** Laddered liquidation to reduce the required maintenance margin. */
+⋮----
+/**
+   * If the position is still subject to liquidation (i.e., does not meet the required maintenance margin level),
+   * the position shall be taken over by the liquidation engine and closed at the bankruptcy price.
+   */
+⋮----
+/** Auto-Deleveraging(ADL) */
+⋮----
+/** Order placed via Paradigm. */
+⋮----
+/** Order created by move position. */
+⋮----
+/** The close order placed via web or app position area - web/app. */
+⋮----
+/** Order created via grid bot - web/app. */
+⋮----
+/** Order closed via grid bot - web/app. */
+⋮----
+/** Order created by TWAP - web/app. */
+⋮----
+/** Order created by TV webhook - web/app. */
+⋮----
+/** Order created by Mm rate close function - web/app. */
+⋮----
+/** Order created by Martingale bot - web/app. */
+⋮----
+/** Order closed by Martingale bot - web/app. */
+⋮----
+/** Order created by Ice berg strategy - web/app. */
+⋮----
+/** Order created by arbitrage - web/app. */
+⋮----
+/** Option dynamic delta hedge order - web/app */
+⋮----
+/** BBO Order - Best Bid/Offer order */
+⋮----
+export type OrderCancelTypeV5 =
+  | 'CancelByUser'
+  | 'CancelByReduceOnly'
+  | 'CancelByPrepareLiq'
+  | 'CancelAllBeforeLiq'
+  | 'CancelByPrepareAdl'
+  | 'CancelAllBeforeAdl'
+  | 'CancelByAdmin'
+  | 'CancelByTpSlTsClear'
+  | 'CancelByPzSideCh'
+  | 'UNKNOWN';
+⋮----
+export type OrderRejectReasonV5 =
+  | 'EC_NoError'
+  | 'EC_Others'
+  | 'EC_UnknownMessageType'
+  | 'EC_MissingClOrdID'
+  | 'EC_MissingOrigClOrdID'
+  | 'EC_ClOrdIDOrigClOrdIDAreTheSame'
+  | 'EC_DuplicatedClOrdID'
+  | 'EC_OrigClOrdIDDoesNotExist'
+  | 'EC_TooLateToCancel'
+  | 'EC_UnknownOrderType'
+  | 'EC_UnknownSide'
+  | 'EC_UnknownTimeInForce'
+  | 'EC_WronglyRouted'
+  | 'EC_MarketOrderPriceIsNotZero'
+  | 'EC_LimitOrderInvalidPrice'
+  | 'EC_NoEnoughQtyToFill'
+  | 'EC_NoImmediateQtyToFill'
+  | 'EC_PerCancelRequest'
+  | 'EC_MarketOrderCannotBePostOnly'
+  | 'EC_PostOnlyWillTakeLiquidity'
+  | 'EC_CancelReplaceOrder'
+  | 'EC_InvalidSymbolStatus';
+⋮----
+export type StopOrderTypeV5 =
+  | 'TakeProfit'
+  | 'StopLoss'
+  | 'TrailingStop'
+  | 'Stop'
+  | 'PartialTakeProfit'
+  | 'PartialStopLoss'
+  | 'tpslOrder'
+  | 'OcoOrder'
+  | 'MmRateClose'
+  | 'BidirectionalTpslOrder';
+⋮----
+/**
+ * Position index. Used to identify positions in different position modes.
+ *
+ * - 0 one-way mode position
+ * - 1 Buy side of hedge-mode position
+ * - 2 Sell side of hedge-mode position
+ */
+export type PositionIdx = 0 | 1 | 2;
+⋮----
+/**
+ * Position status.
+ *
+ * - 'Normal'
+ * - 'Liq' in the liquidation progress
+ * - 'Adl' in the auto-deleverage progress
+ */
+export type PositionStatusV5 = 'Normal' | 'Liq' | 'Adl';
+export type PositionSideV5 = 'Buy' | 'Sell' | 'None' | '';
+⋮----
+export type OptionTypeV5 = 'Call' | 'Put';
+⋮----
+/**
+ * Trade mode.
+ *
+ * - 0 cross-margin,
+ * - 1 isolated margin
+ */
+export type TradeModeV5 = 0 | 1;
+⋮----
+export type TPSLModeV5 = 'Full' | 'Partial';
+export type AccountMarginModeV5 =
+  | 'ISOLATED_MARGIN'
+  | 'REGULAR_MARGIN'
+  | 'PORTFOLIO_MARGIN';
+export type UnifiedUpdateStatusV5 = 'FAIL' | 'PROCESS' | 'SUCCESS';
+⋮----
+export type AccountTypeV5 =
+  | 'CONTRACT'
+  | 'SPOT'
+  | 'INVESTMENT'
+  | 'OPTION'
+  | 'UNIFIED'
+  | 'FUND';
+⋮----
+export type TransactionTypeV5 =
+  | 'TRANSFER_IN'
+  | 'TRANSFER_OUT'
+  | 'TRADE'
+  | 'SETTLEMENT'
+  | 'DELIVERY'
+  | 'LIQUIDATION'
+  | 'ADL'
+  | 'AIRDROP'
+  | 'BONUS_RECOLLECT'
+  | 'BONUS_RECOLLECT'
+  | 'FEE_REFUND'
+  | 'INTEREST'
+  | 'CURRENCY_BUY'
+  | 'CURRENCY_SELL'
+  | 'BORROWED_AMOUNT_INS_LOAN'
+  | 'PRINCIPLE_REPAYMENT_INS_LOAN'
+  | 'INTEREST_REPAYMENT_INS_LOAN'
+  | 'AUTO_SOLD_COLLATERAL_INS_LOAN'
+  | 'AUTO_BUY_LIABILITY_INS_LOAN'
+  | 'AUTO_PRINCIPLE_REPAYMENT_INS_LOAN'
+  | 'AUTO_INTEREST_REPAYMENT_INS_LOAN'
+  | 'TRANSFER_IN_INS_LOAN'
+  | 'TRANSFER_OUT_INS_LOAN'
+  | 'SPOT_REPAYMENT_SELL'
+  | 'SPOT_REPAYMENT_BUY'
+  | 'TOKENS_SUBSCRIPTION'
+  | 'TOKENS_REDEMPTION'
+  | 'AUTO_DEDUCTION'
+  | 'FLEXIBLE_STAKING_SUBSCRIPTION'
+  | 'FLEXIBLE_STAKING_REDEMPTION'
+  | 'FIXED_STAKING_SUBSCRIPTION'
+  | 'BORROWED_AMOUNT_INS_LOAN'
+  | 'PRINCIPLE_REPAYMENT_INS_LOAN'
+  | 'INTEREST_REPAYMENT_INS_LOAN'
+  | 'AUTO_SOLD_COLLATERAL_INS_LOAN'
+  | 'AUTO_BUY_LIABILITY_INS_LOAN'
+  | 'AUTO_PRINCIPLE_REPAYMENT_INS_LOAN'
+  | 'AUTO_INTEREST_REPAYMENT_INS_LOAN'
+  | 'TRANSFER_IN_INS_LOAN'
+  | 'TRANSFER_OUT_INS_LOAN'
+  | 'SPOT_REPAYMENT_SELL'
+  | 'SPOT_REPAYMENT_BUY'
+  | 'TOKENS_SUBSCRIPTION'
+  | 'TOKENS_REDEMPTION'
+  | 'AUTO_DEDUCTION'
+  | 'FLEXIBLE_STAKING_SUBSCRIPTION'
+  | 'FLEXIBLE_STAKING_REDEMPTION'
+  | 'FIXED_STAKING_SUBSCRIPTION'
+  | 'FLEXIBLE_STAKING_REFUND'
+  | 'FIXED_STAKING_REFUND'
+  | 'PREMARKET_TRANSFER_OUT'
+  | 'PREMARKET_DELIVERY_SELL_NEW_COIN'
+  | 'PREMARKET_DELIVERY_BUY_NEW_COIN'
+  | 'PREMARKET_DELIVERY_PLEDGE_PAY_SELLER'
+  | 'PREMARKET_DELIVERY_PLEDGE_BACK'
+  | 'PREMARKET_ROLLBACK_PLEDGE_BACK'
+  | 'PREMARKET_ROLLBACK_PLEDGE_PENALTY_TO_BUYER'
+  | 'CUSTODY_NETWORK_FEE'
+  | 'CUSTODY_SETTLE_FEE'
+  | 'CUSTODY_LOCK'
+  | 'CUSTODY_UNLOCK'
+  | 'CUSTODY_UNLOCK_REFUND'
+  | 'LOANS_BORROW_FUNDS'
+  | 'LOANS_PLEDGE_ASSET'
+  | 'BONUS_TRANSFER_IN'
+  | 'BONUS_TRANSFER_OUT'
+  | 'PEF_TRANSFER_IN'
+  | 'PEF_TRANSFER_OUT'
+  | 'PEF_PROFIT_SHARE'
+  | 'ONCHAINEARN_SUBSCRIPTION'
+  | 'ONCHAINEARN_REDEMPTION'
+  | 'ONCHAINEARN_REFUND'
+  | 'STRUCTURE_PRODUCT_SUBSCRIPTION'
+  | 'STRUCTURE_PRODUCT_REFUND'
+  | 'CLASSIC_WEALTH_MANAGEMENT_SUBSCRIPTION'
+  | 'PREMIMUM_WEALTH_MANAGEMENT_SUBSCRIPTION'
+  | 'PREMIMUM_WEALTH_MANAGEMENT_REFUND'
+  | 'LIQUIDITY_MINING_SUBSCRIPTION'
+  | 'LIQUIDITY_MINING_REFUND'
+  | 'PWM_SUBSCRIPTION'
+  | 'PWM_REFUND'
+  | 'DEFI_INVESTMENT_SUBSCRIPTION'
+  | 'DEFI_INVESTMENT_REFUND'
+  | 'DEFI_INVESTMENT_REDEMPTION'
+  | 'INSTITUTION_LOAN_IN'
+  | 'INSTITUTION_PAYBACK_PRINCIPAL_OUT'
+  | 'INSTITUTION_PAYBACK_INTEREST_OUT'
+  | 'INSTITUTION_EXCHANGE_SELL'
+  | 'INSTITUTION_EXCHANGE_BUY'
+  | 'INSTITUTION_LIQ_PRINCIPAL_OUT'
+  | 'INSTITUTION_LIQ_INTEREST_OUT'
+  | 'INSTITUTION_LOAN_TRANSFER_IN'
+  | 'INSTITUTION_LOAN_TRANSFER_OUT'
+  | 'INSTITUTION_LOAN_WITHOUT_WITHDRAW'
+  | 'INSTITUTION_LOAN_RESERVE_IN'
+  | 'INSTITUTION_LOAN_RESERVE_OUT'
+  | 'PLATFORM_TOKEN_MNT_LIQRECALLEDMMNT'
+  | 'PLATFORM_TOKEN_MNT_LIQRETURNEDMNT';
+⋮----
+export type PermissionTypeV5 =
+  | 'ContractTrade'
+  | 'Spot'
+  | 'Wallet'
+  | 'Options'
+  | 'Derivatives'
+  | 'Exchange'
+  | 'NFT';
+⋮----
+/**
+ * Leveraged token status:
+ *
+ * - '1' LT can be purchased and redeemed
+ * - '2' LT can be purchased, but not redeemed
+ * - '3' LT can be redeemed, but not purchased
+ * - '4' LT cannot be purchased nor redeemed
+ * - '5' Adjusting position
+ */
+export type LeverageTokenStatusV5 = '1' | '2' | '3' | '4' | '5';
+⋮----
+/**
+ * Leveraged token order type: '1': purchase, '2': redeem
+ */
+export type LTOrderTypeV5 = '1' | '2';
+⋮----
+/**
+ * Leveraged token order status: '1': completed, '2': in progress, '3': failed
+ */
+export type LTOrderStatusV5 = '1' | '2' | '3';
+⋮----
+export type ExecTypeV5 =
+  | 'Trade'
+  | 'AdlTrade'
+  | 'Funding'
+  | 'BustTrade'
+  | 'Settle'
+  | 'BlockTrade'
+  | 'MovePosition'
+  | 'UNKNOWN';
+⋮----
+/**
+ * Withdraw type. 0(default): on chain. 1: off chain. 2: all.
+ */
+export type WithdrawalTypeV5 = '0' | '1' | '2';
+⋮----
+export interface PermissionsV5 {
+  ContractTrade?: string[];
+  Spot?: string[];
+  Wallet?: string[];
+  Options?: string[];
+  Derivatives?: string[];
+  CopyTrading?: string[];
+  BlockTrade?: string[];
+  Exchange?: string[];
+  /** @deprecated , always returns []*/
+  NFT?: string[];
+}
+⋮----
+/** @deprecated , always returns []*/
+⋮----
+export interface CategoryCursorListV5<
+  T extends unknown[],
+  TCategory extends CategoryV5 = CategoryV5,
+> {
+  category: TCategory;
+  list: T;
+  nextPageCursor?: string;
+}
+⋮----
+/**
+ * Next page cursor does not exist for spot!
+ */
+export interface CursorListV5<T extends unknown[]> {
+  nextPageCursor: string;
+  list: T;
+}
+⋮----
+/**
+ * A wrapper type for any responses that have a "nextPageCursor" property, and a "rows" property with an array of elements
+ *
+ * ```{ nextPageCursor: "something", rows: someData[] }```
+ */
+export interface CursorRowsV5<T extends unknown[]> {
+  nextPageCursor: string;
+  rows: T;
+}
+⋮----
+export interface CategoryListV5<
+  T extends unknown[],
+  TCategory extends CategoryV5,
+> {
+  category: TCategory;
+  list: T;
+}
+⋮----
+export interface CategorySymbolListV5<
+  T extends unknown[],
+  TCategory extends CategoryV5,
+> {
+  category: TCategory;
   symbol: string;
-  contractType: 'FundingRateArb' | 'CarryTrade' | 'FutureSpread' | 'PerpBasis';
-  status: 'Trading' | 'Settling';
-  baseCoin: string;
-  quoteCoin: string;
-  settleCoin: string;
-  tickSize: string;
-  minPrice: string;
-  maxPrice: string;
-  lotSize: string;
-  minSize: string;
-  maxSize: string;
-  launchTime: string;
-  deliveryTime: string;
-  legs: {
-    symbol: string;
-    contractType: 'LinearPerpetual' | 'LinearFutures' | 'Spot';
-  }[];
+  list: T;
 }
 ⋮----
-export interface SpreadOrderbookResponseV5 {
-  s: string; // Symbol
-  b: [string, string][]; // Bids array [price, size]
-  a: [string, string][]; // Asks array [price, size]
-  u: number; // Update ID
-  ts: number; // Timestamp
-  seq: number; // Sequence
-  cts: number; // Cross timestamp
+export interface GetSystemStatusParamsV5 {
+  id?: string;
+  state?: string;
 }
 ⋮----
-s: string; // Symbol
-b: [string, string][]; // Bids array [price, size]
-a: [string, string][]; // Asks array [price, size]
-u: number; // Update ID
-ts: number; // Timestamp
-seq: number; // Sequence
-cts: number; // Cross timestamp
-⋮----
-export interface SpreadTickerV5 {
-  symbol: string; // Spread combination symbol name
-  bidPrice: string; // Bid 1 price
-  bidSize: string; // Bid 1 size
-  askPrice: string; // Ask 1 price
-  askSize: string; // Ask 1 size
-  lastPrice: string; // Last trade price
-  highPrice24h: string; // The highest price in the last 24 hours
-  lowPrice24h: string; // The lowest price in the last 24 hours
-  prevPrice24h: string; // Price 24 hours ago
-  volume24h: string; // Volume for 24h
+export interface SystemStatusItemV5 {
+  id: string;
+  title: string;
+  state: string;
+  begin: string;
+  end: string;
+  href: string;
+  serviceTypes: number[];
+  product: number[];
+  uidSuffix: number[];
+  maintainType: string;
+  env: string;
 }
-⋮----
-symbol: string; // Spread combination symbol name
-bidPrice: string; // Bid 1 price
-bidSize: string; // Bid 1 size
-askPrice: string; // Ask 1 price
-askSize: string; // Ask 1 size
-lastPrice: string; // Last trade price
-highPrice24h: string; // The highest price in the last 24 hours
-lowPrice24h: string; // The lowest price in the last 24 hours
-prevPrice24h: string; // Price 24 hours ago
-volume24h: string; // Volume for 24h
-⋮----
-export interface SpreadRecentTradeV5 {
-  execId: string; // Execution ID
-  symbol: string; // Spread combination symbol name
-  price: string; // Trade price
-  size: string; // Trade size
-  side: 'Buy' | 'Sell'; // Side of taker
-  time: string; // Trade time (ms)
-  seq?: string;
-}
-⋮----
-execId: string; // Execution ID
-symbol: string; // Spread combination symbol name
-price: string; // Trade price
-size: string; // Trade size
-side: 'Buy' | 'Sell'; // Side of taker
-time: string; // Trade time (ms)
-⋮----
-export interface SpreadOpenOrderV5 {
-  symbol: string;
-  baseCoin: string;
-  orderType: 'Market' | 'Limit';
-  orderLinkId: string;
-  side: 'Buy' | 'Sell';
-  timeInForce: 'GTC' | 'FOK' | 'IOC' | 'PostOnly';
-  orderId: string;
-  leavesQty: string;
-  orderStatus: 'New' | 'PartiallyFilled';
-  cumExecQty: string;
-  price: string;
-  qty: string;
-  createdTime: string;
-  updatedTime: string;
-}
-⋮----
-export interface SpreadOrderHistoryV5 {
-  symbol: string;
-  orderType: 'Market' | 'Limit';
-  orderLinkId: string;
-  orderId: string;
-  contractType: 'FundingRateArb' | 'CarryTrade' | 'FutureSpread' | 'PerpBasis';
-  orderStatus: 'Rejected' | 'Cancelled' | 'Filled';
-  price: string;
-  orderQty: string;
-  timeInForce: 'GTC' | 'FOK' | 'IOC' | 'PostOnly';
-  baseCoin: string;
-  createdAt: string;
-  updatedAt: string;
-  side: 'Buy' | 'Sell';
-  leavesQty: string;
-  settleCoin: string;
-  cumExecQty: string;
-  qty: string;
-  leg1Symbol: string;
-  leg1ProdType: 'Futures' | 'Spot';
-  leg1OrderId: string;
-  leg1Side: string;
-  leg2ProdType: 'Futures' | 'Spot';
-  leg2OrderId: string;
-  leg2Symbol: string;
-  leg2Side: string;
-  cxlRejReason: string;
-  cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee
-}
-⋮----
-cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee
-⋮----
-export interface SpreadTradeLegV5 {
-  symbol: string;
-  side: 'Buy' | 'Sell';
-  execPrice: string;
-  execTime: string;
-  execValue: string;
-  execType: string;
-  category: 'linear' | 'spot';
-  execQty: string;
-  execFee: string;
-  feeCurrency: string; // Trading fee currency
-  execId: string;
-}
-⋮----
-feeCurrency: string; // Trading fee currency
-⋮----
-export interface SpreadTradeV5 {
-  symbol: string;
-  orderLinkId: string;
-  side: 'Buy' | 'Sell';
-  orderId: string;
-  execPrice: string;
-  execTime: string;
-  execType: 'Trade';
-  execQty: string;
-  execId: string;
-  legs: SpreadTradeLegV5[];
-  extraFees: string;
-}
-
-================
-File: src/types/response/v5-trade.ts
-================
-import {
-  CategoryV5,
-  OrderCancelTypeV5,
-  OrderCreateTypeV5,
-  OrderRejectReasonV5,
-  OrderSideV5,
-  OrderStatusV5,
-  OrderTimeInForceV5,
-  OrderTriggerByV5,
-  OrderTypeV5,
-  PositionIdx,
-  StopOrderTypeV5,
-} from '../shared-v5';
-⋮----
-export interface OrderResultV5 {
-  orderId: string;
-  orderLinkId: string;
-}
-⋮----
-export interface AccountOrderV5 {
-  orderId: string;
-  orderLinkId: string;
-  blockTradeId: string;
-  symbol: string;
-  price: string;
-  qty: string;
-  side: OrderSideV5;
-  isLeverage: '0' | '1';
-  positionIdx: PositionIdx;
-  orderStatus: OrderStatusV5;
-  createType: OrderCreateTypeV5;
-  cancelType: OrderCancelTypeV5;
-  rejectReason: OrderRejectReasonV5;
-  avgPrice: string;
-  leavesQty: string;
-  leavesValue: string;
-  cumExecQty: string;
-  cumExecValue: string;
-  cumExecFee: string;
-  timeInForce: OrderTimeInForceV5;
-  orderType: OrderTypeV5;
-  stopOrderType: StopOrderTypeV5;
-  orderIv: string;
-  marketUnit: 'baseCoin' | 'quoteCoin';
-  slippageToleranceType: string;
-  slippageTolerance: string;
-  triggerPrice: string;
-  takeProfit: string;
-  stopLoss: string;
-  tpslMode: 'Full' | 'Partial' | '';
-  ocoTriggerType:
-    | 'OcoTriggerByUnknown'
-    | 'OcoTriggerTp'
-    | 'OcoTriggerBySl'
-    | '';
-  tpLimitPrice: string;
-  slLimitPrice: string;
-  tpTriggerBy: OrderTriggerByV5;
-  slTriggerBy: OrderTriggerByV5;
-  triggerDirection: 1 | 2;
-  triggerBy: OrderTriggerByV5;
-  lastPriceOnCreated: string;
-  reduceOnly: boolean;
-  closeOnTrigger: boolean;
-  placeType: 'iv' | 'price' | '';
-  smpType: string;
-  smpGroup: number;
-  smpOrderId: string;
-  createdTime: string;
-  updatedTime: string;
-  extraFees: string;
-  cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee
-}
-⋮----
-cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee
-⋮----
-export interface BatchCreateOrderResultV5 {
-  category: CategoryV5;
-  symbol: string;
-  orderId: string;
-  orderLinkId: string;
-  createAt?: string;
-}
-⋮----
-export interface BatchOrdersRetExtInfoV5 {
-  list: {
-    code: number;
-    msg: string;
-  }[];
-}
-⋮----
-export interface BatchAmendOrderResultV5 {
-  category: CategoryV5;
-  symbol: string;
-  orderId: string;
-  orderLinkId: string;
-}
-⋮----
-export interface BatchCancelOrderResultV5 {
-  category: CategoryV5;
-  symbol: string;
-  orderId: string;
-  orderLinkId: string;
-}
-⋮----
-export interface SpotBorrowCheckResultV5 {
-  symbol: string;
-  side: OrderSideV5;
-  maxTradeQty: string;
-  maxTradeAmount: string;
-  spotMaxTradeQty: string;
-  spotMaxTradeAmount: string;
-  borrowCoin: string;
-}
-⋮----
-export interface PreCheckOrderResultV5 {
-  orderId: string;
-  orderLinkId: string;
-  preImrE4: number; // Initial margin rate before checking (in basis points)
-  preMmrE4: number; // Maintenance margin rate before checking (in basis points)
-  postImrE4: number; // Initial margin rate after checking (in basis points)
-  postMmrE4: number; // Maintenance margin rate after checking (in basis points)
-}
-⋮----
-preImrE4: number; // Initial margin rate before checking (in basis points)
-preMmrE4: number; // Maintenance margin rate before checking (in basis points)
-postImrE4: number; // Initial margin rate after checking (in basis points)
-postMmrE4: number; // Maintenance margin rate after checking (in basis points)
-
-================
-File: src/index.ts
-================
-
 
 ================
 File: .eslintrc.cjs
@@ -11244,296 +7801,676 @@ File: .eslintrc.cjs
 // 'no-unused-vars': ['warn'],
 
 ================
-File: .gitignore
+File: src/types/response/v5-account.ts
 ================
-!.gitkeep
-.DS_STORE
-*.log
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-lerna-debug.log*
-report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
-pids
-*.pid
-*.seed
-*.pid.lock
-node_modules/
-.npm
-.eslintcache
-.node_repl_history
-*.tgz
-.yarn-integrity
-.env
-.env.test
-.cache
-lib
-bundleReport.html
-.history/
-rawReq.ts
-localtest.sh
-localtest.ts
-privaterepotracker
-restClientRegex.ts
-repomix.sh
-
-examples/ignored
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Fixed-Loan/cancel-borrow-order.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
+import {
+  AccountMarginModeV5,
+  AccountTypeV5,
+  CategoryV5,
+  TransactionTypeV5,
+  UnifiedUpdateStatusV5,
+} from '../shared-v5';
 ⋮----
-const client = new RestClientV5({
+export interface WalletBalanceV5Coin {
+  coin: string;
+  equity: string;
+  usdValue: string;
+  walletBalance: string;
+  free: string; // spot only
+  locked: string; // spot only
+  borrowAmount: string;
+  availableToBorrow: string; // deprecated field
+  availableToWithdraw: string;
+  accruedInterest: string;
+  totalOrderIM: string;
+  totalPositionIM: string;
+  totalPositionMM: string;
+  unrealisedPnl: string;
+  cumRealisedPnl: string;
+  bonus: string;
+  marginCollateral: boolean;
+  collateralSwitch: boolean;
+  spotBorrow: string;
+}
 ⋮----
-client.cancelBorrowOrderFixed({
+free: string; // spot only
+locked: string; // spot only
 ⋮----
-.then(response => {
-console.log(response);
+availableToBorrow: string; // deprecated field
 ⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Fixed-Loan/cancel-supply-order.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
+export interface WalletBalanceV5 {
+  accountType: AccountTypeV5;
+  accountLTV: string;
+  accountIMRate: string;
+  accountMMRate: string;
+  accountIMRateByMp: string;
+  accountMMRateByMp: string;
+  totalInitialMarginByMp: string;
+  totalMaintenanceMarginByMp: string;
+  totalEquity: string;
+  totalWalletBalance: string;
+  totalMarginBalance: string;
+  totalAvailableBalance: string;
+  totalPerpUPL: string;
+  totalInitialMargin: string;
+  totalMaintenanceMargin: string;
+  coin: WalletBalanceV5Coin[];
+}
 ⋮----
-const client = new RestClientV5({
+export interface UnifiedAccountUpgradeResultV5 {
+  unifiedUpdateStatus: UnifiedUpdateStatusV5;
+  unifiedUpdateMsg: {
+    msg: string[] | null;
+  };
+}
 ⋮----
-client.cancelSupplyOrderFixed({
+export interface BorrowHistoryRecordV5 {
+  currency: string;
+  createdTime: number;
+  borrowCost: string;
+  hourlyBorrowRate: string;
+  InterestBearingBorrowSize: string;
+  costExemption: string;
+  borrowAmount: string;
+  unrealisedLoss: string;
+  freeBorrowedAmount: string;
+}
 ⋮----
-.then(response => {
-console.log(response);
+export interface CollateralInfoV5 {
+  currency: string;
+  hourlyBorrowRate: string;
+  maxBorrowingAmount: string;
+  freeBorrowAmount: string;
+  freeBorrowingLimit: string;
+  borrowAmount: string;
+  availableToBorrow: string;
+  borrowable: boolean;
+  borrowUsageRate: string;
+  marginCollateral: boolean;
+  collateralSwitch: boolean;
+  collateralRatio: string;
+}
 ⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Fixed-Loan/create-borrow-order.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
+export interface CoinGreeksV5 {
+  baseCoin: string;
+  totalDelta: string;
+  totalGamma: string;
+  totalVega: string;
+  totalTheta: string;
+}
 ⋮----
-const client = new RestClientV5({
+export interface FeeRateV5 {
+  symbol: string;
+  baseCoin: string;
+  takerFeeRate: string;
+  makerFeeRate: string;
+}
 ⋮----
-client.createBorrowOrderFixed({
+export interface AccountInfoV5 {
+  unifiedMarginStatus: number;
+  marginMode: AccountMarginModeV5;
+  isMasterTrader: boolean;
+  spotHedgingStatus: string;
+  updatedTime: string;
+}
 ⋮----
-.then(response => {
-console.log(response);
+export interface TransactionLogV5 {
+  symbol: string;
+  category: CategoryV5;
+  side: string;
+  transactionTime: string;
+  type: TransactionTypeV5;
+  qty: string;
+  size: string;
+  currency: string;
+  tradePrice: string;
+  funding: string;
+  fee: string;
+  cashFlow: string;
+  change: string;
+  cashBalance: string;
+  feeRate: string;
+  bonusChange: string;
+  tradeId: string;
+  orderId: string;
+  orderLinkId: string;
+  extraFees: string;
+  transSubType: string;
+}
 ⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Fixed-Loan/create-supply-order.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
+export interface MMPStateV5 {
+  baseCoin: string;
+  mmpEnabled: boolean;
+  window: string;
+  frozenPeriod: string;
+  qtyLimit: string;
+  deltaLimit: string;
+  mmpFrozenUntil: string;
+  mmpFrozen: boolean;
+}
 ⋮----
-const client = new RestClientV5({
+export interface RepayLiabilityResultV5 {
+  coin: string;
+  repaymentQty: string;
+}
 ⋮----
-client.createSupplyOrderFixed({
+export interface DCPInfoV5 {
+  product: 'SPOT' | 'DERIVATIVES' | 'OPTIONS';
+  dcpStatus: 'ON';
+  timeWindow: string;
+}
 ⋮----
-.then(response => {
-console.log(response);
-⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Fixed-Loan/get-borrow-contract-info.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
-⋮----
-const client = new RestClientV5({
-⋮----
-client.getBorrowContractInfoFixed({
-⋮----
-.then(response => {
-console.log(response);
-⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Fixed-Loan/get-borrow-order-info.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
-⋮----
-const client = new RestClientV5({
-⋮----
-client.getBorrowOrderInfoFixed({
-⋮----
-.then(response => {
-console.log(response);
-⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Fixed-Loan/get-borrow-order-quote.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
-⋮----
-const client = new RestClientV5({
-⋮----
-client.getBorrowOrderQuoteFixed({
-⋮----
-.then(response => {
-console.log(response);
-⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Fixed-Loan/get-repayment-history.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
-⋮----
-const client = new RestClientV5({
-⋮----
-client.getRepaymentHistoryFixed({
-⋮----
-.then(response => {
-console.log(response);
-⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Fixed-Loan/get-supply-contract-info.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
-⋮----
-const client = new RestClientV5({
-⋮----
-client.getSupplyContractInfoFixed({
-⋮----
-.then(response => {
-console.log(response);
-⋮----
-.catch(error => {
-console.error('Error:', error);
+export interface ManualRepayResultV5 {
+  resultStatus: 'P' | 'SU' | 'FA';
+}
 
 ================
-File: examples/apidoc/V5/Crypto-Loan-New/Fixed-Loan/get-supply-order-info.js
+File: src/types/response/v5-market.ts
 ================
-// or:
-// const { RestClientV5 } = require('bybit-api');
+import {
+  CategoryCursorListV5,
+  CategoryV5,
+  ContractTypeV5,
+  CopyTradingV5,
+  InstrumentStatusV5,
+  MarginTradingV5,
+  OptionTypeV5,
+  OrderSideV5,
+} from '../shared-v5';
 ⋮----
-const client = new RestClientV5({
+/**
+ * OHLCVT candle used by v5 APIs
+ *
+ * - list[0]: startTime	string	Start time of the candle (ms)
+ * - list[1]: openPrice	string	Open price
+ * - list[2]: highPrice	string	Highest price
+ * - list[3]: lowPrice	string	Lowest price
+ * - list[4]: closePrice	string	Close price. Is the last traded price when the candle is not closed
+ * - list[5]: volume	string	Trade volume. Unit of contract: pieces of contract. Unit of spot: quantity of coins
+ * - list[6]: turnover	string	Turnover. Unit of figure: quantity of quota coin
+ */
+export type OHLCVKlineV5 = [
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+];
 ⋮----
-client.getSupplyOrderInfoFixed({
+/**
+ * OHLC candle used by v5 APIs
+ *
+ * - list[0]: startTime	string	Start time of the candle (ms)
+ * - list[1]: openPrice	string	Open price
+ * - list[2]: highPrice	string	Highest price
+ * - list[3]: lowPrice	string	Lowest price
+ * - list[4]: closePrice	string	Close price. Is the last traded price when the candle is not closed
+ */
+export type OHLCKlineV5 = [string, string, string, string, string];
 ⋮----
-.then(response => {
-console.log(response);
+export interface LinearInverseInstrumentInfoV5 {
+  symbol: string;
+  contractType: ContractTypeV5;
+  status: InstrumentStatusV5;
+  baseCoin: string;
+  quoteCoin: string;
+  symbolType: string; // The region to which the trading pair belongs
+  launchTime: string;
+  deliveryTime?: string;
+  deliveryFeeRate?: string;
+  priceScale: string;
+  leverageFilter: {
+    minLeverage: string;
+    maxLeverage: string;
+    leverageStep: string;
+  };
+  priceFilter: {
+    minPrice: string;
+    maxPrice: string;
+    tickSize: string;
+  };
+  lotSizeFilter: {
+    maxOrderQty: string;
+    maxMktOrderQty: string;
+    minOrderQty: string;
+    qtyStep: string;
+    postOnlyMaxOrderQty?: string;
+    minNotionalValue?: string;
+  };
+  unifiedMarginTrade: boolean;
+  fundingInterval: number;
+  settleCoin: string;
+  copyTrading: CopyTradingV5;
+  upperFundingRate: string;
+  lowerFundingRate: string;
+  riskParameters: {
+    priceLimitRatioX: string;
+    priceLimitRatioY: string;
+  };
+  isPreListing: boolean;
+  preListingInfo: {
+    curAuctionPhase: string;
+    phases: {
+      phase: string;
+      startTime: string;
+      endTime: string;
+    }[];
+    auctionFeeInfo: {
+      auctionFeeRate: string;
+      takerFeeRate: string;
+      makerFeeRate: string;
+    };
+  } | null;
+  displayName: string;
+}
 ⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Fixed-Loan/get-supply-order-quote.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
+symbolType: string; // The region to which the trading pair belongs
 ⋮----
-const client = new RestClientV5({
+export interface OptionInstrumentInfoV5 {
+  symbol: string;
+  optionsType: OptionTypeV5;
+  status: InstrumentStatusV5;
+  baseCoin: string;
+  quoteCoin: string;
+  settleCoin: string;
+  symbolType: string; // The region to which the trading pair belongs
+  launchTime: string;
+  deliveryTime: string;
+  deliveryFeeRate: string;
+  priceFilter: {
+    minPrice: string;
+    maxPrice: string;
+    tickSize: string;
+  };
+  lotSizeFilter: {
+    maxOrderQty: string;
+    minOrderQty: string;
+    qtyStep: string;
+  };
+  displayName: string;
+}
 ⋮----
-client.getSupplyOrderQuoteFixed({
+symbolType: string; // The region to which the trading pair belongs
 ⋮----
-.then(response => {
-console.log(response);
+export interface SpotInstrumentInfoV5 {
+  symbol: string;
+  baseCoin: string;
+  quoteCoin: string;
+  symbolType: string; // The region to which the trading pair belongs
+  innovation: '0' | '1'; // Deprecated, always 0
+  status: InstrumentStatusV5;
+  marginTrading: MarginTradingV5;
+  stTag: '0' | '1';
+  lotSizeFilter: {
+    basePrecision: string;
+    quotePrecision: string;
+    minOrderQty: string;
+    maxOrderQty: string;
+    minOrderAmt: string;
+    maxOrderAmt: string;
+    maxLimitOrderQty: string;
+    maxMarketOrderQty: string;
+    postOnlyMaxLimitOrderSize: string;
+  };
+  priceFilter: {
+    tickSize: string;
+  };
+  riskParameters: {
+    priceLimitRatioX: string;
+    priceLimitRatioY: string;
+  };
+  forbidUplWithdrawal: boolean;
+}
 ⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Fixed-Loan/repay.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
+symbolType: string; // The region to which the trading pair belongs
+innovation: '0' | '1'; // Deprecated, always 0
 ⋮----
-const client = new RestClientV5({
+type InstrumentInfoV5Mapping = {
+  linear: LinearInverseInstrumentInfoV5[];
+  inverse: LinearInverseInstrumentInfoV5[];
+  option: OptionInstrumentInfoV5[];
+  spot: SpotInstrumentInfoV5[];
+};
 ⋮----
-client.repayFixed({
+export type InstrumentInfoResponseV5<C extends CategoryV5> =
+  CategoryCursorListV5<InstrumentInfoV5Mapping[C], C>;
 ⋮----
-.then(response => {
-console.log(response);
+// Account Instruments Info (includes RPI permissions)
+export interface AccountSpotInstrumentInfoV5 extends SpotInstrumentInfoV5 {
+  isPublicRpi: boolean;
+  myRpiPermission: boolean;
+}
 ⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Flexible-Loan/borrow.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
+export interface AccountLinearInverseInstrumentInfoV5
+  extends LinearInverseInstrumentInfoV5 {
+  isPublicRpi: boolean;
+  myRpiPermission: boolean;
+}
 ⋮----
-const client = new RestClientV5({
+type AccountInstrumentInfoV5Mapping = {
+  linear: AccountLinearInverseInstrumentInfoV5[];
+  inverse: AccountLinearInverseInstrumentInfoV5[];
+  spot: AccountSpotInstrumentInfoV5[];
+};
 ⋮----
-client.borrowFlexible({
+export type AccountInstrumentInfoResponseV5<
+  C extends 'spot' | 'linear' | 'inverse',
+> = CategoryCursorListV5<AccountInstrumentInfoV5Mapping[C], C>;
 ⋮----
-.then(response => {
-console.log(response);
+/**
+ * [price, size]
+ */
+export type OrderbookLevelV5 = [string, string];
 ⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Flexible-Loan/get-borrow-history.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
+export interface OrderbookResponseV5 {
+  s: string;
+  b: OrderbookLevelV5[];
+  a: OrderbookLevelV5[];
+  ts: number;
+  u: number;
+  seq: number;
+  cts: number;
+}
 ⋮----
-const client = new RestClientV5({
+/**
+ * RPI Orderbook level: [price, nonRpiSize, rpiSize]
+ */
+export type RPIOrderbookLevelV5 = [string, string, string];
 ⋮----
-client.getBorrowHistoryFlexible({
+export interface RPIOrderbookResponseV5 {
+  s: string; // Symbol name
+  b: RPIOrderbookLevelV5[]; // Bids. Sorted by price in descending order
+  a: RPIOrderbookLevelV5[]; // Asks. Sorted by price in ascending order
+  ts: number; // The timestamp (ms) that the system generates the data
+  u: number; // Update ID, is always in sequence corresponds to u in the 50-level WebSocket RPI orderbook stream
+  seq: number; // Cross sequence
+  cts: number; // The timestamp from the matching engine when this orderbook data is produced
+}
 ⋮----
-.then(response => {
-console.log(response);
+s: string; // Symbol name
+b: RPIOrderbookLevelV5[]; // Bids. Sorted by price in descending order
+a: RPIOrderbookLevelV5[]; // Asks. Sorted by price in ascending order
+ts: number; // The timestamp (ms) that the system generates the data
+u: number; // Update ID, is always in sequence corresponds to u in the 50-level WebSocket RPI orderbook stream
+seq: number; // Cross sequence
+cts: number; // The timestamp from the matching engine when this orderbook data is produced
 ⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Flexible-Loan/get-ongoing-flexible-loans.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
+export interface TickerLinearInverseV5 {
+  symbol: string;
+  lastPrice: string;
+  indexPrice: string;
+  markPrice: string;
+  prevPrice24h: string;
+  price24hPcnt: string;
+  highPrice24h: string;
+  lowPrice24h: string;
+  prevPrice1h: string;
+  openInterest: string;
+  openInterestValue: string;
+  turnover24h: string;
+  volume24h: string;
+  fundingRate: string;
+  nextFundingTime: string;
+  predictedDeliveryPrice: string;
+  basisRate: string;
+  basisRateYear: string;
+  fundingIntervalHour: string;
+  fundingCap: string;
+  deliveryFeeRate: string;
+  deliveryTime: string;
+  ask1Size: string;
+  bid1Price: string;
+  ask1Price: string;
+  bid1Size: string;
+  preOpenPrice: string;
+  preQty: string;
+  curPreListingPhase: string;
+  basis: string;
+}
 ⋮----
-const client = new RestClientV5({
+export interface TickerOptionV5 {
+  symbol: string;
+  bid1Price: string;
+  bid1Size: string;
+  bid1Iv: string;
+  ask1Price: string;
+  ask1Size: string;
+  ask1Iv: string;
+  lastPrice: string;
+  highPrice24h: string;
+  lowPrice24h: string;
+  markPrice: string;
+  indexPrice: string;
+  markIv: string;
+  underlyingPrice: string;
+  openInterest: string;
+  turnover24h: string;
+  volume24h: string;
+  totalVolume: string;
+  totalTurnover: string;
+  delta: string;
+  gamma: string;
+  vega: string;
+  theta: string;
+  predictedDeliveryPrice: string;
+  change24h: string;
+}
 ⋮----
-client.getOngoingFlexibleLoans({
+export interface TickerSpotV5 {
+  symbol: string;
+  bid1Price: string;
+  bid1Size: string;
+  ask1Price: string;
+  ask1Size: string;
+  lastPrice: string;
+  prevPrice24h: string;
+  price24hPcnt: string;
+  highPrice24h: string;
+  lowPrice24h: string;
+  turnover24h: string;
+  volume24h: string;
+  usdIndexPrice: string;
+}
 ⋮----
-.then(response => {
-console.log(response);
+export interface FundingRateHistoryResponseV5 {
+  symbol: string;
+  fundingRate: string;
+  fundingRateTimestamp: string;
+}
 ⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/Flexible-Loan/get-repayment-history.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
+export interface PublicTradeV5 {
+  execId: string;
+  symbol: string;
+  price: string;
+  size: string;
+  side: OrderSideV5;
+  time: string;
+  isBlockTrade: boolean;
+  isRPITrade: boolean;
+  mP?: string;
+  iP?: string;
+  mIv?: string;
+  iv?: string;
+  seq?: string;
+}
 ⋮----
-const client = new RestClientV5({
+/**
+ *
+ * - openInterest	string	Open interest
+ * - timestamp	string	The timestamp (ms)
+ */
+export type OpenInterestV5 = {
+  openInterest: string;
+  timestamp: string;
+};
 ⋮----
-client.getRepaymentHistoryFlexible({
+export interface OpenInterestResponseV5 {
+  category: 'linear' | 'inverse';
+  symbol: string;
+  list: OpenInterestV5[];
+  nextPageCursor?: string;
+}
 ⋮----
-.then(response => {
-console.log(response);
+export interface HistoricalVolatilityV5 {
+  period: number;
+  value: string;
+  time: string;
+}
 ⋮----
-.catch(error => {
-console.error('Error:', error);
+export interface InsuranceDataV5 {
+  coin: string;
+  symbols: string;
+  balance: string;
+  value: string;
+}
+⋮----
+export interface InsuranceResponseV5 {
+  updatedTime: string;
+  list: InsuranceDataV5[];
+}
+⋮----
+export interface RiskLimitV5 {
+  id: number;
+  symbol: string;
+  riskLimitValue: string;
+  maintenanceMargin: number;
+  initialMargin: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  section: any;
+  isLowestRisk: 0 | 1;
+  maxLeverage: string;
+  mmDeduction: string;
+  nextPageCursor?: string;
+}
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+⋮----
+/** @deprecated use DeliveryPriceV5 instead */
+export interface OptionDeliveryPriceV5 {
+  symbol: string;
+  deliveryPrice: string;
+  deliveryTime: string;
+}
+⋮----
+export interface DeliveryPriceV5 {
+  symbol: string;
+  deliveryPrice: string;
+  deliveryTime: string;
+}
+⋮----
+export interface LongShortRatioV5 {
+  symbol: string;
+  buyRatio: string;
+  sellRatio: string;
+  timestamp: string;
+}
+⋮----
+export interface OrderPriceLimitV5 {
+  symbol: string;
+  buyLmt: string;
+  sellLmt: string;
+  ts: string;
+}
+⋮----
+export interface IndexPriceComponentV5 {
+  exchange: string; // Name of the exchange
+  spotPair: string; // Spot trading pair on the exchange (e.g., BTCUSDT)
+  equivalentPrice: string; // Equivalent price
+  multiplier: string; // Multiplier used for the component price
+  price: string; // Actual price
+  weight: string; // Weight in the index calculation
+}
+⋮----
+exchange: string; // Name of the exchange
+spotPair: string; // Spot trading pair on the exchange (e.g., BTCUSDT)
+equivalentPrice: string; // Equivalent price
+multiplier: string; // Multiplier used for the component price
+price: string; // Actual price
+weight: string; // Weight in the index calculation
+⋮----
+export interface IndexPriceComponentsResponseV5 {
+  indexName: string; // Name of the index (e.g., BTCUSDT)
+  lastPrice: string; // Last price of the index
+  updateTime: string; // Timestamp of the last update in milliseconds
+  components: IndexPriceComponentV5[]; // List of components contributing to the index price
+}
+⋮----
+indexName: string; // Name of the index (e.g., BTCUSDT)
+lastPrice: string; // Last price of the index
+updateTime: string; // Timestamp of the last update in milliseconds
+components: IndexPriceComponentV5[]; // List of components contributing to the index price
+⋮----
+export interface ADLAlertItemV5 {
+  coin: string; // Token of the insurance pool
+  symbol: string; // Trading pair name
+  balance: string; // Balance of the insurance fund. Used to determine if ADL is triggered
+  maxBalance: string; // Maximum balance of the insurance pool in the last 8 hours
+  insurancePnlRatio: string; // PnL ratio threshold for triggering contract PnL drawdown ADL
+  pnlRatio: string; // Symbol's PnL drawdown ratio in the last 8 hours. Used to determine whether ADL is triggered or stopped
+  adlTriggerThreshold: string; // Trigger threshold for contract PnL drawdown ADL
+  adlStopRatio: string; // Stop ratio threshold for contract PnL drawdown ADL
+}
+⋮----
+coin: string; // Token of the insurance pool
+symbol: string; // Trading pair name
+balance: string; // Balance of the insurance fund. Used to determine if ADL is triggered
+maxBalance: string; // Maximum balance of the insurance pool in the last 8 hours
+insurancePnlRatio: string; // PnL ratio threshold for triggering contract PnL drawdown ADL
+pnlRatio: string; // Symbol's PnL drawdown ratio in the last 8 hours. Used to determine whether ADL is triggered or stopped
+adlTriggerThreshold: string; // Trigger threshold for contract PnL drawdown ADL
+adlStopRatio: string; // Stop ratio threshold for contract PnL drawdown ADL
+⋮----
+export interface ADLAlertResponseV5 {
+  updateTime: string; // Latest data update timestamp (ms)
+  list: ADLAlertItemV5[]; // List of ADL alert items
+}
+⋮----
+updateTime: string; // Latest data update timestamp (ms)
+list: ADLAlertItemV5[]; // List of ADL alert items
+⋮----
+export interface FeeGroupLevelV5 {
+  level: string; // Pro level name or Market Maker level name
+  takerFeeRate: string; // Taker fee rate
+  makerFeeRate: string; // Maker fee rate
+  makerRebate: string; // Maker rebate fee rate
+}
+⋮----
+level: string; // Pro level name or Market Maker level name
+takerFeeRate: string; // Taker fee rate
+makerFeeRate: string; // Maker fee rate
+makerRebate: string; // Maker rebate fee rate
+⋮----
+export interface FeeGroupRatesV5 {
+  pro: FeeGroupLevelV5[]; // Pro-level fee structures
+  marketMaker: FeeGroupLevelV5[]; // Market Maker-level fee structures
+}
+⋮----
+pro: FeeGroupLevelV5[]; // Pro-level fee structures
+marketMaker: FeeGroupLevelV5[]; // Market Maker-level fee structures
+⋮----
+export interface FeeGroupItemV5 {
+  groupName: string; // Fee group name
+  weightingFactor: number; // Group weighting factor
+  symbolsNumbers: number; // Symbols number
+  symbols: string[]; // Symbol names
+  feeRates: FeeGroupRatesV5; // Fee rate details for different categories
+  updateTime: string; // Latest data update timestamp (ms)
+}
+⋮----
+groupName: string; // Fee group name
+weightingFactor: number; // Group weighting factor
+symbolsNumbers: number; // Symbols number
+symbols: string[]; // Symbol names
+feeRates: FeeGroupRatesV5; // Fee rate details for different categories
+updateTime: string; // Latest data update timestamp (ms)
+⋮----
+export interface FeeGroupStructureResponseV5 {
+  list: FeeGroupItemV5[]; // List of fee group objects
+}
+⋮----
+list: FeeGroupItemV5[]; // List of fee group objects
 
 ================
 File: src/types/response/v5-position.ts
@@ -11722,914 +8659,205 @@ export interface ClosedOptionsPositionV5 {
 }
 
 ================
-File: examples/apidoc/V5/Crypto-Loan-New/adjust-collateral-amount.js
+File: src/types/response/v5-spreadtrading.ts
 ================
-// or:
-// const { RestClientV5 } = require('bybit-api');
-⋮----
-const client = new RestClientV5({
-⋮----
-client.updateCollateralAmount({
-⋮----
-direction: '1', // 0: add collateral; 1: reduce collateral
-⋮----
-.then(response => {
-console.log(response);
-⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/get-borrowable-coins.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
-⋮----
-const client = new RestClientV5({
-⋮----
-client.getLoanBorrowableCoins({
-⋮----
-.then(response => {
-console.log(response);
-⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/get-collateral-adjustment-history.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
-⋮----
-const client = new RestClientV5({
-⋮----
-client.getCollateralAdjustmentHistory({
-⋮----
-.then(response => {
-console.log(response);
-⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/get-collateral-coins.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
-⋮----
-const client = new RestClientV5({
-⋮----
-client.getLoanCollateralCoins({
-⋮----
-.then(response => {
-console.log(response);
-⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/get-crypto-loan-position.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
-⋮----
-const client = new RestClientV5({
-⋮----
-client.getCryptoLoanPosition()
-.then(response => {
-console.log(response);
-⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: examples/apidoc/V5/Crypto-Loan-New/get-max-collateral-amount.js
-================
-// or:
-// const { RestClientV5 } = require('bybit-api');
-⋮----
-const client = new RestClientV5({
-⋮----
-client.getMaxCollateralAmount({
-⋮----
-.then(response => {
-console.log(response);
-⋮----
-.catch(error => {
-console.error('Error:', error);
-
-================
-File: src/websocket-api-client.ts
-================
-import {
-  AmendOrderParamsV5,
-  BatchAmendOrderParamsV5,
-  BatchAmendOrderResultV5,
-  BatchCancelOrderParamsV5,
-  BatchCancelOrderResultV5,
-  BatchCreateOrderResultV5,
-  BatchOrderParamsV5,
-  BatchOrdersRetExtInfoV5,
-  CancelOrderParamsV5,
-  OrderParamsV5,
-  OrderResultV5,
-} from './types';
-import { WSAPIResponse } from './types/websockets/ws-api';
-import { WSClientConfigurableOptions } from './types/websockets/ws-general';
-import { DefaultLogger } from './util';
-import { WS_KEY_MAP } from './util/websockets/websocket-util';
-import { WebsocketClient } from './websocket-client';
-⋮----
-/**
- * Configurable options specific to only the REST-like WebsocketAPIClient
- */
-export interface WSAPIClientConfigurableOptions {
-  /**
-   * Default: true
-   *
-   * Attach default event listeners, which will console log any high level
-   * events (opened/reconnecting/reconnected/etc).
-   *
-   * If you disable this, you should set your own event listeners
-   * on the embedded WS Client `wsApiClient.getWSClient().on(....)`.
-   */
-  attachEventListeners: boolean;
+export interface SpreadInstrumentInfoV5 {
+  symbol: string;
+  contractType: 'FundingRateArb' | 'CarryTrade' | 'FutureSpread' | 'PerpBasis';
+  status: 'Trading' | 'Settling';
+  baseCoin: string;
+  quoteCoin: string;
+  settleCoin: string;
+  tickSize: string;
+  minPrice: string;
+  maxPrice: string;
+  lotSize: string;
+  minSize: string;
+  maxSize: string;
+  launchTime: string;
+  deliveryTime: string;
+  legs: {
+    symbol: string;
+    contractType: 'LinearPerpetual' | 'LinearFutures' | 'Spot';
+  }[];
 }
 ⋮----
-/**
-   * Default: true
-   *
-   * Attach default event listeners, which will console log any high level
-   * events (opened/reconnecting/reconnected/etc).
-   *
-   * If you disable this, you should set your own event listeners
-   * on the embedded WS Client `wsApiClient.getWSClient().on(....)`.
-   */
-⋮----
-/**
- * This is a minimal Websocket API wrapper around the WebsocketClient.
- *
- * Some methods support passing in a custom "wsKey". This is a reference to which WS connection should
- * be used to transmit that message. This is only useful if you wish to use an alternative wss
- * domain that is supported by the SDK.
- *
- * Note: To use testnet, don't set the wsKey - use `testnet: true` in
- * the constructor instead.
- *
- * Note: You can also directly use the sendWSAPIRequest() method to make WS API calls, but some
- * may find the below methods slightly more intuitive.
- *
- * Refer to the WS API promises example for a more detailed example on using sendWSAPIRequest() directly:
- * https://github.com/tiagosiebler/bybit-api/blob/master/examples/ws-api-raw-promises.ts
- */
-export class WebsocketAPIClient
-⋮----
-constructor(
-    options?: WSClientConfigurableOptions &
-      Partial<WSAPIClientConfigurableOptions>,
-    logger?: DefaultLogger,
-)
-⋮----
-public getWSClient(): WebsocketClient
-⋮----
-public setTimeOffsetMs(newOffset: number): void
-⋮----
-/*
-   * Bybit WebSocket API Methods
-   * https://bybit-exchange.github.io/docs/v5/websocket/trade/guideline
-   */
-⋮----
-/**
-   * Submit a new order
-   *
-   * @param params
-   * @returns
-   */
-submitNewOrder(
-    params: OrderParamsV5,
-): Promise<WSAPIResponse<OrderResultV5, 'order.create'>>
-⋮----
-/**
-   * Amend an order
-   *
-   * @param params
-   * @returns
-   */
-amendOrder(
-    params: AmendOrderParamsV5,
-): Promise<WSAPIResponse<OrderResultV5, 'order.amend'>>
-⋮----
-/**
-   * Cancel an order
-   *
-   * @param params
-   * @returns
-   */
-cancelOrder(
-    params: CancelOrderParamsV5,
-): Promise<WSAPIResponse<OrderResultV5, 'order.cancel'>>
-⋮----
-/**
-   * Batch submit orders
-   *
-   * @param params
-   * @returns
-   */
-batchSubmitOrders(
-    category: 'option' | 'linear',
-    orders: BatchOrderParamsV5[],
-  ): Promise<
-    WSAPIResponse<
-      {
-        list: BatchCreateOrderResultV5[];
-      },
-      'order.create-batch',
-      BatchOrdersRetExtInfoV5
-    >
-  > {
-    return this.wsClient.sendWSAPIRequest(
-      WS_KEY_MAP.v5PrivateTrade,
-      'order.create-batch',
-      {
-        category,
-        request: orders,
-      },
-    );
-⋮----
-/**
-   * Batch amend orders
-   *
-   * @param params
-   * @returns
-   */
-batchAmendOrder(
-    category: 'option' | 'linear',
-    orders: BatchAmendOrderParamsV5[],
-  ): Promise<
-    WSAPIResponse<
-      {
-        list: BatchAmendOrderResultV5[];
-      },
-      'order.amend-batch',
-      BatchOrdersRetExtInfoV5
-    >
-  > {
-    return this.wsClient.sendWSAPIRequest(
-      WS_KEY_MAP.v5PrivateTrade,
-      'order.amend-batch',
-      {
-        category,
-        request: orders,
-      },
-    );
-⋮----
-/**
-   * Batch cancel orders
-   *
-   * @param params
-   * @returns
-   */
-batchCancelOrder(
-    category: 'option' | 'linear',
-    orders: BatchCancelOrderParamsV5[],
-  ): Promise<
-    WSAPIResponse<
-      {
-        list: BatchCancelOrderResultV5[];
-      },
-      'order.cancel-batch',
-      BatchOrdersRetExtInfoV5
-    >
-  > {
-    return this.wsClient.sendWSAPIRequest(
-      WS_KEY_MAP.v5PrivateTrade,
-      'order.cancel-batch',
-      {
-        category,
-        request: orders,
-      },
-    );
-⋮----
-/**
-   *
-   *
-   *
-   *
-   *
-   *
-   *
-   * Private methods for handling some of the convenience/automation provided by the WS API Client
-   *
-   *
-   *
-   *
-   *
-   *
-   *
-   */
-⋮----
-private setupDefaultEventListeners()
-⋮----
-/**
-       * General event handlers for monitoring the WebsocketClient
-       */
-
-================
-File: examples/ws-api-client.ts
-================
-import { DefaultLogger, WebsocketAPIClient } from '../src';
-⋮----
-// or
-// import { DefaultLogger, WebsocketAPIClient } from 'bybit-api';
-// const { DefaultLogger, WebsocketAPIClient } = require('bybit-api');
-⋮----
-// function attachEventHandlers<TWSClient extends WebsocketClient>(
-//   wsClient: TWSClient,
-// ): void {
-//   wsClient.on('update', (data) => {
-//     console.log('raw message received ', JSON.stringify(data));
-//   });
-//   wsClient.on('open', (data) => {
-//     console.log('ws connected', data.wsKey);
-//   });
-//   wsClient.on('reconnect', ({ wsKey }) => {
-//     console.log('ws automatically reconnecting.... ', wsKey);
-//   });
-//   wsClient.on('reconnected', (data) => {
-//     console.log('ws has reconnected ', data?.wsKey);
-//   });
-//   wsClient.on('authenticated', (data) => {
-//     console.log('ws has authenticated ', data?.wsKey);
-//   });
-// }
-⋮----
-async function main()
-⋮----
-// Optional
-⋮----
-// For a more detailed view of the WebsocketClient, enable the `trace` level by uncommenting the below line:
-// trace: (...params) => console.log('trace', ...params),
-⋮----
-// testnet: true, // Whether to use the testnet environment: https://testnet.bybit.com/app/user/api-management
-⋮----
-// Whether to use the livenet demo trading environment
-// Note: As of Jan 2025, demo trading only supports consuming events, it does
-// NOT support the WS API.
-// demoTrading: false,
-⋮----
-// If you want your own event handlers instead of the default ones with logs,
-// disable this setting and see the `attachEventHandlers` example below:
-// attachEventListeners: false
-⋮----
-logger, // Optional: inject a custom logger
-⋮----
-// Optional, see above "attachEventListeners". Attach basic event handlers, so nothing is left unhandled
-// attachEventHandlers(wsClient.getWSClient());
-⋮----
-// Optional, if you see RECV Window errors, you can use this to manage time issues.
-// ! However, make sure you sync your system clock first!
-// https://github.com/tiagosiebler/awesome-crypto-examples/wiki/Timestamp-for-this-request-is-outside-of-the-recvWindow
-// wsClient.setTimeOffsetMs(-5000);
-⋮----
-// Optional: prepare the WebSocket API connection in advance.
-// This happens automatically but you can do this early before making any API calls, to prevent delays from a cold start.
-// await wsClient.getWSClient().connectWSAPI();
-
-================
-File: src/types/response/v5-crypto-loan.ts
-================
-export interface CollateralCoinV5 {
-  collateralAccuracy: number;
-  initialLTV: string;
-  liquidationLTV: string;
-  marginCallLTV: string;
-  maxLimit: string;
+export interface SpreadOrderbookResponseV5 {
+  s: string; // Symbol
+  b: [string, string][]; // Bids array [price, size]
+  a: [string, string][]; // Asks array [price, size]
+  u: number; // Update ID
+  ts: number; // Timestamp
+  seq: number; // Sequence
+  cts: number; // Cross timestamp
 }
 ⋮----
-export interface VipCollateralCoinsV5 {
-  list: CollateralCoinV5[];
-  vipLevel: string;
+s: string; // Symbol
+b: [string, string][]; // Bids array [price, size]
+a: [string, string][]; // Asks array [price, size]
+u: number; // Update ID
+ts: number; // Timestamp
+seq: number; // Sequence
+cts: number; // Cross timestamp
+⋮----
+export interface SpreadTickerV5 {
+  symbol: string; // Spread combination symbol name
+  bidPrice: string; // Bid 1 price
+  bidSize: string; // Bid 1 size
+  askPrice: string; // Ask 1 price
+  askSize: string; // Ask 1 size
+  lastPrice: string; // Last trade price
+  highPrice24h: string; // The highest price in the last 24 hours
+  lowPrice24h: string; // The lowest price in the last 24 hours
+  prevPrice24h: string; // Price 24 hours ago
+  volume24h: string; // Volume for 24h
 }
 ⋮----
-export interface BorrowableCoinV5 {
-  borrowingAccuracy: number;
-  currency: string;
-  flexibleHourlyInterestRate: string;
-  hourlyInterestRate7D: string;
-  hourlyInterestRate14D: string;
-  hourlyInterestRate30D: string;
-  hourlyInterestRate90D: string;
-  hourlyInterestRate180D: string;
-  maxBorrowingAmount: string;
-  minBorrowingAmount: string;
+symbol: string; // Spread combination symbol name
+bidPrice: string; // Bid 1 price
+bidSize: string; // Bid 1 size
+askPrice: string; // Ask 1 price
+askSize: string; // Ask 1 size
+lastPrice: string; // Last trade price
+highPrice24h: string; // The highest price in the last 24 hours
+lowPrice24h: string; // The lowest price in the last 24 hours
+prevPrice24h: string; // Price 24 hours ago
+volume24h: string; // Volume for 24h
+⋮----
+export interface SpreadRecentTradeV5 {
+  execId: string; // Execution ID
+  symbol: string; // Spread combination symbol name
+  price: string; // Trade price
+  size: string; // Trade size
+  side: 'Buy' | 'Sell'; // Side of taker
+  time: string; // Trade time (ms)
+  seq?: string;
 }
 ⋮----
-export interface VipBorrowableCoinsV5 {
-  list: BorrowableCoinV5[];
-  vipLevel: string;
-}
+execId: string; // Execution ID
+symbol: string; // Spread combination symbol name
+price: string; // Trade price
+size: string; // Trade size
+side: 'Buy' | 'Sell'; // Side of taker
+time: string; // Trade time (ms)
 ⋮----
-export interface AccountBorrowCollateralLimitV5 {
-  collateralCurrency: string;
-  loanCurrency: string;
-  maxCollateralAmount: string;
-  maxLoanAmount: string;
-  minCollateralAmount: string;
-  minLoanAmount: string;
-}
-⋮----
-export interface UnpaidLoanOrderV5 {
-  collateralAmount: string;
-  collateralCurrency: string;
-  currentLTV: string;
-  expirationTime: string;
-  hourlyInterestRate: string;
-  loanCurrency: string;
-  loanTerm: string;
+export interface SpreadOpenOrderV5 {
+  symbol: string;
+  baseCoin: string;
+  orderType: 'Market' | 'Limit';
+  orderLinkId: string;
+  side: 'Buy' | 'Sell';
+  timeInForce: 'GTC' | 'FOK' | 'IOC' | 'PostOnly';
   orderId: string;
-  residualInterest: string;
-  residualPenaltyInterest: string;
-  totalDebt: string;
-}
-⋮----
-export interface RepaymentHistoryV5 {
-  collateralCurrency: string;
-  collateralReturn: string;
-  loanCurrency: string;
-  loanTerm: string;
-  orderId: string;
-  repayAmount: string;
-  repayId: string;
-  repayStatus: number;
-  repayTime: string;
-  repayType: string;
-}
-⋮----
-export interface CompletedLoanOrderV5 {
-  borrowTime: string;
-  collateralCurrency: string;
-  expirationTime: string;
-  hourlyInterestRate: string;
-  initialCollateralAmount: string;
-  initialLoanAmount: string;
-  loanCurrency: string;
-  loanTerm: string;
-  orderId: string;
-  repaidInterest: string;
-  repaidPenaltyInterest: string;
-  status: number;
-}
-export interface LoanLTVAdjustmentHistoryV5 {
-  collateralCurrency: string;
-  orderId: string;
-  adjustId: string;
-  adjustTime: string;
-  preLTV: string;
-  afterLTV: string;
-  direction: number;
-  amount: string;
-}
-⋮----
-// New Crypto Loan Types
-⋮----
-export interface BorrowCoinV5 {
-  currency: string;
-  fixedBorrowable: boolean;
-  fixedBorrowingAccuracy: number;
-  flexibleBorrowable: boolean;
-  flexibleBorrowingAccuracy: number;
-  maxBorrowingAmount: string;
-  minFixedBorrowingAmount: string;
-  minFlexibleBorrowingAmount: string;
-  vipLevel: string;
-  flexibleAnnualizedInterestRate: string;
-  annualizedInterestRate7D: string;
-  annualizedInterestRate14D: string;
-  annualizedInterestRate30D: string;
-  annualizedInterestRate60D: string;
-  annualizedInterestRate90D: string;
-  annualizedInterestRate180D: string;
-}
-⋮----
-export interface CollateralRatioV5 {
-  collateralRatio: string;
-  maxValue: string;
-  minValue: string;
-}
-⋮----
-export interface CollateralRatioConfigV5 {
-  collateralRatioList: CollateralRatioV5[];
-  currencies: string;
-}
-⋮----
-export interface CurrencyLiquidationV5 {
-  currency: string;
-  liquidationOrder: number;
-}
-⋮----
-export interface CollateralDataV5 {
-  collateralRatioConfigList: CollateralRatioConfigV5[];
-  currencyLiquidationList: CurrencyLiquidationV5[];
-}
-⋮----
-// Additional New Crypto Loan Types
-⋮----
-export interface AdjustCollateralAmountV5 {
-  adjustId: number;
-}
-⋮----
-export interface CollateralAdjustmentHistoryV5 {
-  adjustId: number;
-  adjustTime: number;
-  afterLTV: string;
-  amount: string;
-  collateralCurrency: string;
-  direction: number;
-  preLTV: string;
-  status: number;
-}
-⋮----
-export interface BorrowListV5 {
-  fixedTotalDebt: string;
-  fixedTotalDebtUSD: string;
-  flexibleHourlyInterestRate: string;
-  flexibleTotalDebt: string;
-  flexibleTotalDebtUSD: string;
-  loanCurrency: string;
-}
-⋮----
-export interface CollateralListV5 {
-  amount: string;
-  amountUSD: string;
-  currency: string;
-  ltv: string;
-}
-⋮----
-export interface SupplyListV5 {
-  amount: string;
-  amountUSD: string;
-  currency: string;
-}
-⋮----
-export interface CryptoLoanPositionV5 {
-  borrowList: BorrowListV5[];
-  collateralList: CollateralListV5[];
-  supplyList: SupplyListV5[];
-  totalCollateral: string;
-  totalDebt: string;
-  totalSupply: string;
-}
-⋮----
-// Flexible Loan Types
-⋮----
-export interface BorrowFlexibleV5 {
-  orderId: string;
-}
-⋮----
-export interface RepayFlexibleV5 {
-  repayId: string;
-}
-⋮----
-export interface OngoingFlexibleLoanV5 {
-  hourlyInterestRate: string;
-  loanCurrency: string;
-  totalDebt: string;
-}
-⋮----
-export interface BorrowHistoryFlexibleV5 {
-  borrowTime: number;
-  initialLoanAmount: string;
-  loanCurrency: string;
-  orderId: string;
-  status: number;
-}
-⋮----
-export interface RepaymentHistoryFlexibleV5 {
-  loanCurrency: string;
-  repayAmount: string;
-  repayId: string;
-  repayStatus: number;
-  repayTime: number;
-  repayType: number;
-}
-⋮----
-// Fixed Loan Types
-⋮----
-export interface SupplyOrderQuoteFixedV5 {
-  orderCurrency: string;
-  term: number;
-  annualRate: string;
+  leavesQty: string;
+  orderStatus: 'New' | 'PartiallyFilled';
+  cumExecQty: string;
+  price: string;
   qty: string;
+  createdTime: string;
+  updatedTime: string;
 }
 ⋮----
-export interface BorrowOrderQuoteFixedV5 {
-  orderCurrency: string;
-  term: number;
-  annualRate: string;
+export interface SpreadOrderHistoryV5 {
+  symbol: string;
+  orderType: 'Market' | 'Limit';
+  orderLinkId: string;
+  orderId: string;
+  contractType: 'FundingRateArb' | 'CarryTrade' | 'FutureSpread' | 'PerpBasis';
+  orderStatus: 'Rejected' | 'Cancelled' | 'Filled';
+  price: string;
+  orderQty: string;
+  timeInForce: 'GTC' | 'FOK' | 'IOC' | 'PostOnly';
+  baseCoin: string;
+  createdAt: string;
+  updatedAt: string;
+  side: 'Buy' | 'Sell';
+  leavesQty: string;
+  settleCoin: string;
+  cumExecQty: string;
   qty: string;
+  leg1Symbol: string;
+  leg1ProdType: 'Futures' | 'Spot';
+  leg1OrderId: string;
+  leg1Side: string;
+  leg2ProdType: 'Futures' | 'Spot';
+  leg2OrderId: string;
+  leg2Symbol: string;
+  leg2Side: string;
+  cxlRejReason: string;
+  cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee
 }
 ⋮----
-export interface CreateBorrowOrderFixedV5 {
+cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee
+⋮----
+export interface SpreadTradeLegV5 {
+  symbol: string;
+  side: 'Buy' | 'Sell';
+  execPrice: string;
+  execTime: string;
+  execValue: string;
+  execType: string;
+  category: 'linear' | 'spot';
+  execQty: string;
+  execFee: string;
+  feeCurrency: string; // Trading fee currency
+  execId: string;
+}
+⋮----
+feeCurrency: string; // Trading fee currency
+⋮----
+export interface SpreadTradeV5 {
+  symbol: string;
+  orderLinkId: string;
+  side: 'Buy' | 'Sell';
   orderId: string;
-}
-⋮----
-export interface CreateSupplyOrderFixedV5 {
-  orderId: string;
-}
-⋮----
-export interface BorrowContractInfoFixedV5 {
-  annualRate: string;
-  autoRepay: string; // Deprecated
-  borrowCurrency: string;
-  borrowTime: string;
-  interestPaid: string;
-  loanId: string;
-  orderId: string;
-  repayType: string; // 1: Auto Repayment; 2: Transfer to flexible loan; 0: No Automatic Repayment
-  repaymentTime: string;
-  residualPenaltyInterest: string;
-  residualPrincipal: string;
-  status: number;
-  term: string;
-}
-⋮----
-autoRepay: string; // Deprecated
-⋮----
-repayType: string; // 1: Auto Repayment; 2: Transfer to flexible loan; 0: No Automatic Repayment
-⋮----
-export interface SupplyContractInfoFixedV5 {
-  annualRate: string;
-  supplyCurrency: string;
-  supplyTime: string;
-  supplyAmount: string;
-  interestPaid: string;
-  supplyId: string;
-  orderId: string;
-  redemptionTime: string;
-  penaltyInterest: string;
-  actualRedemptionTime: string;
-  status: number;
-  term: string;
-}
-⋮----
-export interface BorrowOrderInfoFixedV5 {
-  annualRate: string;
-  orderId: number;
-  orderTime: string;
-  filledQty: string;
-  orderQty: string;
-  orderCurrency: string;
-  state: number;
-  term: number;
-  repayType: string; // 1: Auto Repayment; 2: Transfer to flexible loan; 0: No Automatic Repayment
-}
-⋮----
-repayType: string; // 1: Auto Repayment; 2: Transfer to flexible loan; 0: No Automatic Repayment
-⋮----
-export interface SupplyOrderInfoFixedV5 {
-  annualRate: string;
-  orderId: number;
-  orderTime: string;
-  filledQty: string;
-  orderQty: string;
-  orderCurrency: string;
-  state: number;
-  term: number;
-}
-⋮----
-export interface RepayFixedV5 {
-  repayId: string;
-}
-⋮----
-export interface RepaymentHistoryFixedV5 {
-  details: {
-    loanCurrency: string;
-    loanId: string;
-    repayAmount: string;
-  }[];
-  loanCurrency: string;
-  repayAmount: string;
-  repayId: string;
-  repayStatus: number;
-  repayTime: number;
-  repayType: number;
+  execPrice: string;
+  execTime: string;
+  execType: 'Trade';
+  execQty: string;
+  execId: string;
+  legs: SpreadTradeLegV5[];
+  extraFees: string;
 }
 
 ================
-File: src/types/request/v5-crypto-loan.ts
+File: .gitignore
 ================
-export interface BorrowCryptoLoanParamsV5 {
-  loanCurrency: string;
-  loanAmount?: string;
-  loanTerm?: string;
-  collateralCurrency: string;
-  collateralAmount?: string;
-}
-⋮----
-export interface GetUnpaidLoanOrdersParamsV5 {
-  orderId?: string;
-  loanCurrency?: string;
-  collateralCurrency?: string;
-  loanTermType?: string;
-  loanTerm?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface GetRepaymentHistoryParamsV5 {
-  orderId?: string;
-  repayId?: string;
-  loanCurrency?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface GetCompletedLoanOrderHistoryParamsV5 {
-  orderId?: string;
-  loanCurrency?: string;
-  collateralCurrency?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface GetLoanLTVAdjustmentHistoryParamsV5 {
-  orderId?: string;
-  adjustId?: string;
-  collateralCurrency?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-// New Crypto Loan Request Types
-⋮----
-export interface GetBorrowableCoinsParamsV5 {
-  vipLevel?: string;
-  currency?: string;
-}
-⋮----
-export interface GetCollateralCoinsParamsV5 {
-  currency?: string;
-}
-⋮----
-export interface GetMaxCollateralAmountParamsV5 {
-  currency: string;
-}
-⋮----
-export interface AdjustCollateralAmountParamsV5 {
-  currency: string;
-  amount: string;
-  direction: '0' | '1';
-}
-⋮----
-export interface GetCollateralAdjustmentHistoryParamsV5 {
-  adjustId?: string;
-  collateralCurrency?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-// Flexible Loan Request Types
-⋮----
-export interface BorrowFlexibleParamsV5 {
-  loanCurrency: string;
-  loanAmount: string;
-  collateralList?: {
-    currency: string;
-    amount: string;
-  }[];
-}
-⋮----
-export interface RepayFlexibleParamsV5 {
-  loanCurrency: string;
-  amount: string;
-}
-⋮----
-export interface RepayCollateralFlexibleParamsV5 {
-  loanCurrency: string;
-  collateralCoin: string;
-  amount: string;
-}
-⋮----
-export interface GetOngoingFlexibleLoansParamsV5 {
-  loanCurrency?: string;
-}
-⋮----
-export interface GetBorrowHistoryFlexibleParamsV5 {
-  orderId?: string;
-  loanCurrency?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface GetRepaymentHistoryFlexibleParamsV5 {
-  repayId?: string;
-  loanCurrency?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-// Fixed Loan Request Types
-⋮----
-export interface GetSupplyOrderQuoteFixedParamsV5 {
-  orderCurrency: string;
-  term?: string;
-  orderBy: 'apy' | 'term' | 'quantity';
-  sort?: number;
-  limit?: number;
-}
-⋮----
-export interface GetBorrowOrderQuoteFixedParamsV5 {
-  orderCurrency: string;
-  term?: string;
-  orderBy: 'apy' | 'term' | 'quantity';
-  sort?: number;
-  limit?: number;
-}
-⋮----
-export interface CreateBorrowOrderFixedParamsV5 {
-  orderCurrency: string;
-  orderAmount: string;
-  annualRate: string;
-  term: string;
-  autoRepay?: string; // Deprecated
-  repayType?: string; // 1: Auto Repayment (default); 2: Transfer to flexible loan
-  collateralList?: {
-    currency: string;
-    amount: string;
-  }[];
-}
-⋮----
-autoRepay?: string; // Deprecated
-repayType?: string; // 1: Auto Repayment (default); 2: Transfer to flexible loan
-⋮----
-export interface CreateSupplyOrderFixedParamsV5 {
-  orderCurrency: string;
-  orderAmount: string;
-  annualRate: string;
-  term: string;
-}
-⋮----
-export interface CancelBorrowOrderFixedParamsV5 {
-  orderId: string;
-}
-⋮----
-export interface CancelSupplyOrderFixedParamsV5 {
-  orderId: string;
-}
-⋮----
-export interface GetBorrowContractInfoFixedParamsV5 {
-  orderId?: string;
-  loanId?: string;
-  orderCurrency?: string;
-  term?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface GetSupplyContractInfoFixedParamsV5 {
-  orderId?: string;
-  supplyId?: string;
-  supplyCurrency?: string;
-  term?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface GetBorrowOrderInfoFixedParamsV5 {
-  orderId?: string;
-  orderCurrency?: string;
-  state?: string;
-  term?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface GetSupplyOrderInfoFixedParamsV5 {
-  orderId?: string;
-  orderCurrency?: string;
-  state?: string;
-  term?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface RepayFixedParamsV5 {
-  loanId?: string;
-  loanCurrency?: string;
-}
-⋮----
-export interface RepayCollateralFixedParamsV5 {
-  loanCurrency: string;
-  collateralCoin: string;
-  amount: string;
-}
-⋮----
-export interface GetRepaymentHistoryFixedParamsV5 {
-  repayId?: string;
-  loanCurrency?: string;
-  limit?: string;
-  cursor?: string;
-}
+!.gitkeep
+.DS_STORE
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+pids
+*.pid
+*.seed
+*.pid.lock
+node_modules/
+.npm
+.eslintcache
+.node_repl_history
+*.tgz
+.yarn-integrity
+.env
+.env.test
+.cache
+lib
+bundleReport.html
+.history/
+rawReq.ts
+localtest.sh
+localtest.ts
+privaterepotracker
+restClientRegex.ts
+repomix.sh
+
+examples/ignored
+examples/ts-testnet-private.ts
+examples/ts-testnet-trade.ts
+examples/ts-testnet.ts
 
 ================
 File: src/websocket-client.ts
@@ -12995,648 +9223,6 @@ protected resolveEmittableEvents(
 // Request/reply pattern for authentication success
 ⋮----
 // In case of catastrophic failure, fallback to noisy emit update
-
-================
-File: src/types/websockets/ws-events.ts
-================
-import WebSocket from 'isomorphic-ws';
-⋮----
-import {
-  RFQItemV5,
-  RFQPublicTradeV5,
-  RFQQuoteItemV5,
-  RFQTradeV5,
-} from '../response/v5-rfq';
-import {
-  CategoryV5,
-  ExecTypeV5,
-  OCOTriggerTypeV5,
-  OrderCancelTypeV5,
-  OrderCreateTypeV5,
-  OrderRejectReasonV5,
-  OrderSideV5,
-  OrderSMPTypeV5,
-  OrderStatusV5,
-  OrderTimeInForceV5,
-  OrderTriggerByV5,
-  OrderTypeV5,
-  PositionIdx,
-  PositionSideV5,
-  PositionStatusV5,
-  StopOrderTypeV5,
-  SystemStatusItemV5,
-  TPSLModeV5,
-  TradeModeV5,
-} from '../shared-v5';
-import { WsKey } from './ws-general';
-⋮----
-export interface MessageEventLike {
-  target: WebSocket;
-  type: 'message';
-  data: string;
-}
-⋮----
-export function isMessageEvent(msg: unknown): msg is MessageEventLike
-⋮----
-export interface WSPublicTopicEventV5<TTopic extends string, TType, TData> {
-  id?: string;
-  topic: TTopic;
-  type: TType;
-  /** Cross sequence */
-  cs?: number;
-  /** Event timestamp */
-  ts: number;
-  data: TData;
-  /**
-   * matching engine timestamp (correlated with T from public trade channel)
-   */
-  cts: number;
-  /**
-   * Internal reference, can be used to determine if this is spot/linear/inverse/etc
-   */
-  wsKey: WsKey;
-}
-⋮----
-/** Cross sequence */
-⋮----
-/** Event timestamp */
-⋮----
-/**
-   * matching engine timestamp (correlated with T from public trade channel)
-   */
-⋮----
-/**
-   * Internal reference, can be used to determine if this is spot/linear/inverse/etc
-   */
-⋮----
-export interface WSPrivateTopicEventV5<TTopic extends string, TData> {
-  id?: string;
-  topic: TTopic;
-  creationTime: number;
-  data: TData;
-  wsKey: WsKey;
-}
-⋮----
-export interface WSOrderbookV5 {
-  /** Symbol */
-  s: string;
-  /** [price, qty][] */
-  b: [string, string][];
-  /** [price, qty][] */
-  a: [string, string][];
-  /** Update ID */
-  u: number;
-  /** Cross sequence */
-  seq: number;
-}
-⋮----
-/** Symbol */
-⋮----
-/** [price, qty][] */
-⋮----
-/** [price, qty][] */
-⋮----
-/** Update ID */
-⋮----
-/** Cross sequence */
-⋮----
-export type WSOrderbookEventV5 = WSPublicTopicEventV5<
-  string,
-  'delta' | 'snapshot',
-  WSOrderbookV5
->;
-⋮----
-export interface WSTradeV5 {
-  T: number;
-  s: string;
-  S: OrderSideV5;
-  v: string;
-  p: string;
-  L?: string;
-  i: string;
-  BT: boolean;
-  RPI?: boolean;
-  mP?: string;
-  iP?: string;
-  mIv?: string;
-  iv?: string;
-}
-⋮----
-export type WSTradeEventV5 = WSPublicTopicEventV5<
-  string,
-  'snapshot',
-  WSTradeV5[]
->;
-⋮----
-/**
- *  WSTickerV5 is the data structure for the "linear" ticker channel
- *  */
-export interface WSTickerV5 {
-  symbol: string;
-  tickDirection: string;
-  price24hPcnt: string;
-  lastPrice: string;
-  prevPrice24h: string;
-  highPrice24h: string;
-  lowPrice24h: string;
-  prevPrice1h: string;
-  markPrice: string;
-  indexPrice: string;
-  openInterest: string;
-  openInterestValue: string;
-  turnover24h: string;
-  volume24h: string;
-  nextFundingTime: string;
-  fundingRate: string;
-  bid1Price: string;
-  bid1Size: string;
-  ask1Price: string;
-  ask1Size: string;
-  deliveryTime?: string;
-  basisRate?: string;
-  deliveryFeeRate?: string;
-  predictedDeliveryPrice?: string;
-  preOpenPrice?: string;
-  preQty?: string;
-  curPreListingPhase?: string;
-}
-⋮----
-export interface WSTickerOptionV5 {
-  symbol: string;
-  bidPrice: string;
-  bidSize: string;
-  bidIv: string;
-  askPrice: string;
-  askSize: string;
-  askIv: string;
-  lastPrice: string;
-  highPrice24h: string;
-  lowPrice24h: string;
-  markPrice: string;
-  indexPrice: string;
-  markPriceIv: string;
-  underlyingPrice: string;
-  openInterest: string;
-  turnover24h: string;
-  volume24h: string;
-  totalVolume: string;
-  totalTurnover: string;
-  delta: string;
-  gamma: string;
-  vega: string;
-  theta: string;
-  predictedDeliveryPrice: string;
-  change24h: string;
-}
-⋮----
-export interface WSTickerSpotV5 {
-  symbol: string;
-  lastPrice: string;
-  highPrice24h: string;
-  lowPrice24h: string;
-  prevPrice24h: string;
-  volume24h: string;
-  turnover24h: string;
-  price24hPcnt: string;
-  usdIndexPrice: string;
-}
-⋮----
-export type WSTickerEventV5 = WSPublicTopicEventV5<
-  string,
-  'snapshot' | 'delta',
-  WSTickerV5 | WSTickerOptionV5 | WSTickerSpotV5
->;
-⋮----
-export interface WSKlineV5 {
-  start: number;
-  end: number;
-  interval: string;
-  open: string;
-  close: string;
-  high: string;
-  low: string;
-  volume: string;
-  turnover: string;
-  confirm: boolean;
-  timestamp: number;
-}
-⋮----
-export type WSKlineEventV5 = WSPublicTopicEventV5<
-  string,
-  'snapshot',
-  WSKlineV5[]
->;
-⋮----
-export interface WSLiquidationV5 {
-  T: number;
-  s: string;
-  S: OrderSideV5;
-  v: string;
-  p: string;
-}
-⋮----
-export type WSLiquidationEventV5 = WSPublicTopicEventV5<
-  string,
-  'snapshot',
-  WSLiquidationV5[]
->;
-⋮----
-export interface WSPositionV5 {
-  category: string;
-  symbol: string;
-  side: PositionSideV5;
-  size: string;
-  positionIdx: PositionIdx;
-  tradeMode: TradeModeV5;
-  positionValue: string;
-  riskId: number;
-  riskLimitValue: string;
-  entryPrice: string;
-  markPrice: string;
-  leverage: string;
-  positionBalance: string;
-  autoAddMargin: number;
-  positionMM: string;
-  positionIM: string;
-  positionIMByMp: string;
-  positionMMByMp: string;
-  liqPrice: string;
-  bustPrice: string;
-  tpslMode: string;
-  takeProfit: string;
-  stopLoss: string;
-  trailingStop: string;
-  unrealisedPnl: string;
-  curRealisedPnl: string;
-  sessionAvgPrice: string;
-  delta: string;
-  gamma: string;
-  vega: string;
-  theta: string;
-  cumRealisedPnl: string;
-  positionStatus: PositionStatusV5;
-  adlRankIndicator: number;
-  isReduceOnly: boolean;
-  mmrSysUpdatedTime: string;
-  leverageSysUpdatedTime: string;
-  createdTime: string;
-  updatedTime: string;
-  seq: number;
-}
-⋮----
-export type WSPositionEventV5 = WSPrivateTopicEventV5<
-  'position',
-  WSPositionV5[]
->;
-⋮----
-export interface WSAccountOrderV5 {
-  category: CategoryV5;
-  orderId: string;
-  orderLinkId: string;
-  isLeverage: string;
-  blockTradeId: string;
-  symbol: string;
-  price: string;
-  qty: string;
-  side: OrderSideV5;
-  positionIdx: PositionIdx;
-  orderStatus: OrderStatusV5;
-  createType: OrderCreateTypeV5;
-  cancelType: OrderCancelTypeV5;
-  rejectReason?: OrderRejectReasonV5;
-  avgPrice?: string;
-  leavesQty?: string;
-  leavesValue?: string;
-  cumExecQty: string;
-  cumExecValue: string;
-  cumExecFee: string;
-  closedPnl: string;
-  feeCurrency: string;
-  timeInForce: OrderTimeInForceV5;
-  orderType: OrderTypeV5;
-  stopOrderType: StopOrderTypeV5;
-  ocoTriggerType?: OCOTriggerTypeV5;
-  orderIv: string;
-  marketUnit?: 'baseCoin' | 'quoteCoin';
-  triggerPrice: string;
-  takeProfit: string;
-  stopLoss: string;
-  tpslMode?: TPSLModeV5;
-  tpLimitPrice?: string;
-  slLimitPrice?: string;
-  tpTriggerBy: string;
-  slTriggerBy: string;
-  triggerDirection: number;
-  triggerBy: OrderTriggerByV5;
-  lastPriceOnCreated: string;
-  reduceOnly: boolean;
-  closeOnTrigger: boolean;
-  placeType: string;
-  smpType: OrderSMPTypeV5;
-  smpGroup: number;
-  smpOrderId: string;
-  createdTime: string;
-  updatedTime: string;
-  cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee and feeCurrency
-}
-⋮----
-cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee and feeCurrency
-⋮----
-export type WSAccountOrderEventV5 = WSPrivateTopicEventV5<
-  'order',
-  WSAccountOrderV5[]
->;
-⋮----
-export interface WSExecutionV5 {
-  category: CategoryV5;
-  symbol: string;
-  isLeverage: string;
-  orderId: string;
-  orderLinkId: string;
-  side: OrderSideV5;
-  orderPrice: string;
-  orderQty: string;
-  leavesQty: string;
-  createType: OrderCreateTypeV5;
-  orderType: OrderTypeV5;
-  stopOrderType: StopOrderTypeV5;
-  execFee: string;
-  feeCurrency: string; // Trading fee currency
-  execId: string;
-  execPrice: string;
-  execQty: string;
-  execPnl: string;
-  execType: ExecTypeV5;
-  execValue: string;
-  execTime: string;
-  isMaker: boolean;
-  feeRate: string;
-  tradeIv: string;
-  markIv: string;
-  markPrice: string;
-  indexPrice: string;
-  underlyingPrice: string;
-  blockTradeId: string;
-  closedSize: string;
-  extraFees: string;
-  seq: number;
-  marketUnit: string;
-}
-⋮----
-feeCurrency: string; // Trading fee currency
-⋮----
-export type WSExecutionEventV5 = WSPrivateTopicEventV5<
-  'execution',
-  WSExecutionV5[]
->;
-⋮----
-export interface WSExecutionFastV5 {
-  category: CategoryV5;
-  symbol: string;
-  execId: string;
-  execPrice: string;
-  execQty: string;
-  orderId: string;
-  isMaker: boolean;
-  orderLinkId: string;
-  side: OrderSideV5;
-  execTime: string;
-  seq: number;
-}
-⋮----
-export type WSExecutionFastEventV5 = WSPrivateTopicEventV5<
-  'execution.fast',
-  WSExecutionFastV5[]
->;
-⋮----
-export interface WSCoinV5 {
-  coin: string;
-  equity: string;
-  usdValue: string;
-  walletBalance: string;
-  free?: string;
-  locked: string;
-  spotHedgingQty: string;
-  borrowAmount: string;
-  availableToBorrow: string;
-  availableToWithdraw: string;
-  accruedInterest: string;
-  totalOrderIM: string;
-  totalPositionIM: string;
-  totalPositionMM: string;
-  unrealisedPnl: string;
-  cumRealisedPnl: string;
-  bonus: string;
-  collateralSwitch: boolean;
-  marginCollateral: boolean;
-  spotBorrow: string;
-}
-⋮----
-export interface WSWalletV5 {
-  accountType: string;
-  accountLTV: string;
-  accountIMRate: string;
-  accountMMRate: string;
-  accountIMRateByMp: string;
-  accountMMRateByMp: string;
-  totalInitialMarginByMp: string;
-  totalMaintenanceMarginByMp: string;
-  totalEquity: string;
-  totalWalletBalance: string;
-  totalMarginBalance: string;
-  totalAvailableBalance: string;
-  totalPerpUPL: string;
-  totalInitialMargin: string;
-  totalMaintenanceMargin: string;
-  coin: WSCoinV5[];
-}
-⋮----
-export type WSWalletEventV5 = WSPrivateTopicEventV5<'wallet', WSWalletV5[]>;
-⋮----
-export interface WSGreeksV5 {
-  baseCoin: string;
-  totalDelta: string;
-  totalGamma: string;
-  totalVega: string;
-  totalTheta: string;
-}
-⋮----
-export type WSGreeksEventV5 = WSPrivateTopicEventV5<'greeks', WSGreeksV5[]>;
-⋮----
-export interface WSSpreadOrderV5 {
-  category: 'combination' | 'spot_leg' | 'future_leg';
-  symbol: string;
-  parentOrderId: string;
-  orderId: string;
-  orderLinkId: string;
-  side: OrderSideV5;
-  orderStatus: OrderStatusV5;
-  cancelType: OrderCancelTypeV5;
-  rejectReason: OrderRejectReasonV5;
-  timeInForce: OrderTimeInForceV5;
-  price: string;
-  qty: string;
-  avgPrice: string;
-  leavesQty: string;
-  leavesValue: string;
-  cumExecQty: string;
-  cumExecValue: string;
-  cumExecFee: string;
-  orderType: OrderTypeV5;
-  isLeverage: string;
-  createdTime: string;
-  updatedTime: string;
-  feeCurrency: string;
-  createType: OrderCreateTypeV5;
-  closedPnl: string;
-  cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee and feeCurrency
-}
-⋮----
-cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee and feeCurrency
-⋮----
-export type WSSpreadOrderEventV5 = WSPrivateTopicEventV5<
-  'spread.order',
-  WSSpreadOrderV5[]
->;
-⋮----
-export interface WSSpreadExecutionV5 {
-  category: 'combination' | 'spot_leg' | 'future_leg';
-  symbol: string;
-  isLeverage: string;
-  orderId: string;
-  orderLinkId: string;
-  side: OrderSideV5;
-  orderPrice: string;
-  orderQty: string;
-  leavesQty: string;
-  createType: OrderCreateTypeV5;
-  orderType: OrderTypeV5;
-  execFee: string;
-  execFeeV2: string;
-  feeCurrency: string; // Trading fee currency
-  parentExecId: string;
-  execId: string;
-  execPrice: string;
-  execQty: string;
-  execPnl: string;
-  execType: ExecTypeV5;
-  execValue: string;
-  execTime: string;
-  isMaker: boolean;
-  feeRate: string;
-  markPrice: string;
-  closedSize: string;
-  seq: number;
-}
-⋮----
-feeCurrency: string; // Trading fee currency
-⋮----
-export type WSSpreadExecutionEventV5 = WSPrivateTopicEventV5<
-  'spread.execution',
-  WSSpreadExecutionV5[]
->;
-⋮----
-export interface WSInsuranceV5 {
-  coin: string;
-  symbols: string;
-  balance: string;
-  updateTime: string;
-}
-⋮----
-export type WSInsuranceEventV5 = WSPublicTopicEventV5<
-  'insurance.USDT' | 'insurance.USDC' | 'insurance.inverse',
-  'snapshot' | 'delta',
-  WSInsuranceV5[]
->;
-⋮----
-export interface WSPriceLimitV5 {
-  symbol: string;
-  buyLmt: string;
-  sellLmt: string;
-}
-⋮----
-export type WSPriceLimitEventV5 = WSPublicTopicEventV5<
-  string,
-  'snapshot',
-  WSPriceLimitV5
->;
-⋮----
-export interface WSADLAlertV5 {
-  c: string; // Token of the insurance pool
-  s: string; // Trading pair name
-  b: string; // Balance of the insurance fund. Used to determine if ADL is triggered
-  mb: string; // Maximum balance of the insurance pool in the last 8 hours
-  i_pr: string; // PnL ratio threshold for triggering contract PnL drawdown ADL
-  pr: string; // Symbol's PnL drawdown ratio in the last 8 hours. Used to determine whether ADL is triggered or stopped
-  adl_tt: string; // Trigger threshold for contract PnL drawdown ADL
-  adl_sr: string; // Stop ratio threshold for contract PnL drawdown ADL
-}
-⋮----
-c: string; // Token of the insurance pool
-s: string; // Trading pair name
-b: string; // Balance of the insurance fund. Used to determine if ADL is triggered
-mb: string; // Maximum balance of the insurance pool in the last 8 hours
-i_pr: string; // PnL ratio threshold for triggering contract PnL drawdown ADL
-pr: string; // Symbol's PnL drawdown ratio in the last 8 hours. Used to determine whether ADL is triggered or stopped
-adl_tt: string; // Trigger threshold for contract PnL drawdown ADL
-adl_sr: string; // Stop ratio threshold for contract PnL drawdown ADL
-⋮----
-export type WSADLAlertEventV5 = WSPublicTopicEventV5<
-  'adlAlert.USDT' | 'adlAlert.USDC' | 'adlAlert.inverse',
-  'snapshot',
-  WSADLAlertV5[]
->;
-⋮----
-export type WSSystemStatusEventV5 = WSPublicTopicEventV5<
-  'system.status',
-  'snapshot',
-  SystemStatusItemV5[]
->;
-⋮----
-/**
- * RFQ WebSocket Events
- */
-⋮----
-/**
- * RFQ Inquiry Channel
- * Private push for RFQ inquiries sent or received by the user
- * Topics: rfq.open.rfqs, rfq.site.rfqs
- */
-export type WSRFQInquiryEventV5 = WSPrivateTopicEventV5<
-  'rfq.open.rfqs' | 'rfq.site.rfqs',
-  RFQItemV5[]
->;
-⋮----
-/**
- * RFQ Quote Channel
- * Private push for quotes sent or received by the user
- * Topics: rfq.open.quotes, rfq.site.quotes
- */
-export type WSRFQQuoteEventV5 = WSPrivateTopicEventV5<
-  'rfq.open.quotes' | 'rfq.site.quotes',
-  RFQQuoteItemV5[]
->;
-⋮----
-/**
- * RFQ Trade Channel
- * Private push for block trades executed by the user
- * Topics: rfq.open.trades, rfq.site.trades
- */
-export type WSRFQTradeEventV5 = WSPrivateTopicEventV5<
-  'rfq.open.trades' | 'rfq.site.trades',
-  RFQTradeV5[]
->;
-⋮----
-/**
- * RFQ Public Trade Channel
- * Public push for all block trades
- * Topics: rfq.open.public.trades, rfq.site.public.trades
- */
-export type WSRFQPublicTradeEventV5 = WSPublicTopicEventV5<
-  'rfq.open.public.trades' | 'rfq.site.public.trades',
-  'snapshot',
-  RFQPublicTradeV5[]
->;
 
 ================
 File: README.md
@@ -14297,6 +9883,1186 @@ Contributions are encouraged, I will review any incoming pull requests. See the 
 <!-- template_star_history_end -->
 
 ================
+File: src/types/response/v5-crypto-loan.ts
+================
+export interface CollateralCoinV5 {
+  collateralAccuracy: number;
+  initialLTV: string;
+  liquidationLTV: string;
+  marginCallLTV: string;
+  maxLimit: string;
+}
+⋮----
+export interface VipCollateralCoinsV5 {
+  list: CollateralCoinV5[];
+  vipLevel: string;
+}
+⋮----
+export interface BorrowableCoinV5 {
+  borrowingAccuracy: number;
+  currency: string;
+  flexibleHourlyInterestRate: string;
+  hourlyInterestRate7D: string;
+  hourlyInterestRate14D: string;
+  hourlyInterestRate30D: string;
+  hourlyInterestRate90D: string;
+  hourlyInterestRate180D: string;
+  maxBorrowingAmount: string;
+  minBorrowingAmount: string;
+}
+⋮----
+export interface VipBorrowableCoinsV5 {
+  list: BorrowableCoinV5[];
+  vipLevel: string;
+}
+⋮----
+export interface AccountBorrowCollateralLimitV5 {
+  collateralCurrency: string;
+  loanCurrency: string;
+  maxCollateralAmount: string;
+  maxLoanAmount: string;
+  minCollateralAmount: string;
+  minLoanAmount: string;
+}
+⋮----
+export interface UnpaidLoanOrderV5 {
+  collateralAmount: string;
+  collateralCurrency: string;
+  currentLTV: string;
+  expirationTime: string;
+  hourlyInterestRate: string;
+  loanCurrency: string;
+  loanTerm: string;
+  orderId: string;
+  residualInterest: string;
+  residualPenaltyInterest: string;
+  totalDebt: string;
+}
+⋮----
+export interface RepaymentHistoryV5 {
+  collateralCurrency: string;
+  collateralReturn: string;
+  loanCurrency: string;
+  loanTerm: string;
+  orderId: string;
+  repayAmount: string;
+  repayId: string;
+  repayStatus: number;
+  repayTime: string;
+  repayType: string;
+}
+⋮----
+export interface CompletedLoanOrderV5 {
+  borrowTime: string;
+  collateralCurrency: string;
+  expirationTime: string;
+  hourlyInterestRate: string;
+  initialCollateralAmount: string;
+  initialLoanAmount: string;
+  loanCurrency: string;
+  loanTerm: string;
+  orderId: string;
+  repaidInterest: string;
+  repaidPenaltyInterest: string;
+  status: number;
+}
+export interface LoanLTVAdjustmentHistoryV5 {
+  collateralCurrency: string;
+  orderId: string;
+  adjustId: string;
+  adjustTime: string;
+  preLTV: string;
+  afterLTV: string;
+  direction: number;
+  amount: string;
+}
+⋮----
+// New Crypto Loan Types
+⋮----
+export interface BorrowCoinV5 {
+  currency: string;
+  fixedBorrowable: boolean;
+  fixedBorrowingAccuracy: number;
+  flexibleBorrowable: boolean;
+  flexibleBorrowingAccuracy: number;
+  maxBorrowingAmount: string;
+  minFixedBorrowingAmount: string;
+  minFlexibleBorrowingAmount: string;
+  vipLevel: string;
+  flexibleAnnualizedInterestRate: string;
+  annualizedInterestRate7D: string;
+  annualizedInterestRate14D: string;
+  annualizedInterestRate30D: string;
+  annualizedInterestRate60D: string;
+  annualizedInterestRate90D: string;
+  annualizedInterestRate180D: string;
+}
+⋮----
+export interface CollateralRatioV5 {
+  collateralRatio: string;
+  maxValue: string;
+  minValue: string;
+}
+⋮----
+export interface CollateralRatioConfigV5 {
+  collateralRatioList: CollateralRatioV5[];
+  currencies: string;
+}
+⋮----
+export interface CurrencyLiquidationV5 {
+  currency: string;
+  liquidationOrder: number;
+}
+⋮----
+export interface CollateralDataV5 {
+  collateralRatioConfigList: CollateralRatioConfigV5[];
+  currencyLiquidationList: CurrencyLiquidationV5[];
+}
+⋮----
+// Additional New Crypto Loan Types
+⋮----
+export interface AdjustCollateralAmountV5 {
+  adjustId: number;
+}
+⋮----
+export interface CollateralAdjustmentHistoryV5 {
+  adjustId: number;
+  adjustTime: number;
+  afterLTV: string;
+  amount: string;
+  collateralCurrency: string;
+  direction: number;
+  preLTV: string;
+  status: number;
+}
+⋮----
+export interface BorrowListV5 {
+  fixedTotalDebt: string;
+  fixedTotalDebtUSD: string;
+  flexibleHourlyInterestRate: string;
+  flexibleTotalDebt: string;
+  flexibleTotalDebtUSD: string;
+  loanCurrency: string;
+}
+⋮----
+export interface CollateralListV5 {
+  amount: string;
+  amountUSD: string;
+  currency: string;
+  ltv: string;
+}
+⋮----
+export interface SupplyListV5 {
+  amount: string;
+  amountUSD: string;
+  currency: string;
+}
+⋮----
+export interface CryptoLoanPositionV5 {
+  borrowList: BorrowListV5[];
+  collateralList: CollateralListV5[];
+  supplyList: SupplyListV5[];
+  totalCollateral: string;
+  totalDebt: string;
+  totalSupply: string;
+}
+⋮----
+// Flexible Loan Types
+⋮----
+export interface BorrowFlexibleV5 {
+  orderId: string;
+}
+⋮----
+export interface RepayFlexibleV5 {
+  repayId: string;
+}
+⋮----
+export interface OngoingFlexibleLoanV5 {
+  hourlyInterestRate: string;
+  loanCurrency: string;
+  totalDebt: string;
+  unpaidAmount: string;
+  unpaidInterest: string;
+}
+⋮----
+export interface BorrowHistoryFlexibleV5 {
+  borrowTime: number;
+  initialLoanAmount: string;
+  loanCurrency: string;
+  orderId: string;
+  status: number;
+}
+⋮----
+export interface RepaymentHistoryFlexibleV5 {
+  loanCurrency: string;
+  repayAmount: string;
+  repayId: string;
+  repayStatus: number;
+  repayTime: number;
+  repayType: number;
+}
+⋮----
+// Fixed Loan Types
+⋮----
+export interface SupplyOrderQuoteFixedV5 {
+  orderCurrency: string;
+  term: number;
+  annualRate: string;
+  qty: string;
+}
+⋮----
+export interface BorrowOrderQuoteFixedV5 {
+  orderCurrency: string;
+  term: number;
+  annualRate: string;
+  qty: string;
+}
+⋮----
+export interface CreateBorrowOrderFixedV5 {
+  orderId: string;
+}
+⋮----
+export interface CreateSupplyOrderFixedV5 {
+  orderId: string;
+}
+⋮----
+export interface BorrowContractInfoFixedV5 {
+  annualRate: string;
+  autoRepay: string; // Deprecated
+  borrowCurrency: string;
+  borrowTime: string;
+  interestPaid: string;
+  loanId: string;
+  orderId: string;
+  repayType: string; // 1: Auto Repayment; 2: Transfer to flexible loan; 0: No Automatic Repayment
+  repaymentTime: string;
+  residualPenaltyInterest: string;
+  residualPrincipal: string;
+  status: number;
+  term: string;
+}
+⋮----
+autoRepay: string; // Deprecated
+⋮----
+repayType: string; // 1: Auto Repayment; 2: Transfer to flexible loan; 0: No Automatic Repayment
+⋮----
+export interface SupplyContractInfoFixedV5 {
+  annualRate: string;
+  supplyCurrency: string;
+  supplyTime: string;
+  supplyAmount: string;
+  interestPaid: string;
+  supplyId: string;
+  orderId: string;
+  redemptionTime: string;
+  penaltyInterest: string;
+  actualRedemptionTime: string;
+  status: number;
+  term: string;
+}
+⋮----
+export interface BorrowOrderInfoFixedV5 {
+  annualRate: string;
+  orderId: number;
+  orderTime: string;
+  filledQty: string;
+  orderQty: string;
+  orderCurrency: string;
+  state: number;
+  term: number;
+  repayType: string; // 1: Auto Repayment; 2: Transfer to flexible loan; 0: No Automatic Repayment
+}
+⋮----
+repayType: string; // 1: Auto Repayment; 2: Transfer to flexible loan; 0: No Automatic Repayment
+⋮----
+export interface SupplyOrderInfoFixedV5 {
+  annualRate: string;
+  orderId: number;
+  orderTime: string;
+  filledQty: string;
+  orderQty: string;
+  orderCurrency: string;
+  state: number;
+  term: number;
+}
+⋮----
+export interface RepayFixedV5 {
+  repayId: string;
+}
+⋮----
+export interface RepaymentHistoryFixedV5 {
+  details: {
+    loanCurrency: string;
+    loanId: string;
+    repayAmount: string;
+  }[];
+  loanCurrency: string;
+  repayAmount: string;
+  repayId: string;
+  repayStatus: number;
+  repayTime: number;
+  repayType: number;
+}
+
+================
+File: src/types/websockets/ws-events.ts
+================
+import WebSocket from 'isomorphic-ws';
+⋮----
+import {
+  RFQItemV5,
+  RFQPublicTradeV5,
+  RFQQuoteItemV5,
+  RFQTradeV5,
+} from '../response/v5-rfq';
+import {
+  CategoryV5,
+  ExecTypeV5,
+  OCOTriggerTypeV5,
+  OrderCancelTypeV5,
+  OrderCreateTypeV5,
+  OrderRejectReasonV5,
+  OrderSideV5,
+  OrderSMPTypeV5,
+  OrderStatusV5,
+  OrderTimeInForceV5,
+  OrderTriggerByV5,
+  OrderTypeV5,
+  PositionIdx,
+  PositionSideV5,
+  PositionStatusV5,
+  StopOrderTypeV5,
+  SystemStatusItemV5,
+  TPSLModeV5,
+  TradeModeV5,
+} from '../shared-v5';
+import { WsKey } from './ws-general';
+⋮----
+export interface MessageEventLike {
+  target: WebSocket;
+  type: 'message';
+  data: string;
+}
+⋮----
+export function isMessageEvent(msg: unknown): msg is MessageEventLike
+⋮----
+export interface WSPublicTopicEventV5<TTopic extends string, TType, TData> {
+  id?: string;
+  topic: TTopic;
+  type: TType;
+  /** Cross sequence */
+  cs?: number;
+  /** Event timestamp */
+  ts: number;
+  data: TData;
+  /**
+   * matching engine timestamp (correlated with T from public trade channel)
+   */
+  cts: number;
+  /**
+   * Internal reference, can be used to determine if this is spot/linear/inverse/etc
+   */
+  wsKey: WsKey;
+}
+⋮----
+/** Cross sequence */
+⋮----
+/** Event timestamp */
+⋮----
+/**
+   * matching engine timestamp (correlated with T from public trade channel)
+   */
+⋮----
+/**
+   * Internal reference, can be used to determine if this is spot/linear/inverse/etc
+   */
+⋮----
+export interface WSPrivateTopicEventV5<TTopic extends string, TData> {
+  id?: string;
+  topic: TTopic;
+  creationTime: number;
+  data: TData;
+  wsKey: WsKey;
+}
+⋮----
+export interface WSOrderbookV5 {
+  /** Symbol */
+  s: string;
+  /** [price, qty][] */
+  b: [string, string][];
+  /** [price, qty][] */
+  a: [string, string][];
+  /** Update ID */
+  u: number;
+  /** Cross sequence */
+  seq: number;
+}
+⋮----
+/** Symbol */
+⋮----
+/** [price, qty][] */
+⋮----
+/** [price, qty][] */
+⋮----
+/** Update ID */
+⋮----
+/** Cross sequence */
+⋮----
+export type WSOrderbookEventV5 = WSPublicTopicEventV5<
+  string,
+  'delta' | 'snapshot',
+  WSOrderbookV5
+>;
+⋮----
+export interface WSTradeV5 {
+  T: number;
+  s: string;
+  S: OrderSideV5;
+  v: string;
+  p: string;
+  L?: string;
+  i: string;
+  BT: boolean;
+  RPI?: boolean;
+  mP?: string;
+  iP?: string;
+  mIv?: string;
+  iv?: string;
+}
+⋮----
+export type WSTradeEventV5 = WSPublicTopicEventV5<
+  string,
+  'snapshot',
+  WSTradeV5[]
+>;
+⋮----
+/**
+ *  WSTickerV5 is the data structure for the "linear" ticker channel
+ *  */
+export interface WSTickerV5 {
+  symbol: string;
+  tickDirection: string;
+  price24hPcnt: string;
+  lastPrice: string;
+  prevPrice24h: string;
+  highPrice24h: string;
+  lowPrice24h: string;
+  prevPrice1h: string;
+  markPrice: string;
+  indexPrice: string;
+  openInterest: string;
+  openInterestValue: string;
+  turnover24h: string;
+  volume24h: string;
+  nextFundingTime: string;
+  fundingRate: string;
+  bid1Price: string;
+  bid1Size: string;
+  ask1Price: string;
+  ask1Size: string;
+  deliveryTime?: string;
+  basisRate?: string;
+  deliveryFeeRate?: string;
+  predictedDeliveryPrice?: string;
+  preOpenPrice?: string;
+  preQty?: string;
+  curPreListingPhase?: string;
+}
+⋮----
+export interface WSTickerOptionV5 {
+  symbol: string;
+  bidPrice: string;
+  bidSize: string;
+  bidIv: string;
+  askPrice: string;
+  askSize: string;
+  askIv: string;
+  lastPrice: string;
+  highPrice24h: string;
+  lowPrice24h: string;
+  markPrice: string;
+  indexPrice: string;
+  markPriceIv: string;
+  underlyingPrice: string;
+  openInterest: string;
+  turnover24h: string;
+  volume24h: string;
+  totalVolume: string;
+  totalTurnover: string;
+  delta: string;
+  gamma: string;
+  vega: string;
+  theta: string;
+  predictedDeliveryPrice: string;
+  change24h: string;
+}
+⋮----
+export interface WSTickerSpotV5 {
+  symbol: string;
+  lastPrice: string;
+  highPrice24h: string;
+  lowPrice24h: string;
+  prevPrice24h: string;
+  volume24h: string;
+  turnover24h: string;
+  price24hPcnt: string;
+  usdIndexPrice: string;
+}
+⋮----
+export type WSTickerEventV5 = WSPublicTopicEventV5<
+  string,
+  'snapshot' | 'delta',
+  WSTickerV5 | WSTickerOptionV5 | WSTickerSpotV5
+>;
+⋮----
+export interface WSKlineV5 {
+  start: number;
+  end: number;
+  interval: string;
+  open: string;
+  close: string;
+  high: string;
+  low: string;
+  volume: string;
+  turnover: string;
+  confirm: boolean;
+  timestamp: number;
+}
+⋮----
+export type WSKlineEventV5 = WSPublicTopicEventV5<
+  string,
+  'snapshot',
+  WSKlineV5[]
+>;
+⋮----
+export interface WSLiquidationV5 {
+  T: number;
+  s: string;
+  S: OrderSideV5;
+  v: string;
+  p: string;
+}
+⋮----
+export type WSLiquidationEventV5 = WSPublicTopicEventV5<
+  string,
+  'snapshot',
+  WSLiquidationV5[]
+>;
+⋮----
+export interface WSPositionV5 {
+  category: string;
+  symbol: string;
+  side: PositionSideV5;
+  size: string;
+  positionIdx: PositionIdx;
+  tradeMode: TradeModeV5;
+  positionValue: string;
+  riskId: number;
+  riskLimitValue: string;
+  entryPrice: string;
+  markPrice: string;
+  leverage: string;
+  positionBalance: string;
+  autoAddMargin: number;
+  positionMM: string;
+  positionIM: string;
+  positionIMByMp: string;
+  positionMMByMp: string;
+  liqPrice: string;
+  bustPrice: string;
+  tpslMode: string;
+  takeProfit: string;
+  stopLoss: string;
+  trailingStop: string;
+  unrealisedPnl: string;
+  curRealisedPnl: string;
+  sessionAvgPrice: string;
+  delta: string;
+  gamma: string;
+  vega: string;
+  theta: string;
+  cumRealisedPnl: string;
+  positionStatus: PositionStatusV5;
+  adlRankIndicator: number;
+  isReduceOnly: boolean;
+  mmrSysUpdatedTime: string;
+  leverageSysUpdatedTime: string;
+  createdTime: string;
+  updatedTime: string;
+  seq: number;
+}
+⋮----
+export type WSPositionEventV5 = WSPrivateTopicEventV5<
+  'position',
+  WSPositionV5[]
+>;
+⋮----
+export interface WSAccountOrderV5 {
+  category: CategoryV5;
+  orderId: string;
+  orderLinkId: string;
+  isLeverage: string;
+  blockTradeId: string;
+  symbol: string;
+  price: string;
+  qty: string;
+  side: OrderSideV5;
+  positionIdx: PositionIdx;
+  orderStatus: OrderStatusV5;
+  createType: OrderCreateTypeV5;
+  cancelType: OrderCancelTypeV5;
+  rejectReason?: OrderRejectReasonV5;
+  avgPrice?: string;
+  leavesQty?: string;
+  leavesValue?: string;
+  cumExecQty: string;
+  cumExecValue: string;
+  cumExecFee: string;
+  closedPnl: string;
+  feeCurrency: string;
+  timeInForce: OrderTimeInForceV5;
+  orderType: OrderTypeV5;
+  stopOrderType: StopOrderTypeV5;
+  ocoTriggerType?: OCOTriggerTypeV5;
+  orderIv: string;
+  marketUnit?: 'baseCoin' | 'quoteCoin';
+  triggerPrice: string;
+  takeProfit: string;
+  stopLoss: string;
+  tpslMode?: TPSLModeV5;
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
+  tpTriggerBy: string;
+  slTriggerBy: string;
+  triggerDirection: number;
+  triggerBy: OrderTriggerByV5;
+  lastPriceOnCreated: string;
+  reduceOnly: boolean;
+  closeOnTrigger: boolean;
+  placeType: string;
+  smpType: OrderSMPTypeV5;
+  smpGroup: number;
+  smpOrderId: string;
+  createdTime: string;
+  updatedTime: string;
+  cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee and feeCurrency
+}
+⋮----
+cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee and feeCurrency
+⋮----
+export type WSAccountOrderEventV5 = WSPrivateTopicEventV5<
+  'order',
+  WSAccountOrderV5[]
+>;
+⋮----
+export interface WSExecutionV5 {
+  category: CategoryV5;
+  symbol: string;
+  isLeverage: string;
+  orderId: string;
+  orderLinkId: string;
+  side: OrderSideV5;
+  orderPrice: string;
+  orderQty: string;
+  leavesQty: string;
+  createType: OrderCreateTypeV5;
+  orderType: OrderTypeV5;
+  stopOrderType: StopOrderTypeV5;
+  execFee: string;
+  feeCurrency: string; // Trading fee currency
+  execId: string;
+  execPrice: string;
+  execQty: string;
+  execPnl: string;
+  execType: ExecTypeV5;
+  execValue: string;
+  execTime: string;
+  isMaker: boolean;
+  feeRate: string;
+  tradeIv: string;
+  markIv: string;
+  markPrice: string;
+  indexPrice: string;
+  underlyingPrice: string;
+  blockTradeId: string;
+  closedSize: string;
+  extraFees: string;
+  seq: number;
+  marketUnit: string;
+}
+⋮----
+feeCurrency: string; // Trading fee currency
+⋮----
+export type WSExecutionEventV5 = WSPrivateTopicEventV5<
+  'execution',
+  WSExecutionV5[]
+>;
+⋮----
+export interface WSExecutionFastV5 {
+  category: CategoryV5;
+  symbol: string;
+  execId: string;
+  execPrice: string;
+  execQty: string;
+  orderId: string;
+  isMaker: boolean;
+  orderLinkId: string;
+  side: OrderSideV5;
+  execTime: string;
+  seq: number;
+}
+⋮----
+export type WSExecutionFastEventV5 = WSPrivateTopicEventV5<
+  'execution.fast',
+  WSExecutionFastV5[]
+>;
+⋮----
+export interface WSCoinV5 {
+  coin: string;
+  equity: string;
+  usdValue: string;
+  walletBalance: string;
+  free?: string;
+  locked: string;
+  spotHedgingQty: string;
+  borrowAmount: string;
+  availableToBorrow: string;
+  availableToWithdraw: string;
+  accruedInterest: string;
+  totalOrderIM: string;
+  totalPositionIM: string;
+  totalPositionMM: string;
+  unrealisedPnl: string;
+  cumRealisedPnl: string;
+  bonus: string;
+  collateralSwitch: boolean;
+  marginCollateral: boolean;
+  spotBorrow: string;
+}
+⋮----
+export interface WSWalletV5 {
+  accountType: string;
+  accountLTV: string;
+  accountIMRate: string;
+  accountMMRate: string;
+  accountIMRateByMp: string;
+  accountMMRateByMp: string;
+  totalInitialMarginByMp: string;
+  totalMaintenanceMarginByMp: string;
+  totalEquity: string;
+  totalWalletBalance: string;
+  totalMarginBalance: string;
+  totalAvailableBalance: string;
+  totalPerpUPL: string;
+  totalInitialMargin: string;
+  totalMaintenanceMargin: string;
+  coin: WSCoinV5[];
+}
+⋮----
+export type WSWalletEventV5 = WSPrivateTopicEventV5<'wallet', WSWalletV5[]>;
+⋮----
+export interface WSGreeksV5 {
+  baseCoin: string;
+  totalDelta: string;
+  totalGamma: string;
+  totalVega: string;
+  totalTheta: string;
+}
+⋮----
+export type WSGreeksEventV5 = WSPrivateTopicEventV5<'greeks', WSGreeksV5[]>;
+⋮----
+export interface WSSpreadOrderV5 {
+  category: 'combination' | 'spot_leg' | 'future_leg';
+  symbol: string;
+  parentOrderId: string;
+  orderId: string;
+  orderLinkId: string;
+  side: OrderSideV5;
+  orderStatus: OrderStatusV5;
+  cancelType: OrderCancelTypeV5;
+  rejectReason: OrderRejectReasonV5;
+  timeInForce: OrderTimeInForceV5;
+  price: string;
+  qty: string;
+  avgPrice: string;
+  leavesQty: string;
+  leavesValue: string;
+  cumExecQty: string;
+  cumExecValue: string;
+  cumExecFee: string;
+  orderType: OrderTypeV5;
+  isLeverage: string;
+  createdTime: string;
+  updatedTime: string;
+  feeCurrency: string;
+  createType: OrderCreateTypeV5;
+  closedPnl: string;
+  cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee and feeCurrency
+}
+⋮----
+cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee and feeCurrency
+⋮----
+export type WSSpreadOrderEventV5 = WSPrivateTopicEventV5<
+  'spread.order',
+  WSSpreadOrderV5[]
+>;
+⋮----
+export interface WSSpreadExecutionV5 {
+  category: 'combination' | 'spot_leg' | 'future_leg';
+  symbol: string;
+  isLeverage: string;
+  orderId: string;
+  orderLinkId: string;
+  side: OrderSideV5;
+  orderPrice: string;
+  orderQty: string;
+  leavesQty: string;
+  createType: OrderCreateTypeV5;
+  orderType: OrderTypeV5;
+  execFee: string;
+  execFeeV2: string;
+  feeCurrency: string; // Trading fee currency
+  parentExecId: string;
+  execId: string;
+  execPrice: string;
+  execQty: string;
+  execPnl: string;
+  execType: ExecTypeV5;
+  execValue: string;
+  execTime: string;
+  isMaker: boolean;
+  feeRate: string;
+  markPrice: string;
+  closedSize: string;
+  seq: number;
+}
+⋮----
+feeCurrency: string; // Trading fee currency
+⋮----
+export type WSSpreadExecutionEventV5 = WSPrivateTopicEventV5<
+  'spread.execution',
+  WSSpreadExecutionV5[]
+>;
+⋮----
+export interface WSInsuranceV5 {
+  coin: string;
+  symbols: string;
+  balance: string;
+  updateTime: string;
+}
+⋮----
+export type WSInsuranceEventV5 = WSPublicTopicEventV5<
+  'insurance.USDT' | 'insurance.USDC' | 'insurance.inverse',
+  'snapshot' | 'delta',
+  WSInsuranceV5[]
+>;
+⋮----
+export interface WSPriceLimitV5 {
+  symbol: string;
+  buyLmt: string;
+  sellLmt: string;
+}
+⋮----
+export type WSPriceLimitEventV5 = WSPublicTopicEventV5<
+  string,
+  'snapshot',
+  WSPriceLimitV5
+>;
+⋮----
+export interface WSADLAlertV5 {
+  c: string; // Token of the insurance pool
+  s: string; // Trading pair name
+  b: string; // Balance of the insurance fund. Used to determine if ADL is triggered
+  mb: string; // Maximum balance of the insurance pool in the last 8 hours
+  i_pr: string; // PnL ratio threshold for triggering contract PnL drawdown ADL
+  pr: string; // Symbol's PnL drawdown ratio in the last 8 hours. Used to determine whether ADL is triggered or stopped
+  adl_tt: string; // Trigger threshold for contract PnL drawdown ADL
+  adl_sr: string; // Stop ratio threshold for contract PnL drawdown ADL
+}
+⋮----
+c: string; // Token of the insurance pool
+s: string; // Trading pair name
+b: string; // Balance of the insurance fund. Used to determine if ADL is triggered
+mb: string; // Maximum balance of the insurance pool in the last 8 hours
+i_pr: string; // PnL ratio threshold for triggering contract PnL drawdown ADL
+pr: string; // Symbol's PnL drawdown ratio in the last 8 hours. Used to determine whether ADL is triggered or stopped
+adl_tt: string; // Trigger threshold for contract PnL drawdown ADL
+adl_sr: string; // Stop ratio threshold for contract PnL drawdown ADL
+⋮----
+export type WSADLAlertEventV5 = WSPublicTopicEventV5<
+  'adlAlert.USDT' | 'adlAlert.USDC' | 'adlAlert.inverse',
+  'snapshot',
+  WSADLAlertV5[]
+>;
+⋮----
+export type WSSystemStatusEventV5 = WSPublicTopicEventV5<
+  'system.status',
+  'snapshot',
+  SystemStatusItemV5[]
+>;
+⋮----
+/**
+ * RFQ WebSocket Events
+ */
+⋮----
+/**
+ * RFQ Inquiry Channel
+ * Private push for RFQ inquiries sent or received by the user
+ * Topics: rfq.open.rfqs, rfq.site.rfqs
+ */
+export type WSRFQInquiryEventV5 = WSPrivateTopicEventV5<
+  'rfq.open.rfqs' | 'rfq.site.rfqs',
+  RFQItemV5[]
+>;
+⋮----
+/**
+ * RFQ Quote Channel
+ * Private push for quotes sent or received by the user
+ * Topics: rfq.open.quotes, rfq.site.quotes
+ */
+export type WSRFQQuoteEventV5 = WSPrivateTopicEventV5<
+  'rfq.open.quotes' | 'rfq.site.quotes',
+  RFQQuoteItemV5[]
+>;
+⋮----
+/**
+ * RFQ Trade Channel
+ * Private push for block trades executed by the user
+ * Topics: rfq.open.trades, rfq.site.trades
+ */
+export type WSRFQTradeEventV5 = WSPrivateTopicEventV5<
+  'rfq.open.trades' | 'rfq.site.trades',
+  RFQTradeV5[]
+>;
+⋮----
+/**
+ * RFQ Public Trade Channel
+ * Public push for all block trades
+ * Topics: rfq.open.public.trades, rfq.site.public.trades
+ */
+export type WSRFQPublicTradeEventV5 = WSPublicTopicEventV5<
+  'rfq.open.public.trades' | 'rfq.site.public.trades',
+  'snapshot',
+  RFQPublicTradeV5[]
+>;
+
+================
+File: src/types/request/v5-crypto-loan.ts
+================
+export interface BorrowCryptoLoanParamsV5 {
+  loanCurrency: string;
+  loanAmount?: string;
+  loanTerm?: string;
+  collateralCurrency: string;
+  collateralAmount?: string;
+}
+⋮----
+export interface GetUnpaidLoanOrdersParamsV5 {
+  orderId?: string;
+  loanCurrency?: string;
+  collateralCurrency?: string;
+  loanTermType?: string;
+  loanTerm?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface GetRepaymentHistoryParamsV5 {
+  orderId?: string;
+  repayId?: string;
+  loanCurrency?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface GetCompletedLoanOrderHistoryParamsV5 {
+  orderId?: string;
+  loanCurrency?: string;
+  collateralCurrency?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface GetLoanLTVAdjustmentHistoryParamsV5 {
+  orderId?: string;
+  adjustId?: string;
+  collateralCurrency?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+// New Crypto Loan Request Types
+⋮----
+export interface GetBorrowableCoinsParamsV5 {
+  vipLevel?: string;
+  currency?: string;
+}
+⋮----
+export interface GetCollateralCoinsParamsV5 {
+  currency?: string;
+}
+⋮----
+export interface GetMaxCollateralAmountParamsV5 {
+  currency: string;
+}
+⋮----
+export interface AdjustCollateralAmountParamsV5 {
+  currency: string;
+  amount: string;
+  direction: '0' | '1';
+}
+⋮----
+export interface GetCollateralAdjustmentHistoryParamsV5 {
+  adjustId?: string;
+  collateralCurrency?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+// Flexible Loan Request Types
+⋮----
+export interface BorrowFlexibleParamsV5 {
+  loanCurrency: string;
+  loanAmount: string;
+  collateralList?: {
+    currency: string;
+    amount: string;
+  }[];
+}
+⋮----
+export interface RepayFlexibleParamsV5 {
+  loanCurrency: string;
+  amount: string;
+}
+⋮----
+export interface RepayCollateralFlexibleParamsV5 {
+  loanCurrency: string;
+  collateralCoin: string;
+  amount: string;
+}
+⋮----
+export interface GetOngoingFlexibleLoansParamsV5 {
+  loanCurrency?: string;
+}
+⋮----
+export interface GetBorrowHistoryFlexibleParamsV5 {
+  orderId?: string;
+  loanCurrency?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface GetRepaymentHistoryFlexibleParamsV5 {
+  repayId?: string;
+  loanCurrency?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+// Fixed Loan Request Types
+⋮----
+export interface GetSupplyOrderQuoteFixedParamsV5 {
+  orderCurrency: string;
+  term?: string;
+  orderBy: 'apy' | 'term' | 'quantity';
+  sort?: number;
+  limit?: number;
+}
+⋮----
+export interface GetBorrowOrderQuoteFixedParamsV5 {
+  orderCurrency: string;
+  term?: string;
+  orderBy: 'apy' | 'term' | 'quantity';
+  sort?: number;
+  limit?: number;
+}
+⋮----
+export interface CreateBorrowOrderFixedParamsV5 {
+  orderCurrency: string;
+  orderAmount: string;
+  annualRate: string;
+  term: string;
+  autoRepay?: string; // Deprecated
+  repayType?: string; // 1: Auto Repayment (default); 2: Transfer to flexible loan
+  collateralList?: {
+    currency: string;
+    amount: string;
+  }[];
+}
+⋮----
+autoRepay?: string; // Deprecated
+repayType?: string; // 1: Auto Repayment (default); 2: Transfer to flexible loan
+⋮----
+export interface CreateSupplyOrderFixedParamsV5 {
+  orderCurrency: string;
+  orderAmount: string;
+  annualRate: string;
+  term: string;
+}
+⋮----
+export interface CancelBorrowOrderFixedParamsV5 {
+  orderId: string;
+}
+⋮----
+export interface CancelSupplyOrderFixedParamsV5 {
+  orderId: string;
+}
+⋮----
+export interface GetBorrowContractInfoFixedParamsV5 {
+  orderId?: string;
+  loanId?: string;
+  orderCurrency?: string;
+  term?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface GetSupplyContractInfoFixedParamsV5 {
+  orderId?: string;
+  supplyId?: string;
+  supplyCurrency?: string;
+  term?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface GetBorrowOrderInfoFixedParamsV5 {
+  orderId?: string;
+  orderCurrency?: string;
+  state?: string;
+  term?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface GetSupplyOrderInfoFixedParamsV5 {
+  orderId?: string;
+  orderCurrency?: string;
+  state?: string;
+  term?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface RepayFixedParamsV5 {
+  loanId?: string;
+  loanCurrency?: string;
+}
+⋮----
+export interface RepayCollateralFixedParamsV5 {
+  loanCurrency: string;
+  collateralCoin: string;
+  amount: string;
+}
+⋮----
+export interface GetRepaymentHistoryFixedParamsV5 {
+  repayId?: string;
+  loanCurrency?: string;
+  limit?: string;
+  cursor?: string;
+}
+
+================
 File: src/rest-client-v5.ts
 ================
 /* eslint-disable max-len */
@@ -14305,6 +11071,7 @@ import {
   AccountBorrowCollateralLimitV5,
   AccountCoinBalanceV5,
   AccountInfoV5,
+  AccountInstrumentInfoResponseV5,
   AccountMarginModeV5,
   AccountOrderV5,
   AccountTypeV5,
@@ -14323,6 +11090,7 @@ import {
   APIResponseV3,
   APIResponseV3WithTime,
   AssetInfoV5,
+  AvailableAmountToRepayV5,
   BatchAmendOrderParamsV5,
   BatchAmendOrderResultV5,
   BatchCancelOrderParamsV5,
@@ -14360,6 +11128,7 @@ import {
   CoinExchangeRecordV5,
   CoinGreeksV5,
   CoinInfoV5,
+  CoinStateV5,
   CollateralAdjustmentHistoryV5,
   CollateralDataV5,
   CollateralInfoV5,
@@ -14384,6 +11153,7 @@ import {
   CreateSupplyOrderFixedParamsV5,
   CreateSupplyOrderFixedV5,
   CryptoLoanPositionV5,
+  CurrencyPositionTiersV5,
   CursorListV5,
   CursorRowsV5,
   DCPInfoV5,
@@ -14392,9 +11162,11 @@ import {
   DeliveryRecordV5,
   DepositAddressChainV5,
   DepositRecordV5,
+  EarnHourlyYieldHistoryV5,
   EarnOrderHistoryV5,
   EarnPositionV5,
   EarnProductV5,
+  EarnYieldHistoryV5,
   ExchangeBrokerAccountInfoV5,
   ExchangeBrokerEarningResultV5,
   ExchangeBrokerSubAccountDepositRecordV5,
@@ -14406,11 +11178,13 @@ import {
   FundingRateHistoryResponseV5,
   GetAccountCoinBalanceParamsV5,
   GetAccountHistoricOrdersParamsV5,
+  GetAccountInstrumentsInfoParamsV5,
   GetAccountOrdersParamsV5,
   GetADLAlertParamsV5,
   GetAllCoinsBalanceParamsV5,
   GetAllowedDepositCoinInfoParamsV5,
   GetAssetInfoParamsV5,
+  GetAvailableAmountToRepayParamsV5,
   GetBorrowableCoinsParamsV5,
   GetBorrowContractInfoFixedParamsV5,
   GetBorrowHistoryFlexibleParamsV5,
@@ -14423,6 +11197,7 @@ import {
   GetClosedOptionsPositionsParamsV5,
   GetClosedPnLParamsV5,
   GetCoinExchangeRecordParamsV5,
+  GetCoinStateParamsV5,
   GetCollateralAdjustmentHistoryParamsV5,
   GetCollateralCoinsParamsV5,
   GetCompletedLoanOrderHistoryParamsV5,
@@ -14430,8 +11205,10 @@ import {
   GetDeliveryPriceParamsV5,
   GetDeliveryRecordParamsV5,
   GetDepositRecordParamsV5,
+  GetEarnHourlyYieldHistoryParamsV5,
   GetEarnOrderHistoryParamsV5,
   GetEarnPositionParamsV5,
+  GetEarnYieldHistoryParamsV5,
   GetExchangeBrokerEarningsParamsV5,
   GetExecutionListParamsV5,
   GetFeeGroupStructureParamsV5,
@@ -14448,6 +11225,7 @@ import {
   GetLoanLTVAdjustmentHistoryParamsV5,
   GetLongShortRatioParamsV5,
   GetMarkPriceKlineParamsV5,
+  GetMaxBorrowableAmountParamsV5,
   GetMaxCollateralAmountParamsV5,
   GetMovePositionHistoryParamsV5,
   GetOngoingFlexibleLoansParamsV5,
@@ -14461,6 +11239,7 @@ import {
   GetP2POrdersParamsV5,
   GetP2PPendingOrdersParamsV5,
   GetP2PPersonalAdsParamsV5,
+  GetPositionTiersParamsV5,
   GetPremiumIndexPriceKlineParamsV5,
   GetPreUpgradeClosedPnlParamsV5,
   GetPreUpgradeOptionDeliveryRecordParamsV5,
@@ -14498,6 +11277,7 @@ import {
   GetUnpaidLoanOrdersParamsV5,
   GetVIPMarginDataParamsV5,
   GetWalletBalanceParamsV5,
+  GetWithdrawalAddressListParamsV5,
   GetWithdrawalRecordsParamsV5,
   HistoricalVolatilityV5,
   IndexPriceComponentsResponseV5,
@@ -14508,7 +11288,14 @@ import {
   IssueVoucherParamsV5,
   LoanLTVAdjustmentHistoryV5,
   LongShortRatioV5,
+  ManualBorrowParamsV5,
+  ManualBorrowResultV5,
+  ManualRepayParamsV5,
+  ManualRepayResultV5,
+  ManualRepayWithoutConversionParamsV5,
+  ManualRepayWithoutConversionResultV5,
   MarkP2POrderAsPaidParamsV5,
+  MaxBorrowableAmountV5,
   MMPModifyParamsV5,
   MMPStateV5,
   MovePositionHistoryV5,
@@ -14568,6 +11355,7 @@ import {
   SetLimitPriceActionParamsV5,
   SetRiskLimitParamsV5,
   SetRiskLimitResultV5,
+  SetSpotMarginLeverageParamsV5,
   SettlementRecordV5,
   SetTPSLModeParamsV5,
   SetTradingStopParamsV5,
@@ -14607,6 +11395,7 @@ import {
   VIPMarginDataV5,
   WalletBalanceV5,
   WithdrawableAmountV5,
+  WithdrawalAddressV5,
   WithdrawalRecordV5,
   WithdrawParamsV5,
 } from './types';
@@ -15573,6 +12362,18 @@ getTransferableAmount(params: { coinName: string }): Promise<
     return this.getPrivate('/v5/account/withdrawal', params);
 ⋮----
 /**
+   * Get Account Instruments Info
+   * Query for the instrument specification of online trading pairs that available to users.
+   *
+   * Covers: SPOT / USDT contract / USDC contract / Inverse contract
+   *
+   * Includes RPI permission information (isPublicRpi, myRpiPermission)
+   */
+getAccountInstrumentsInfo<C extends 'spot' | 'linear' | 'inverse'>(
+    params: GetAccountInstrumentsInfoParamsV5 & { category: C },
+): Promise<APIResponseV3WithTime<AccountInstrumentInfoResponseV5<C>>>
+⋮----
+/**
    * Upgrade to unified account.
    *
    * Banned/OTC loan/Net asset unsatisfying/Express path users cannot upgrade the account to Unified Account for now.
@@ -15602,6 +12403,21 @@ getBorrowHistory(
 repayLiability(
     params?: RepayLiabilityParamsV5,
 ): Promise<APIResponseV3WithTime<CursorListV5<RepayLiabilityResultV5[]>>>
+⋮----
+/**
+   * Manual Repay
+   *
+   * If neither coin nor amount is passed, then repay all the liabilities.
+   * If coin is passed and amount is not, the coin will be repaid in full.
+   *
+   * When repaying, the system will first use the spot available balance of the debt currency.
+   * If that's not enough, the remaining amount will be repaid by converting other assets.
+   *
+   * Repayment is prohibited between 04:00 and 05:30 per hour.
+   */
+manualRepay(
+    params?: ManualRepayParamsV5,
+): Promise<APIResponseV3WithTime<ManualRepayResultV5>>
 ⋮----
 /**
    * You can decide whether the assets in the Unified account needs to be collateral coins.
@@ -16040,6 +12856,20 @@ getWithdrawalRecords(
 ): Promise<APIResponseV3<CursorRowsV5<WithdrawalRecordV5[]>>>
 ⋮----
 /**
+   * Get Withdrawal Address List
+   * Query the withdrawal addresses in the address book.
+   *
+   * TIP: The API key for querying this endpoint must have withdrawal permissions.
+   */
+getWithdrawalAddressList(params?: GetWithdrawalAddressListParamsV5): Promise<
+    APIResponseV3WithTime<{
+      rows: WithdrawalAddressV5[];
+      nextPageCursor: string;
+    }>
+  > {
+    return this.getPrivate('/v5/asset/withdraw/query-address', params);
+⋮----
+/**
    * Get Exchange Entity List.
    *
    * This endpoint is particularly used for kyc=KOR users. When withdraw funds, you need to fill entity id.
@@ -16285,7 +13115,15 @@ deleteSubApiKey(params?: {
    * - Use master UID only
    * - The api key can only have "Affiliate" permission
    */
-getAffiliateUserList(params?: { size?: number; cursor?: string }): Promise<
+getAffiliateUserList(params?: {
+    size?: number;
+    cursor?: string;
+    needDeposit?: boolean;
+    need30?: boolean;
+    need365?: boolean;
+    startDate?: string;
+    endDate?: string;
+  }): Promise<
     APIResponseV3WithTime<{
       list: AffiliateUserListItemV5[];
       nextPageCursor: string;
@@ -16364,7 +13202,9 @@ toggleSpotMarginTrade(
    * Set the user's maximum leverage in spot cross margin.
    * CAUTION: Your account needs to enable spot margin first; i.e., you must have finished the quiz on web / app.
    */
-setSpotMarginLeverage(leverage: string): Promise<APIResponseV3WithTime<
+setSpotMarginLeverage(
+    params: SetSpotMarginLeverageParamsV5,
+): Promise<APIResponseV3WithTime<
 ⋮----
 /**
    * Query the Spot margin status and leverage of Unified account.
@@ -16372,6 +13212,57 @@ setSpotMarginLeverage(leverage: string): Promise<APIResponseV3WithTime<
    * Covers: Margin trade (Unified Account)
    */
 getSpotMarginState(): Promise<APIResponseV3WithTime<SpotMarginStateV5>>
+⋮----
+/**
+   * Manual borrow for UTA
+   */
+manualBorrow(
+    params: ManualBorrowParamsV5,
+): Promise<APIResponseV3WithTime<ManualBorrowResultV5>>
+⋮----
+/**
+   * Get max borrowable amount
+   */
+getMaxBorrowableAmount(
+    params: GetMaxBorrowableAmountParamsV5,
+): Promise<APIResponseV3WithTime<MaxBorrowableAmountV5>>
+⋮----
+/**
+   * Get loan position risk information (position tiers)
+   */
+getPositionTiers(params?: GetPositionTiersParamsV5): Promise<
+    APIResponseV3WithTime<{
+      list: CurrencyPositionTiersV5[];
+    }>
+  > {
+    return this.getPrivate('/v5/spot-margin-trade/position-tiers', params);
+⋮----
+/**
+   * Get currency leverage information (coin state)
+   */
+getCoinState(params?: GetCoinStateParamsV5): Promise<
+    APIResponseV3WithTime<{
+      list: CoinStateV5[];
+    }>
+  > {
+    return this.getPrivate('/v5/spot-margin-trade/coinstate', params);
+⋮----
+/**
+   * Get available amount to repay
+   */
+getAvailableAmountToRepay(
+    params: GetAvailableAmountToRepayParamsV5,
+): Promise<APIResponseV3WithTime<AvailableAmountToRepayV5>>
+⋮----
+/**
+   * Manual repay without asset conversion
+   *
+   * IMPORTANT: Repayment is prohibited between 04:00 and 05:30 per hour.
+   * When repaying, system will only use the spot available balance of the debt currency.
+   */
+manualRepayWithoutConversion(
+    params: ManualRepayWithoutConversionParamsV5,
+): Promise<APIResponseV3WithTime<ManualRepayWithoutConversionResultV5>>
 ⋮----
 /**
    *
@@ -17239,12 +14130,15 @@ submitStakeRedeem(params: SubmitStakeRedeemParamsV5): Promise<
    *
    * INFO: API key needs "Earn" permission
    *
-   * Note: Either orderId or orderLinkId is required. If both are passed,
-   * make sure they're matched, otherwise returning empty result
+   * Note:
+   * - For category = OnChain, either orderId or orderLinkId is required
+   * - If both are passed, make sure they're matched, otherwise returning empty result
+   * - Supports batch query with productId, startTime, endTime, limit, cursor
    */
 getEarnOrderHistory(params: GetEarnOrderHistoryParamsV5): Promise<
     APIResponseV3WithTime<{
       list: EarnOrderHistoryV5[];
+      nextPageCursor: string;
     }>
   > {
     return this.getPrivate('/v5/earn/order', params);
@@ -17262,6 +14156,32 @@ getEarnPosition(params: GetEarnPositionParamsV5): Promise<
     }>
   > {
     return this.getPrivate('/v5/earn/position', params);
+⋮----
+/**
+   * Get Yield History
+   *
+   * INFO: API key needs "Earn" permission
+   */
+getEarnYieldHistory(params: GetEarnYieldHistoryParamsV5): Promise<
+    APIResponseV3WithTime<{
+      yield: EarnYieldHistoryV5[];
+      nextPageCursor: string;
+    }>
+  > {
+    return this.getPrivate('/v5/earn/yield', params);
+⋮----
+/**
+   * Get Hourly Yield History
+   *
+   * INFO: API key needs "Earn" permission
+   */
+getEarnHourlyYieldHistory(params: GetEarnHourlyYieldHistoryParamsV5): Promise<
+    APIResponseV3WithTime<{
+      list: EarnHourlyYieldHistoryV5[];
+      nextPageCursor: string;
+    }>
+  > {
+    return this.getPrivate('/v5/earn/hourly-yield', params);
 ⋮----
 /**
    *
@@ -17546,13 +14466,30 @@ sendP2POrderMessage(
 ): Promise<APIResponseV3WithTime<null>>
 ⋮----
 /**
-   * Upload chat file for P2P order
+   * Upload chat file for P2P order (Node.js only)
+   *
+   * Note: You must provide a Buffer. To upload from a file path, read it into a Buffer first:
+   * ```typescript
+   * import fs from 'fs';
+   * const buffer = fs.readFileSync('./path/to/file.png');
+   * await client.uploadP2PChatFile({ fileBuffer: buffer, fileName: 'file.png' });
+   * ```
+   *
+   * Supported file types: jpg, png, jpeg, pdf, mp4
    */
 uploadP2PChatFile(params: {
-    upload_file: File; // Only supports: jpg, png, jpeg, pdf, mp4
-}): Promise<APIResponseV3WithTime<null>>
+    fileBuffer: Buffer;
+    fileName: string; // Required: the filename (used for MIME type detection)
+  }): Promise<
+    APIResponseV3WithTime<{
+      url: string;
+      type: string;
+      uploadId: string | null;
+    }>
+  > {
+    return this.postPrivateFile('/v5/p2p/oss/upload_file', params);
 ⋮----
-upload_file: File; // Only supports: jpg, png, jpeg, pdf, mp4
+fileName: string; // Required: the filename (used for MIME type detection)
 ⋮----
 /**
    * Get chat messages in a P2P order
@@ -17684,7 +14621,7 @@ File: package.json
 ================
 {
   "name": "bybit-api",
-  "version": "4.3.2",
+  "version": "4.4.2",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bybit-api",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bybit-api",
-      "version": "4.4.1",
+      "version": "4.4.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -2456,7 +2456,6 @@ export class RestClientV5 extends BaseRestClient {
   /**
    * Set the user's maximum leverage in spot cross margin.
    * CAUTION: Your account needs to enable spot margin first; i.e., you must have finished the quiz on web / app.
-   * @deprecated Use setSpotMarginLeverageV2() instead
    */
   setSpotMarginLeverageV2(
     params: SetSpotMarginLeverageParamsV5,

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -4,6 +4,7 @@ import {
   AccountBorrowCollateralLimitV5,
   AccountCoinBalanceV5,
   AccountInfoV5,
+  AccountInstrumentInfoResponseV5,
   AccountMarginModeV5,
   AccountOrderV5,
   AccountTypeV5,
@@ -22,6 +23,7 @@ import {
   APIResponseV3,
   APIResponseV3WithTime,
   AssetInfoV5,
+  AvailableAmountToRepayV5,
   BatchAmendOrderParamsV5,
   BatchAmendOrderResultV5,
   BatchCancelOrderParamsV5,
@@ -59,6 +61,7 @@ import {
   CoinExchangeRecordV5,
   CoinGreeksV5,
   CoinInfoV5,
+  CoinStateV5,
   CollateralAdjustmentHistoryV5,
   CollateralDataV5,
   CollateralInfoV5,
@@ -83,6 +86,7 @@ import {
   CreateSupplyOrderFixedParamsV5,
   CreateSupplyOrderFixedV5,
   CryptoLoanPositionV5,
+  CurrencyPositionTiersV5,
   CursorListV5,
   CursorRowsV5,
   DCPInfoV5,
@@ -91,9 +95,11 @@ import {
   DeliveryRecordV5,
   DepositAddressChainV5,
   DepositRecordV5,
+  EarnHourlyYieldHistoryV5,
   EarnOrderHistoryV5,
   EarnPositionV5,
   EarnProductV5,
+  EarnYieldHistoryV5,
   ExchangeBrokerAccountInfoV5,
   ExchangeBrokerEarningResultV5,
   ExchangeBrokerSubAccountDepositRecordV5,
@@ -105,11 +111,14 @@ import {
   FundingRateHistoryResponseV5,
   GetAccountCoinBalanceParamsV5,
   GetAccountHistoricOrdersParamsV5,
+  GetAccountInstrumentsInfoParamsV5,
   GetAccountOrdersParamsV5,
   GetADLAlertParamsV5,
+  GetAffiliateUserListParamsV5,
   GetAllCoinsBalanceParamsV5,
   GetAllowedDepositCoinInfoParamsV5,
   GetAssetInfoParamsV5,
+  GetAvailableAmountToRepayParamsV5,
   GetBorrowableCoinsParamsV5,
   GetBorrowContractInfoFixedParamsV5,
   GetBorrowHistoryFlexibleParamsV5,
@@ -122,6 +131,7 @@ import {
   GetClosedOptionsPositionsParamsV5,
   GetClosedPnLParamsV5,
   GetCoinExchangeRecordParamsV5,
+  GetCoinStateParamsV5,
   GetCollateralAdjustmentHistoryParamsV5,
   GetCollateralCoinsParamsV5,
   GetCompletedLoanOrderHistoryParamsV5,
@@ -129,8 +139,10 @@ import {
   GetDeliveryPriceParamsV5,
   GetDeliveryRecordParamsV5,
   GetDepositRecordParamsV5,
+  GetEarnHourlyYieldHistoryParamsV5,
   GetEarnOrderHistoryParamsV5,
   GetEarnPositionParamsV5,
+  GetEarnYieldHistoryParamsV5,
   GetExchangeBrokerEarningsParamsV5,
   GetExecutionListParamsV5,
   GetFeeGroupStructureParamsV5,
@@ -147,6 +159,7 @@ import {
   GetLoanLTVAdjustmentHistoryParamsV5,
   GetLongShortRatioParamsV5,
   GetMarkPriceKlineParamsV5,
+  GetMaxBorrowableAmountParamsV5,
   GetMaxCollateralAmountParamsV5,
   GetMovePositionHistoryParamsV5,
   GetOngoingFlexibleLoansParamsV5,
@@ -160,6 +173,7 @@ import {
   GetP2POrdersParamsV5,
   GetP2PPendingOrdersParamsV5,
   GetP2PPersonalAdsParamsV5,
+  GetPositionTiersParamsV5,
   GetPremiumIndexPriceKlineParamsV5,
   GetPreUpgradeClosedPnlParamsV5,
   GetPreUpgradeOptionDeliveryRecordParamsV5,
@@ -197,6 +211,7 @@ import {
   GetUnpaidLoanOrdersParamsV5,
   GetVIPMarginDataParamsV5,
   GetWalletBalanceParamsV5,
+  GetWithdrawalAddressListParamsV5,
   GetWithdrawalRecordsParamsV5,
   HistoricalVolatilityV5,
   IndexPriceComponentsResponseV5,
@@ -207,7 +222,14 @@ import {
   IssueVoucherParamsV5,
   LoanLTVAdjustmentHistoryV5,
   LongShortRatioV5,
+  ManualBorrowParamsV5,
+  ManualBorrowResultV5,
+  ManualRepayParamsV5,
+  ManualRepayResultV5,
+  ManualRepayWithoutConversionParamsV5,
+  ManualRepayWithoutConversionResultV5,
   MarkP2POrderAsPaidParamsV5,
+  MaxBorrowableAmountV5,
   MMPModifyParamsV5,
   MMPStateV5,
   MovePositionHistoryV5,
@@ -267,6 +289,7 @@ import {
   SetLimitPriceActionParamsV5,
   SetRiskLimitParamsV5,
   SetRiskLimitResultV5,
+  SetSpotMarginLeverageParamsV5,
   SettlementRecordV5,
   SetTPSLModeParamsV5,
   SetTradingStopParamsV5,
@@ -306,6 +329,7 @@ import {
   VIPMarginDataV5,
   WalletBalanceV5,
   WithdrawableAmountV5,
+  WithdrawalAddressV5,
   WithdrawalRecordV5,
   WithdrawParamsV5,
 } from './types';
@@ -1445,6 +1469,20 @@ export class RestClientV5 extends BaseRestClient {
   }
 
   /**
+   * Get Account Instruments Info
+   * Query for the instrument specification of online trading pairs that available to users.
+   *
+   * Covers: SPOT / USDT contract / USDC contract / Inverse contract
+   *
+   * Includes RPI permission information (isPublicRpi, myRpiPermission)
+   */
+  getAccountInstrumentsInfo<C extends 'spot' | 'linear' | 'inverse'>(
+    params: GetAccountInstrumentsInfoParamsV5 & { category: C },
+  ): Promise<APIResponseV3WithTime<AccountInstrumentInfoResponseV5<C>>> {
+    return this.getPrivate('/v5/account/instruments-info', params);
+  }
+
+  /**
    * Upgrade to unified account.
    *
    * Banned/OTC loan/Net asset unsatisfying/Express path users cannot upgrade the account to Unified Account for now.
@@ -1478,6 +1516,23 @@ export class RestClientV5 extends BaseRestClient {
     params?: RepayLiabilityParamsV5,
   ): Promise<APIResponseV3WithTime<CursorListV5<RepayLiabilityResultV5[]>>> {
     return this.postPrivate('/v5/account/quick-repayment', params);
+  }
+
+  /**
+   * Manual Repay
+   *
+   * If neither coin nor amount is passed, then repay all the liabilities.
+   * If coin is passed and amount is not, the coin will be repaid in full.
+   *
+   * When repaying, the system will first use the spot available balance of the debt currency.
+   * If that's not enough, the remaining amount will be repaid by converting other assets.
+   *
+   * Repayment is prohibited between 04:00 and 05:30 per hour.
+   */
+  manualRepay(
+    params?: ManualRepayParamsV5,
+  ): Promise<APIResponseV3WithTime<ManualRepayResultV5>> {
+    return this.postPrivate('/v5/account/repay', params);
   }
 
   /**
@@ -2013,6 +2068,21 @@ export class RestClientV5 extends BaseRestClient {
   }
 
   /**
+   * Get Withdrawal Address List
+   * Query the withdrawal addresses in the address book.
+   *
+   * TIP: The API key for querying this endpoint must have withdrawal permissions.
+   */
+  getWithdrawalAddressList(params?: GetWithdrawalAddressListParamsV5): Promise<
+    APIResponseV3WithTime<{
+      rows: WithdrawalAddressV5[];
+      nextPageCursor: string;
+    }>
+  > {
+    return this.getPrivate('/v5/asset/withdraw/query-address', params);
+  }
+
+  /**
    * Get Exchange Entity List.
    *
    * This endpoint is particularly used for kyc=KOR users. When withdraw funds, you need to fill entity id.
@@ -2291,7 +2361,7 @@ export class RestClientV5 extends BaseRestClient {
    * - Use master UID only
    * - The api key can only have "Affiliate" permission
    */
-  getAffiliateUserList(params?: { size?: number; cursor?: string }): Promise<
+  getAffiliateUserList(params?: GetAffiliateUserListParamsV5): Promise<
     APIResponseV3WithTime<{
       list: AffiliateUserListItemV5[];
       nextPageCursor: string;
@@ -2380,8 +2450,10 @@ export class RestClientV5 extends BaseRestClient {
    * Set the user's maximum leverage in spot cross margin.
    * CAUTION: Your account needs to enable spot margin first; i.e., you must have finished the quiz on web / app.
    */
-  setSpotMarginLeverage(leverage: string): Promise<APIResponseV3WithTime<{}>> {
-    return this.postPrivate('/v5/spot-margin-trade/set-leverage', { leverage });
+  setSpotMarginLeverage(
+    params: SetSpotMarginLeverageParamsV5,
+  ): Promise<APIResponseV3WithTime<{}>> {
+    return this.postPrivate('/v5/spot-margin-trade/set-leverage', params);
   }
 
   /**
@@ -2391,6 +2463,70 @@ export class RestClientV5 extends BaseRestClient {
    */
   getSpotMarginState(): Promise<APIResponseV3WithTime<SpotMarginStateV5>> {
     return this.getPrivate('/v5/spot-margin-trade/state');
+  }
+
+  /**
+   * Manual borrow for UTA
+   */
+  manualBorrow(
+    params: ManualBorrowParamsV5,
+  ): Promise<APIResponseV3WithTime<ManualBorrowResultV5>> {
+    return this.postPrivate('/v5/account/borrow', params);
+  }
+
+  /**
+   * Get max borrowable amount
+   */
+  getMaxBorrowableAmount(
+    params: GetMaxBorrowableAmountParamsV5,
+  ): Promise<APIResponseV3WithTime<MaxBorrowableAmountV5>> {
+    return this.getPrivate('/v5/spot-margin-trade/max-borrowable', params);
+  }
+
+  /**
+   * Get loan position risk information (position tiers)
+   */
+  getPositionTiers(params?: GetPositionTiersParamsV5): Promise<
+    APIResponseV3WithTime<{
+      list: CurrencyPositionTiersV5[];
+    }>
+  > {
+    return this.getPrivate('/v5/spot-margin-trade/position-tiers', params);
+  }
+
+  /**
+   * Get currency leverage information (coin state)
+   */
+  getCoinState(params?: GetCoinStateParamsV5): Promise<
+    APIResponseV3WithTime<{
+      list: CoinStateV5[];
+    }>
+  > {
+    return this.getPrivate('/v5/spot-margin-trade/coinstate', params);
+  }
+
+  /**
+   * Get available amount to repay
+   */
+  getAvailableAmountToRepay(
+    params: GetAvailableAmountToRepayParamsV5,
+  ): Promise<APIResponseV3WithTime<AvailableAmountToRepayV5>> {
+    return this.getPrivate(
+      '/v5/spot-margin-trade/repayment-available-amount',
+      params,
+    );
+  }
+
+  /**
+   * Manual repay without asset conversion
+   *
+   * IMPORTANT: Repayment is prohibited between 04:00 and 05:30 per hour.
+   * When repaying, system will only use the spot available balance of the debt currency.
+   */
+  manualRepayWithoutConversion(
+    params: ManualRepayWithoutConversionParamsV5,
+  ): Promise<APIResponseV3WithTime<ManualRepayWithoutConversionResultV5>> {
+    return this.postPrivate('/v5/account/no-convert-repay', params);
   }
 
   /**
@@ -3357,12 +3493,15 @@ export class RestClientV5 extends BaseRestClient {
    *
    * INFO: API key needs "Earn" permission
    *
-   * Note: Either orderId or orderLinkId is required. If both are passed,
-   * make sure they're matched, otherwise returning empty result
+   * Note:
+   * - For category = OnChain, either orderId or orderLinkId is required
+   * - If both are passed, make sure they're matched, otherwise returning empty result
+   * - Supports batch query with productId, startTime, endTime, limit, cursor
    */
   getEarnOrderHistory(params: GetEarnOrderHistoryParamsV5): Promise<
     APIResponseV3WithTime<{
       list: EarnOrderHistoryV5[];
+      nextPageCursor: string;
     }>
   > {
     return this.getPrivate('/v5/earn/order', params);
@@ -3381,6 +3520,34 @@ export class RestClientV5 extends BaseRestClient {
     }>
   > {
     return this.getPrivate('/v5/earn/position', params);
+  }
+
+  /**
+   * Get Yield History
+   *
+   * INFO: API key needs "Earn" permission
+   */
+  getEarnYieldHistory(params: GetEarnYieldHistoryParamsV5): Promise<
+    APIResponseV3WithTime<{
+      yield: EarnYieldHistoryV5[];
+      nextPageCursor: string;
+    }>
+  > {
+    return this.getPrivate('/v5/earn/yield', params);
+  }
+
+  /**
+   * Get Hourly Yield History
+   *
+   * INFO: API key needs "Earn" permission
+   */
+  getEarnHourlyYieldHistory(params: GetEarnHourlyYieldHistoryParamsV5): Promise<
+    APIResponseV3WithTime<{
+      list: EarnHourlyYieldHistoryV5[];
+      nextPageCursor: string;
+    }>
+  > {
+    return this.getPrivate('/v5/earn/hourly-yield', params);
   }
 
   /**

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -2447,7 +2447,7 @@ export class RestClientV5 extends BaseRestClient {
   }
 
   /**
-   * @deprecated Use setSpotMarginLeverageV2 instead
+   * @deprecated Use setSpotMarginLeverageV2 instead, which uses an object parameter instead. This method will be replaced by setSpotMarginLeverageV2 in a future release.
    */
   setSpotMarginLeverage(leverage: string): Promise<APIResponseV3WithTime<{}>> {
     return this.postPrivate('/v5/spot-margin-trade/set-leverage', { leverage });

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -2447,10 +2447,18 @@ export class RestClientV5 extends BaseRestClient {
   }
 
   /**
+   * @deprecated Use setSpotMarginLeverageV2 instead
+   */
+  setSpotMarginLeverage(leverage: string): Promise<APIResponseV3WithTime<{}>> {
+    return this.postPrivate('/v5/spot-margin-trade/set-leverage', { leverage });
+  }
+
+  /**
    * Set the user's maximum leverage in spot cross margin.
    * CAUTION: Your account needs to enable spot margin first; i.e., you must have finished the quiz on web / app.
+   * @deprecated Use setSpotMarginLeverageV2 instead
    */
-  setSpotMarginLeverage(
+  setSpotMarginLeverageV2(
     params: SetSpotMarginLeverageParamsV5,
   ): Promise<APIResponseV3WithTime<{}>> {
     return this.postPrivate('/v5/spot-margin-trade/set-leverage', params);

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -2456,7 +2456,7 @@ export class RestClientV5 extends BaseRestClient {
   /**
    * Set the user's maximum leverage in spot cross margin.
    * CAUTION: Your account needs to enable spot margin first; i.e., you must have finished the quiz on web / app.
-   * @deprecated Use setSpotMarginLeverageV2 instead
+   * @deprecated Use setSpotMarginLeverageV2() instead
    */
   setSpotMarginLeverageV2(
     params: SetSpotMarginLeverageParamsV5,

--- a/src/types/request/v5-account.ts
+++ b/src/types/request/v5-account.ts
@@ -25,6 +25,10 @@ export interface GetTransactionLogParamsV5 {
   currency?: string;
   baseCoin?: string;
   type?: TransactionTypeV5;
+  /**
+   * Transaction sub type, "movePosition", used to filter trans logs of Move Position only
+   */
+  transSubType?: string;
   startTime?: number;
   endTime?: number;
   limit?: number;
@@ -61,4 +65,16 @@ export interface GetClassicTransactionLogsParamsV5 {
 export interface SetLimitPriceActionParamsV5 {
   category: CategoryV5;
   modifyEnable: boolean;
+}
+
+export interface GetAccountInstrumentsInfoParamsV5 {
+  category: 'spot' | 'linear' | 'inverse';
+  symbol?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface ManualRepayParamsV5 {
+  coin?: string;
+  amount?: string;
 }

--- a/src/types/request/v5-asset.ts
+++ b/src/types/request/v5-asset.ts
@@ -127,6 +127,14 @@ export interface GetWithdrawalRecordsParamsV5 {
   cursor?: string;
 }
 
+export interface GetWithdrawalAddressListParamsV5 {
+  coin?: string;
+  chain?: string;
+  addressType?: 0 | 1 | 2;
+  limit?: number;
+  cursor?: string;
+}
+
 export interface WithdrawParamsV5 {
   coin: string;
   chain: string;

--- a/src/types/request/v5-earn.ts
+++ b/src/types/request/v5-earn.ts
@@ -13,10 +13,33 @@ export interface GetEarnOrderHistoryParamsV5 {
   category: string;
   orderId?: string;
   orderLinkId?: string;
+  productId?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
 }
 
 export interface GetEarnPositionParamsV5 {
   category: string;
   productId?: string;
   coin?: string;
+}
+
+export interface GetEarnYieldHistoryParamsV5 {
+  category: string;
+  productId?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface GetEarnHourlyYieldHistoryParamsV5 {
+  category: string;
+  productId?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
 }

--- a/src/types/request/v5-market.ts
+++ b/src/types/request/v5-market.ts
@@ -40,6 +40,7 @@ export interface GetPremiumIndexPriceKlineParamsV5 {
 export interface GetInstrumentsInfoParamsV5 {
   category: CategoryV5;
   symbol?: string;
+  symbolType?: string;
   status?: InstrumentStatusV5;
   baseCoin?: string;
   limit?: number;

--- a/src/types/request/v5-spot-leverage-token.ts
+++ b/src/types/request/v5-spot-leverage-token.ts
@@ -26,3 +26,35 @@ export interface GetVIPMarginDataParamsV5 {
   vipLevel?: string;
   currency?: string;
 }
+
+// Spot Margin Trade (UTA) endpoints
+export interface ManualBorrowParamsV5 {
+  coin: string;
+  amount: string;
+}
+
+export interface GetMaxBorrowableAmountParamsV5 {
+  currency: string;
+}
+
+export interface GetPositionTiersParamsV5 {
+  currency?: string;
+}
+
+export interface GetCoinStateParamsV5 {
+  currency?: string;
+}
+
+export interface GetAvailableAmountToRepayParamsV5 {
+  currency: string;
+}
+
+export interface SetSpotMarginLeverageParamsV5 {
+  leverage: string;
+  currency?: string;
+}
+
+export interface ManualRepayWithoutConversionParamsV5 {
+  coin: string;
+  amount?: string;
+}

--- a/src/types/request/v5-trade.ts
+++ b/src/types/request/v5-trade.ts
@@ -43,6 +43,8 @@ export interface OrderParamsV5 {
   slLimitPrice?: string;
   tpOrderType?: OrderTypeV5;
   slOrderType?: OrderTypeV5;
+  bboSideType?: 'Queue' | 'Counterparty';
+  bboLevel?: '1' | '2' | '3' | '4' | '5';
 }
 
 export interface AmendOrderParamsV5 {

--- a/src/types/request/v5-user.ts
+++ b/src/types/request/v5-user.ts
@@ -45,3 +45,13 @@ export interface GetSubAccountAllApiKeysParamsV5 {
   limit?: number;
   cursor?: string;
 }
+
+export interface GetAffiliateUserListParamsV5 {
+  size?: number;
+  cursor?: string;
+  needDeposit?: boolean;
+  need30?: boolean;
+  need365?: boolean;
+  startDate?: string;
+  endDate?: string;
+}

--- a/src/types/response/v5-account.ts
+++ b/src/types/response/v5-account.ts
@@ -149,3 +149,7 @@ export interface DCPInfoV5 {
   dcpStatus: 'ON';
   timeWindow: string;
 }
+
+export interface ManualRepayResultV5 {
+  resultStatus: 'P' | 'SU' | 'FA';
+}

--- a/src/types/response/v5-asset.ts
+++ b/src/types/response/v5-asset.ts
@@ -182,6 +182,18 @@ export interface WithdrawalRecordV5 {
   updateTime: string;
 }
 
+export interface WithdrawalAddressV5 {
+  coin: string;
+  chain: string;
+  address: string;
+  tag: string;
+  remark: string;
+  status: number;
+  addressType: number;
+  verified: number;
+  createdAt: string;
+}
+
 export interface WithdrawableAmountV5 {
   limitAmountUsd: string;
   withdrawableAmount: {

--- a/src/types/response/v5-crypto-loan.ts
+++ b/src/types/response/v5-crypto-loan.ts
@@ -194,6 +194,8 @@ export interface OngoingFlexibleLoanV5 {
   hourlyInterestRate: string;
   loanCurrency: string;
   totalDebt: string;
+  unpaidAmount: string;
+  unpaidInterest: string;
 }
 
 export interface BorrowHistoryFlexibleV5 {

--- a/src/types/response/v5-earn.ts
+++ b/src/types/response/v5-earn.ts
@@ -19,6 +19,9 @@ export interface EarnOrderHistoryV5 {
   createdAt: string;
   productId: string;
   updatedAt: string;
+  swapOrderValue: string;
+  estimateRedeemTime: string;
+  estimateStakeTime: string;
 }
 
 export interface EarnPositionV5 {
@@ -27,4 +30,28 @@ export interface EarnPositionV5 {
   amount: string;
   totalPnl: string;
   claimableYield: string;
+}
+
+export interface EarnYieldHistoryV5 {
+  productId: string;
+  coin: string;
+  id: string;
+  amount: string;
+  yieldType: string;
+  distributionMode: string;
+  effectiveStakingAmount: string;
+  orderId: string;
+  status: 'Pending' | 'Success' | 'Fail';
+  createdAt: string;
+}
+
+export interface EarnHourlyYieldHistoryV5 {
+  productId: string;
+  coin: string;
+  id: string;
+  amount: string;
+  effectiveStakingAmount: string;
+  status: 'Pending' | 'Success' | 'Fail';
+  hourlyDate: string;
+  createdAt: string;
 }

--- a/src/types/response/v5-market.ts
+++ b/src/types/response/v5-market.ts
@@ -137,6 +137,9 @@ export interface SpotInstrumentInfoV5 {
     maxOrderQty: string;
     minOrderAmt: string;
     maxOrderAmt: string;
+    maxLimitOrderQty: string;
+    maxMarketOrderQty: string;
+    postOnlyMaxLimitOrderSize: string;
   };
   priceFilter: {
     tickSize: string;
@@ -145,6 +148,7 @@ export interface SpotInstrumentInfoV5 {
     priceLimitRatioX: string;
     priceLimitRatioY: string;
   };
+  forbidUplWithdrawal: boolean;
 }
 
 type InstrumentInfoV5Mapping = {
@@ -156,6 +160,28 @@ type InstrumentInfoV5Mapping = {
 
 export type InstrumentInfoResponseV5<C extends CategoryV5> =
   CategoryCursorListV5<InstrumentInfoV5Mapping[C], C>;
+
+// Account Instruments Info (includes RPI permissions)
+export interface AccountSpotInstrumentInfoV5 extends SpotInstrumentInfoV5 {
+  isPublicRpi: boolean;
+  myRpiPermission: boolean;
+}
+
+export interface AccountLinearInverseInstrumentInfoV5
+  extends LinearInverseInstrumentInfoV5 {
+  isPublicRpi: boolean;
+  myRpiPermission: boolean;
+}
+
+type AccountInstrumentInfoV5Mapping = {
+  linear: AccountLinearInverseInstrumentInfoV5[];
+  inverse: AccountLinearInverseInstrumentInfoV5[];
+  spot: AccountSpotInstrumentInfoV5[];
+};
+
+export type AccountInstrumentInfoResponseV5<
+  C extends 'spot' | 'linear' | 'inverse',
+> = CategoryCursorListV5<AccountInstrumentInfoV5Mapping[C], C>;
 
 /**
  * [price, size]
@@ -205,6 +231,9 @@ export interface TickerLinearInverseV5 {
   nextFundingTime: string;
   predictedDeliveryPrice: string;
   basisRate: string;
+  basisRateYear: string;
+  fundingIntervalHour: string;
+  fundingCap: string;
   deliveryFeeRate: string;
   deliveryTime: string;
   ask1Size: string;

--- a/src/types/response/v5-spot-leverage-token.ts
+++ b/src/types/response/v5-spot-leverage-token.ts
@@ -89,3 +89,47 @@ export interface SpotMarginStateV5 {
   spotMarginMode: '1' | '0';
   effectiveLeverage: string;
 }
+
+// Spot Margin Trade (UTA) response types
+export interface ManualBorrowResultV5 {
+  coin: string;
+  amount: string;
+}
+
+export interface MaxBorrowableAmountV5 {
+  currency: string;
+  maxLoan: string;
+}
+
+export interface PositionTierV5 {
+  tier: string;
+  borrowLimit: string;
+  positionMMR: string;
+  positionIMR: string;
+  maxLeverage: string;
+}
+
+export interface CurrencyPositionTiersV5 {
+  currency: string;
+  positionTiersRatioList: PositionTierV5[];
+}
+
+export interface CoinStateV5 {
+  currency: string;
+  spotLeverage: string;
+}
+
+export interface AvailableAmountToRepayV5 {
+  currency: string;
+  lossLessRepaymentAmount: string;
+}
+
+export interface ManualRepayWithoutConversionResultV5 {
+  /**
+   * Result status:
+   * - P: Processing
+   * - SU: Success
+   * - FA: Failed
+   */
+  resultStatus: 'P' | 'SU' | 'FA';
+}

--- a/src/types/response/v5-user.ts
+++ b/src/types/response/v5-user.ts
@@ -102,6 +102,19 @@ export interface AffiliateUserListItemV5 {
   source: string;
   remarks: string;
   isKyc: boolean;
+  takerVol30Day: string;
+  makerVol30Day: string;
+  tradeVol30Day: string;
+  depositAmount30Day: string;
+  takerVol365Day: string;
+  makerVol365Day: string;
+  tradeVol365Day: string;
+  depositAmount365Day: string;
+  takerVol: string;
+  makerVol: string;
+  tradeVol: string;
+  startDate: string;
+  endDate: string;
 }
 
 export interface AffiliateUserInfoV5 {

--- a/src/types/shared-v5.ts
+++ b/src/types/shared-v5.ts
@@ -97,7 +97,9 @@ export type OrderCreateTypeV5 =
   /** Order created by arbitrage - web/app. */
   | 'CreateByArbitrage'
   /** Option dynamic delta hedge order - web/app */
-  | 'CreateByDdh';
+  | 'CreateByDdh'
+  /** BBO Order - Best Bid/Offer order */
+  | 'CreateByBboOrder';
 
 export type OrderCancelTypeV5 =
   | 'CancelByUser'


### PR DESCRIPTION
## API Updates - November 2025 Release

### Market Data APIs
- **Get Tickers (Linear/Inverse)**: Added new response fields `basisRateYear`, `fundingIntervalHour`, and `fundingCap` for enhanced funding rate information

### Account APIs
- **Get Transaction Log**: Added optional `transSubType` parameter to filter transaction logs by sub-type (e.g., "movePosition" for Move Position logs)

### Spot Margin Trade (UTA) APIs - New Endpoints
- **Manual Borrow** (`POST /v5/account/borrow`): New endpoint for UTA manual borrow operations
  - Added `ManualBorrowParamsV5` request type
  - Added `ManualBorrowResultV5` response type
  
- **Get Max Borrowable Amount** (`GET /v5/spot-margin-trade/max-borrowable`): New endpoint to query maximum borrowable amount for a currency
  - Added `GetMaxBorrowableAmountParamsV5` request type
  - Added `MaxBorrowableAmountV5` response type
  
- **Get Position Tiers** (`GET /v5/spot-margin-trade/position-tiers`): New endpoint to get loan position risk information
  - Added `GetPositionTiersParamsV5` request type
  - Added `PositionTierV5` and `CurrencyPositionTiersV5` response types
  
- **Get Coin State** (`GET /v5/spot-margin-trade/coinstate`): New endpoint to get currency leverage information
  - Added `GetCoinStateParamsV5` request type
  - Added `CoinStateV5` response type
  
- **Get Available Amount to Repay** (`GET /v5/spot-margin-trade/repayment-available-amount`): New endpoint to query available amount for repayment
  - Added `GetAvailableAmountToRepayParamsV5` request type
  - Added `AvailableAmountToRepayV5` response type
  
- **Manual Repay Without Asset Conversion** (`POST /v5/account/no-convert-repay`): New endpoint for manual repayment without asset conversion
  - Added `ManualRepayWithoutConversionParamsV5` request type
  - Added `ManualRepayWithoutConversionResultV5` response type
  - Note: Repayment is prohibited between 04:00 and 05:30 per hour

### Spot Margin Trade - Updated Endpoints
- **Set Leverage** (`POST /v5/spot-margin-trade/set-leverage`): Enhanced to support optional `currency` parameter for setting leverage by currency
  - Added `SetSpotMarginLeverageParamsV5` type
  - Maintains backward compatibility

### Code Quality Improvements
- **Get Affiliate User List**: Extracted inline type definition to proper exported interface `GetAffiliateUserListParamsV5` for better type reusability and maintainability

### Type Definitions
- All new request and response types are properly exported from their respective type definition files
- Types are fully documented with JSDoc comments where applicable
- All changes maintain backward compatibility