### PR TITLE
feat(v4.5.1): add new API endpoints for crypto loans and fiat trading, enhance existing functionality with new examples and documentation updates

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -49,263 +49,270 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getSystemStatus()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L417) | :closed_lock_with_key:  | GET | `/v5/system/status` |
-| [getServerTime()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L434) |  | GET | `/v5/market/time` |
-| [requestDemoTradingFunds()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L446) | :closed_lock_with_key:  | POST | `/v5/account/demo-apply-money` |
-| [createDemoAccount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L459) | :closed_lock_with_key:  | POST | `/v5/user/create-demo-member` |
-| [getSpreadInstrumentsInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L472) |  | GET | `/v5/spread/instrument` |
-| [getSpreadOrderbook()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L484) |  | GET | `/v5/spread/orderbook` |
-| [getSpreadTickers()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L494) |  | GET | `/v5/spread/tickers` |
-| [getSpreadRecentTrades()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L505) |  | GET | `/v5/spread/recent-trade` |
-| [submitSpreadOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L516) | :closed_lock_with_key:  | POST | `/v5/spread/order/create` |
-| [amendSpreadOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L529) | :closed_lock_with_key:  | POST | `/v5/spread/order/amend` |
-| [cancelSpreadOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L541) | :closed_lock_with_key:  | POST | `/v5/spread/order/cancel` |
-| [cancelAllSpreadOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L559) | :closed_lock_with_key:  | POST | `/v5/spread/order/cancel-all` |
-| [getSpreadOpenOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L578) | :closed_lock_with_key:  | GET | `/v5/spread/order/realtime` |
-| [getSpreadOrderHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L595) | :closed_lock_with_key:  | GET | `/v5/spread/order/history` |
-| [getSpreadTradeHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L611) | :closed_lock_with_key:  | GET | `/v5/spread/execution/list` |
-| [getKline()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L631) |  | GET | `/v5/market/kline` |
-| [getMarkPriceKline()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L646) |  | GET | `/v5/market/mark-price-kline` |
-| [getIndexPriceKline()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L661) |  | GET | `/v5/market/index-price-kline` |
-| [getPremiumIndexPriceKline()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L676) |  | GET | `/v5/market/premium-index-price-kline` |
-| [getInstrumentsInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L691) |  | GET | `/v5/market/instruments-info` |
-| [getOrderbook()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L702) |  | GET | `/v5/market/orderbook` |
-| [getRPIOrderbook()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L716) |  | GET | `/v5/market/rpi_orderbook` |
-| [getTickers()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L722) |  | GET | `/v5/market/tickers` |
-| [getFundingRateHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L760) |  | GET | `/v5/market/funding/history` |
-| [getPublicTradingHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L775) |  | GET | `/v5/market/recent-trade` |
-| [getOpenInterest()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L788) |  | GET | `/v5/market/open-interest` |
-| [getHistoricalVolatility()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L798) |  | GET | `/v5/market/historical-volatility` |
-| [getInsurance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L809) |  | GET | `/v5/market/insurance` |
-| [getRiskLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L820) |  | GET | `/v5/market/risk-limit` |
-| [getOptionDeliveryPrice()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L835) |  | GET | `/v5/market/delivery-price` |
-| [getDeliveryPrice()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L848) |  | GET | `/v5/market/delivery-price` |
-| [getNewDeliveryPrice()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L864) |  | GET | `/v5/market/new-delivery-price` |
-| [getLongShortRatio()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L880) |  | GET | `/v5/market/account-ratio` |
-| [getIndexPriceComponents()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L890) |  | GET | `/v5/market/index-price-components` |
-| [getOrderPriceLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L896) |  | GET | `/v5/market/price-limit` |
-| [getADLAlert()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L910) |  | GET | `/v5/market/adlAlert` |
-| [getFeeGroupStructure()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L923) |  | GET | `/v5/market/fee-group-info` |
-| [submitOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L935) | :closed_lock_with_key:  | POST | `/v5/order/create` |
-| [amendOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L941) | :closed_lock_with_key:  | POST | `/v5/order/amend` |
-| [cancelOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L947) | :closed_lock_with_key:  | POST | `/v5/order/cancel` |
-| [getActiveOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L956) | :closed_lock_with_key:  | GET | `/v5/order/realtime` |
-| [cancelAllOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L962) | :closed_lock_with_key:  | POST | `/v5/order/cancel-all` |
-| [getHistoricOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L975) | :closed_lock_with_key:  | GET | `/v5/order/history` |
-| [getExecutionList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L987) | :closed_lock_with_key:  | GET | `/v5/execution/list` |
-| [batchSubmitOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1005) | :closed_lock_with_key:  | POST | `/v5/order/create-batch` |
-| [batchAmendOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1030) | :closed_lock_with_key:  | POST | `/v5/order/amend-batch` |
-| [batchCancelOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1055) | :closed_lock_with_key:  | POST | `/v5/order/cancel-batch` |
-| [getSpotBorrowCheck()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1077) | :closed_lock_with_key:  | GET | `/v5/order/spot-borrow-check` |
-| [setDisconnectCancelAllWindow()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1098) | :closed_lock_with_key:  | POST | `/v5/order/disconnected-cancel-all` |
-| [setDisconnectCancelAllWindowV2()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1116) | :closed_lock_with_key:  | POST | `/v5/order/disconnected-cancel-all` |
-| [preCheckOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1131) | :closed_lock_with_key:  | POST | `/v5/order/pre-check` |
-| [getPositionInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1154) | :closed_lock_with_key:  | GET | `/v5/position/list` |
-| [setLeverage()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1169) | :closed_lock_with_key:  | POST | `/v5/position/set-leverage` |
-| [switchIsolatedMargin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1182) | :closed_lock_with_key:  | POST | `/v5/position/switch-isolated` |
-| [setTPSLMode()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1196) | :closed_lock_with_key:  | POST | `/v5/position/set-tpsl-mode` |
-| [switchPositionMode()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1211) | :closed_lock_with_key:  | POST | `/v5/position/switch-mode` |
-| [setRiskLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1225) | :closed_lock_with_key:  | POST | `/v5/position/set-risk-limit` |
-| [setTradingStop()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1240) | :closed_lock_with_key:  | POST | `/v5/position/trading-stop` |
-| [setAutoAddMargin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1251) | :closed_lock_with_key:  | POST | `/v5/position/set-auto-add-margin` |
-| [addOrReduceMargin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1263) | :closed_lock_with_key:  | POST | `/v5/position/add-margin` |
-| [getClosedPnL()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1275) | :closed_lock_with_key:  | GET | `/v5/position/closed-pnl` |
-| [getClosedOptionsPositions()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1289) | :closed_lock_with_key:  | GET | `/v5/position/get-closed-positions` |
-| [movePosition()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1314) | :closed_lock_with_key:  | POST | `/v5/position/move-positions` |
-| [getMovePositionHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1325) | :closed_lock_with_key:  | GET | `/v5/position/move-history` |
-| [confirmNewRiskLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1344) | :closed_lock_with_key:  | POST | `/v5/position/confirm-pending-mmr` |
-| [getPreUpgradeOrderHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1364) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/order/history` |
-| [getPreUpgradeTradeHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1379) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/execution/list` |
-| [getPreUpgradeClosedPnl()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1390) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/position/closed-pnl` |
-| [getPreUpgradeTransactions()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1404) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/account/transaction-log` |
-| [getPreUpgradeOptionDeliveryRecord()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1421) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/asset/delivery-record` |
-| [getPreUpgradeUSDCSessionSettlements()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1435) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/asset/settlement-record` |
-| [getWalletBalance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1456) | :closed_lock_with_key:  | GET | `/v5/account/wallet-balance` |
-| [getTransferableAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1467) | :closed_lock_with_key:  | GET | `/v5/account/withdrawal` |
-| [getAccountInstrumentsInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1483) | :closed_lock_with_key:  | GET | `/v5/account/instruments-info` |
-| [upgradeToUnifiedAccount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1494) | :closed_lock_with_key:  | POST | `/v5/account/upgrade-to-uta` |
-| [getBorrowHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1505) | :closed_lock_with_key:  | GET | `/v5/account/borrow-history` |
-| [repayLiability()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1519) | :closed_lock_with_key:  | POST | `/v5/account/quick-repayment` |
-| [manualRepay()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1536) | :closed_lock_with_key:  | POST | `/v5/account/repay` |
-| [setCollateralCoin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1545) | :closed_lock_with_key:  | POST | `/v5/account/set-collateral-switch` |
-| [batchSetCollateralCoin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1551) | :closed_lock_with_key:  | POST | `/v5/account/set-collateral-switch-batch` |
-| [getCollateralInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1561) | :closed_lock_with_key:  | GET | `/v5/account/collateral-info` |
-| [getCoinGreeks()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1570) | :closed_lock_with_key:  | GET | `/v5/asset/coin-greeks` |
-| [getFeeRate()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1583) | :closed_lock_with_key:  | GET | `/v5/account/fee-rate` |
-| [getAccountInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1592) | :closed_lock_with_key:  | GET | `/v5/account/info` |
-| [getDCPInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1605) | :closed_lock_with_key:  | GET | `/v5/account/query-dcp-info` |
-| [getTransactionLog()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1612) | :closed_lock_with_key:  | GET | `/v5/account/transaction-log` |
-| [getClassicTransactionLogs()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1623) | :closed_lock_with_key:  | GET | `/v5/account/contract-transaction-log` |
-| [getSMPGroup()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1634) | :closed_lock_with_key:  | GET | `/v5/account/smp-group` |
-| [setMarginMode()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1647) | :closed_lock_with_key:  | POST | `/v5/account/set-margin-mode` |
-| [setSpotHedging()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1664) | :closed_lock_with_key:  | POST | `/v5/account/set-hedging-mode` |
-| [setLimitPriceAction()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1677) | :closed_lock_with_key:  | POST | `/v5/account/set-limit-px-action` |
-| [getLimitPriceAction()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1687) | :closed_lock_with_key:  | GET | `/v5/account/user-setting-config` |
-| [setMMP()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1699) | :closed_lock_with_key:  | POST | `/v5/account/mmp-modify` |
-| [resetMMP()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1706) | :closed_lock_with_key:  | POST | `/v5/account/mmp-reset` |
-| [getMMPState()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1713) | :closed_lock_with_key:  | GET | `/v5/account/mmp-state` |
-| [getDeliveryRecord()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1730) | :closed_lock_with_key:  | GET | `/v5/asset/delivery-record` |
-| [getSettlementRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1741) | :closed_lock_with_key:  | GET | `/v5/asset/settlement-record` |
-| [getCoinExchangeRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1754) | :closed_lock_with_key:  | GET | `/v5/asset/exchange/order-record` |
-| [getCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1766) | :closed_lock_with_key:  | GET | `/v5/asset/coin/query-info` |
-| [getSubUID()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1780) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-sub-member-list` |
-| [getAssetInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1795) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-asset-info` |
-| [getAllCoinsBalance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1806) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-account-coins-balance` |
-| [getCoinBalance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1820) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-account-coin-balance` |
-| [getWithdrawableAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1832) | :closed_lock_with_key:  | GET | `/v5/asset/withdraw/withdrawable-amount` |
-| [getTransferableCoinList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1841) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-transfer-coin-list` |
-| [createInternalTransfer()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1857) | :closed_lock_with_key:  | POST | `/v5/asset/transfer/inter-transfer` |
-| [getInternalTransferRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1876) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-inter-transfer-list` |
-| [enableUniversalTransferForSubUIDs()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1896) | :closed_lock_with_key:  | POST | `/v5/asset/transfer/save-transfer-sub-member` |
-| [createUniversalTransfer()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1907) | :closed_lock_with_key:  | POST | `/v5/asset/transfer/universal-transfer` |
-| [getUniversalTransferRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1919) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-universal-transfer-list` |
-| [getAllowedDepositCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1932) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-allowed-list` |
-| [setDepositAccount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1946) | :closed_lock_with_key:  | POST | `/v5/asset/deposit/deposit-to-account` |
-| [getDepositRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1962) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-record` |
-| [getSubAccountDepositRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1977) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-sub-member-record` |
-| [getInternalDepositRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1993) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-internal-record` |
-| [getMasterDepositAddress()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2005) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-address` |
-| [getSubDepositAddress()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2023) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-sub-member-address` |
-| [querySubMemberAddress()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2048) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-sub-member-address` |
-| [getWithdrawalRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2068) | :closed_lock_with_key:  | GET | `/v5/asset/withdraw/query-record` |
-| [getWithdrawalAddressList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2080) | :closed_lock_with_key:  | GET | `/v5/asset/withdraw/query-address` |
-| [getExchangeEntities()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2094) | :closed_lock_with_key:  | GET | `/v5/asset/withdraw/vasp/list` |
-| [submitWithdrawal()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2107) | :closed_lock_with_key:  | POST | `/v5/asset/withdraw/create` |
-| [cancelWithdrawal()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2118) | :closed_lock_with_key:  | POST | `/v5/asset/withdraw/cancel` |
-| [getConvertCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2127) | :closed_lock_with_key:  | GET | `/v5/asset/exchange/query-coin-list` |
-| [requestConvertQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2138) | :closed_lock_with_key:  | POST | `/v5/asset/exchange/quote-apply` |
-| [confirmConvertQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2147) | :closed_lock_with_key:  | POST | `/v5/asset/exchange/convert-execute` |
-| [getConvertStatus()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2159) | :closed_lock_with_key:  | GET | `/v5/asset/exchange/convert-result-query` |
-| [getConvertHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2178) | :closed_lock_with_key:  | GET | `/v5/asset/exchange/query-convert-history` |
-| [createSubMember()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2198) | :closed_lock_with_key:  | POST | `/v5/user/create-sub-member` |
-| [createSubUIDAPIKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2210) | :closed_lock_with_key:  | POST | `/v5/user/create-sub-api` |
-| [getSubUIDList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2219) | :closed_lock_with_key:  | GET | `/v5/user/query-sub-members` |
-| [getSubUIDListUnlimited()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2228) | :closed_lock_with_key:  | GET | `/v5/user/submembers` |
-| [setSubUIDFrozenState()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2246) | :closed_lock_with_key:  | POST | `/v5/user/frozen-sub-member` |
-| [getQueryApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2259) | :closed_lock_with_key:  | GET | `/v5/user/query-api` |
-| [getSubAccountAllApiKeys()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2266) | :closed_lock_with_key:  | GET | `/v5/user/sub-apikeys` |
-| [getUIDWalletType()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2275) | :closed_lock_with_key:  | GET | `/v5/user/get-member-type` |
-| [updateMasterApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2292) | :closed_lock_with_key:  | POST | `/v5/user/update-api` |
-| [updateSubApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2306) | :closed_lock_with_key:  | POST | `/v5/user/update-sub-api` |
-| [deleteSubMember()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2319) | :closed_lock_with_key:  | POST | `/v5/user/del-submember` |
-| [deleteMasterApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2334) | :closed_lock_with_key:  | POST | `/v5/user/delete-api` |
-| [deleteSubApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2348) | :closed_lock_with_key:  | POST | `/v5/user/delete-sub-api` |
-| [getAffiliateUserList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2368) | :closed_lock_with_key:  | GET | `/v5/affiliate/aff-user-list` |
-| [getAffiliateUserInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2387) | :closed_lock_with_key:  | GET | `/v5/user/aff-customer-info` |
-| [getVIPMarginData()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2407) |  | GET | `/v5/spot-margin-trade/data` |
-| [getHistoricalInterestRate()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2418) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/interest-rate-history` |
-| [toggleSpotMarginTrade()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2445) | :closed_lock_with_key:  | POST | `/v5/spot-margin-trade/switch-mode` |
-| [setSpotMarginLeverage()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2456) | :closed_lock_with_key:  | POST | `/v5/spot-margin-trade/set-leverage` |
-| [setSpotMarginLeverageV2()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2464) | :closed_lock_with_key:  | POST | `/v5/spot-margin-trade/set-leverage` |
-| [getSpotMarginState()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2475) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/state` |
-| [manualBorrow()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2482) | :closed_lock_with_key:  | POST | `/v5/account/borrow` |
-| [getMaxBorrowableAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2491) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/max-borrowable` |
-| [getPositionTiers()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2500) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/position-tiers` |
-| [getCoinState()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2511) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/coinstate` |
-| [getAvailableAmountToRepay()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2522) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/repayment-available-amount` |
-| [manualRepayWithoutConversion()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2537) | :closed_lock_with_key:  | POST | `/v5/account/no-convert-repay` |
-| [getSpotMarginCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2552) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/pledge-token` |
-| [getSpotMarginBorrowableCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2569) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/borrow-token` |
-| [getSpotMarginInterestAndQuota()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2586) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/loan-info` |
-| [getSpotMarginLoanAccountInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2604) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/account` |
-| [spotMarginBorrow()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2628) | :closed_lock_with_key:  | POST | `/v5/spot-cross-margin-trade/loan` |
-| [spotMarginRepay()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2639) | :closed_lock_with_key:  | POST | `/v5/spot-cross-margin-trade/repay` |
-| [getSpotMarginBorrowOrderDetail()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2654) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/orders` |
-| [getSpotMarginRepaymentOrderDetail()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2683) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/repay-history` |
-| [toggleSpotCrossMarginTrade()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2712) | :closed_lock_with_key:  | POST | `/v5/spot-cross-margin-trade/switch` |
-| [getCollateralCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2732) |  | GET | `/v5/crypto-loan/collateral-data` |
-| [getBorrowableCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2749) |  | GET | `/v5/crypto-loan/loanable-data` |
-| [getAccountBorrowCollateralLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2767) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/borrowable-collateralisable-number` |
-| [borrowCryptoLoan()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2787) | :closed_lock_with_key:  | POST | `/v5/crypto-loan/borrow` |
-| [repayCryptoLoan()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2808) | :closed_lock_with_key:  | POST | `/v5/crypto-loan/repay` |
-| [getUnpaidLoanOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2824) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/ongoing-orders` |
-| [getRepaymentHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2845) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/repayment-history` |
-| [getCompletedLoanOrderHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2865) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/borrow-history` |
-| [getMaxAllowedReductionCollateralAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2884) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/max-collateral-amount` |
-| [adjustCollateralAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2903) | :closed_lock_with_key:  | POST | `/v5/crypto-loan/adjust-ltv` |
-| [getLoanLTVAdjustmentHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2927) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/adjustment-history` |
-| [getLoanBorrowableCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2948) |  | GET | `/v5/crypto-loan-common/loanable-data` |
-| [getLoanCollateralCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2960) |  | GET | `/v5/crypto-loan-common/collateral-data` |
-| [getMaxCollateralAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2970) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-common/max-collateral-amount` |
-| [updateCollateralAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2985) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-common/adjust-ltv` |
-| [getCollateralAdjustmentHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2996) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-common/adjustment-history` |
-| [getCryptoLoanPosition()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3011) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-common/position` |
-| [borrowFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3028) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-flexible/borrow` |
-| [repayFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3039) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-flexible/repay` |
-| [repayCollateralFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3049) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-flexible/repay-collateral` |
-| [getOngoingFlexibleLoans()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3063) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-flexible/ongoing-coin` |
-| [getBorrowHistoryFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3075) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-flexible/borrow-history` |
-| [getRepaymentHistoryFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3088) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-flexible/repayment-history` |
-| [getSupplyOrderQuoteFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3113) |  | GET | `/v5/crypto-loan-fixed/supply-order-quote` |
-| [getBorrowOrderQuoteFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3126) |  | GET | `/v5/crypto-loan-fixed/borrow-order-quote` |
-| [createBorrowOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3139) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/borrow` |
-| [createSupplyOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3150) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/supply` |
-| [cancelBorrowOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3160) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/borrow-order-cancel` |
-| [cancelSupplyOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3172) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/supply-order-cancel` |
-| [getBorrowContractInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3185) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/borrow-contract-info` |
-| [getSupplyContractInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3203) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/supply-contract-info` |
-| [getBorrowOrderInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3221) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/borrow-order-info` |
-| [getSupplyOrderInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3234) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/supply-order-info` |
-| [repayFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3248) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/fully-repay` |
-| [repayCollateralFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3259) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-flexible/repay-collateral` |
-| [getRepaymentHistoryFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3272) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/repayment-history` |
-| [renewBorrowOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3289) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/renew` |
-| [getRenewOrderInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3302) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/renew-info` |
-| [getInstitutionalLendingProductInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3320) |  | GET | `/v5/ins-loan/product-infos` |
-| [getInstitutionalLendingMarginCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3330) |  | GET | `/v5/ins-loan/ensure-tokens` |
-| [getInstitutionalLendingMarginCoinInfoWithConversionRate()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3339) |  | GET | `/v5/ins-loan/ensure-tokens-convert` |
-| [getInstitutionalLendingLoanOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3348) | :closed_lock_with_key:  | GET | `/v5/ins-loan/loan-order` |
-| [getInstitutionalLendingRepayOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3360) | :closed_lock_with_key:  | GET | `/v5/ins-loan/repaid-history` |
-| [getInstitutionalLendingLTV()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3372) | :closed_lock_with_key:  | GET | `/v5/ins-loan/ltv` |
-| [getInstitutionalLendingLTVWithLadderConversionRate()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3381) | :closed_lock_with_key:  | GET | `/v5/ins-loan/ltv-convert` |
-| [bindOrUnbindUID()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3396) | :closed_lock_with_key:  | POST | `/v5/ins-loan/association-uid` |
-| [getExchangeBrokerEarnings()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3420) | :closed_lock_with_key:  | GET | `/v5/broker/earnings-info` |
-| [getExchangeBrokerAccountInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3433) | :closed_lock_with_key:  | GET | `/v5/broker/account-info` |
-| [getBrokerSubAccountDeposits()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3449) | :closed_lock_with_key:  | GET | `/v5/broker/asset/query-sub-member-deposit-record` |
-| [getBrokerVoucherSpec()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3464) | :closed_lock_with_key:  | POST | `/v5/broker/award/info` |
-| [issueBrokerVoucher()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3476) | :closed_lock_with_key:  | POST | `/v5/broker/award/distribute-award` |
-| [getBrokerIssuedVoucher()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3488) | :closed_lock_with_key:  | POST | `/v5/broker/award/distribution-record` |
-| [getEarnProduct()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3505) |  | GET | `/v5/earn/product` |
-| [submitStakeRedeem()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3523) | :closed_lock_with_key:  | POST | `/v5/earn/place-order` |
-| [getEarnOrderHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3542) | :closed_lock_with_key:  | GET | `/v5/earn/order` |
-| [getEarnPosition()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3558) | :closed_lock_with_key:  | GET | `/v5/earn/position` |
-| [getEarnYieldHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3571) | :closed_lock_with_key:  | GET | `/v5/earn/yield` |
-| [getEarnHourlyYieldHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3585) | :closed_lock_with_key:  | GET | `/v5/earn/hourly-yield` |
-| [createRFQ()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3604) | :closed_lock_with_key:  | POST | `/v5/rfq/create-rfq` |
-| [getRFQConfig()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3615) | :closed_lock_with_key:  | GET | `/v5/rfq/config` |
-| [cancelRFQ()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3624) | :closed_lock_with_key:  | POST | `/v5/rfq/cancel-rfq` |
-| [cancelAllRFQ()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3634) | :closed_lock_with_key:  | POST | `/v5/rfq/cancel-all-rfq` |
-| [createRFQQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3643) | :closed_lock_with_key:  | POST | `/v5/rfq/create-quote` |
-| [executeRFQQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3654) | :closed_lock_with_key:  | POST | `/v5/rfq/execute-quote` |
-| [cancelRFQQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3665) | :closed_lock_with_key:  | POST | `/v5/rfq/cancel-quote` |
-| [cancelAllRFQQuotes()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3675) | :closed_lock_with_key:  | POST | `/v5/rfq/cancel-all-quotes` |
-| [getRFQRealtimeInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3689) | :closed_lock_with_key:  | GET | `/v5/rfq/rfq-realtime` |
-| [getRFQHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3701) | :closed_lock_with_key:  | GET | `/v5/rfq/rfq-list` |
-| [getRFQRealtimeQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3715) | :closed_lock_with_key:  | GET | `/v5/rfq/quote-realtime` |
-| [getRFQHistoryQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3730) | :closed_lock_with_key:  | GET | `/v5/rfq/quote-list` |
-| [getRFQTrades()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3743) | :closed_lock_with_key:  | GET | `/v5/rfq/trade-list` |
-| [getRFQPublicTrades()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3756) | :closed_lock_with_key:  | GET | `/v5/rfq/public-trades` |
-| [getP2PAccountCoinsBalance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3781) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-account-coins-balance` |
-| [getP2POnlineAds()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3798) | :closed_lock_with_key:  | POST | `/v5/p2p/item/online` |
-| [createP2PAd()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3807) | :closed_lock_with_key:  | POST | `/v5/p2p/item/create` |
-| [cancelP2PAd()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3816) | :closed_lock_with_key:  | POST | `/v5/p2p/item/cancel` |
-| [updateP2PAd()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3830) | :closed_lock_with_key:  | POST | `/v5/p2p/item/update` |
-| [getP2PPersonalAds()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3840) | :closed_lock_with_key:  | POST | `/v5/p2p/item/personal/list` |
-| [getP2PAdDetail()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3849) | :closed_lock_with_key:  | POST | `/v5/p2p/item/info` |
-| [getP2POrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3864) | :closed_lock_with_key:  | POST | `/v5/p2p/order/simplifyList` |
-| [getP2POrderDetail()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3874) | :closed_lock_with_key:  | POST | `/v5/p2p/order/info` |
-| [getP2PPendingOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3883) | :closed_lock_with_key:  | POST | `/v5/p2p/order/pending/simplifyList` |
-| [markP2POrderAsPaid()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3892) | :closed_lock_with_key:  | POST | `/v5/p2p/order/pay` |
-| [releaseP2POrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3901) | :closed_lock_with_key:  | POST | `/v5/p2p/order/finish` |
-| [sendP2POrderMessage()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3910) | :closed_lock_with_key:  | POST | `/v5/p2p/order/message/send` |
-| [getP2POrderMessages()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3944) | :closed_lock_with_key:  | POST | `/v5/p2p/order/message/listpage` |
-| [getP2PUserInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3958) | :closed_lock_with_key:  | POST | `/v5/p2p/user/personal/info` |
-| [getP2PCounterpartyUserInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3965) | :closed_lock_with_key:  | POST | `/v5/p2p/user/order/personal/info` |
-| [getP2PUserPayments()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3974) | :closed_lock_with_key:  | POST | `/v5/p2p/user/payment/list` |
-| [setApiRateLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3994) | :closed_lock_with_key:  | POST | `/v5/apilimit/set` |
-| [queryApiRateLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4023) | :closed_lock_with_key:  | GET | `/v5/apilimit/query` |
-| [getRateLimitCap()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4042) | :closed_lock_with_key:  | GET | `/v5/apilimit/query-cap` |
-| [getAllRateLimits()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4061) | :closed_lock_with_key:  | GET | `/v5/apilimit/query-all` |
+| [getSystemStatus()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L432) | :closed_lock_with_key:  | GET | `/v5/system/status` |
+| [getServerTime()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L449) |  | GET | `/v5/market/time` |
+| [requestDemoTradingFunds()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L461) | :closed_lock_with_key:  | POST | `/v5/account/demo-apply-money` |
+| [createDemoAccount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L474) | :closed_lock_with_key:  | POST | `/v5/user/create-demo-member` |
+| [getSpreadInstrumentsInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L487) |  | GET | `/v5/spread/instrument` |
+| [getSpreadOrderbook()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L499) |  | GET | `/v5/spread/orderbook` |
+| [getSpreadTickers()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L509) |  | GET | `/v5/spread/tickers` |
+| [getSpreadRecentTrades()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L520) |  | GET | `/v5/spread/recent-trade` |
+| [submitSpreadOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L531) | :closed_lock_with_key:  | POST | `/v5/spread/order/create` |
+| [amendSpreadOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L544) | :closed_lock_with_key:  | POST | `/v5/spread/order/amend` |
+| [cancelSpreadOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L556) | :closed_lock_with_key:  | POST | `/v5/spread/order/cancel` |
+| [cancelAllSpreadOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L574) | :closed_lock_with_key:  | POST | `/v5/spread/order/cancel-all` |
+| [getSpreadOpenOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L593) | :closed_lock_with_key:  | GET | `/v5/spread/order/realtime` |
+| [getSpreadOrderHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L610) | :closed_lock_with_key:  | GET | `/v5/spread/order/history` |
+| [getSpreadTradeHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L626) | :closed_lock_with_key:  | GET | `/v5/spread/execution/list` |
+| [getKline()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L646) |  | GET | `/v5/market/kline` |
+| [getMarkPriceKline()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L661) |  | GET | `/v5/market/mark-price-kline` |
+| [getIndexPriceKline()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L676) |  | GET | `/v5/market/index-price-kline` |
+| [getPremiumIndexPriceKline()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L691) |  | GET | `/v5/market/premium-index-price-kline` |
+| [getInstrumentsInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L706) |  | GET | `/v5/market/instruments-info` |
+| [getOrderbook()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L717) |  | GET | `/v5/market/orderbook` |
+| [getRPIOrderbook()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L731) |  | GET | `/v5/market/rpi_orderbook` |
+| [getTickers()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L737) |  | GET | `/v5/market/tickers` |
+| [getFundingRateHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L775) |  | GET | `/v5/market/funding/history` |
+| [getPublicTradingHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L790) |  | GET | `/v5/market/recent-trade` |
+| [getOpenInterest()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L803) |  | GET | `/v5/market/open-interest` |
+| [getHistoricalVolatility()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L813) |  | GET | `/v5/market/historical-volatility` |
+| [getInsurance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L824) |  | GET | `/v5/market/insurance` |
+| [getRiskLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L835) |  | GET | `/v5/market/risk-limit` |
+| [getOptionDeliveryPrice()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L850) |  | GET | `/v5/market/delivery-price` |
+| [getDeliveryPrice()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L863) |  | GET | `/v5/market/delivery-price` |
+| [getNewDeliveryPrice()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L879) |  | GET | `/v5/market/new-delivery-price` |
+| [getLongShortRatio()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L895) |  | GET | `/v5/market/account-ratio` |
+| [getIndexPriceComponents()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L905) |  | GET | `/v5/market/index-price-components` |
+| [getOrderPriceLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L911) |  | GET | `/v5/market/price-limit` |
+| [getADLAlert()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L925) |  | GET | `/v5/market/adlAlert` |
+| [getFeeGroupStructure()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L938) |  | GET | `/v5/market/fee-group-info` |
+| [submitOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L950) | :closed_lock_with_key:  | POST | `/v5/order/create` |
+| [amendOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L956) | :closed_lock_with_key:  | POST | `/v5/order/amend` |
+| [cancelOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L962) | :closed_lock_with_key:  | POST | `/v5/order/cancel` |
+| [getActiveOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L971) | :closed_lock_with_key:  | GET | `/v5/order/realtime` |
+| [cancelAllOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L977) | :closed_lock_with_key:  | POST | `/v5/order/cancel-all` |
+| [getHistoricOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L990) | :closed_lock_with_key:  | GET | `/v5/order/history` |
+| [getExecutionList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1002) | :closed_lock_with_key:  | GET | `/v5/execution/list` |
+| [batchSubmitOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1020) | :closed_lock_with_key:  | POST | `/v5/order/create-batch` |
+| [batchAmendOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1045) | :closed_lock_with_key:  | POST | `/v5/order/amend-batch` |
+| [batchCancelOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1070) | :closed_lock_with_key:  | POST | `/v5/order/cancel-batch` |
+| [getSpotBorrowCheck()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1092) | :closed_lock_with_key:  | GET | `/v5/order/spot-borrow-check` |
+| [setDisconnectCancelAllWindow()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1113) | :closed_lock_with_key:  | POST | `/v5/order/disconnected-cancel-all` |
+| [setDisconnectCancelAllWindowV2()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1131) | :closed_lock_with_key:  | POST | `/v5/order/disconnected-cancel-all` |
+| [preCheckOrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1146) | :closed_lock_with_key:  | POST | `/v5/order/pre-check` |
+| [getPositionInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1169) | :closed_lock_with_key:  | GET | `/v5/position/list` |
+| [setLeverage()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1184) | :closed_lock_with_key:  | POST | `/v5/position/set-leverage` |
+| [switchIsolatedMargin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1197) | :closed_lock_with_key:  | POST | `/v5/position/switch-isolated` |
+| [setTPSLMode()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1211) | :closed_lock_with_key:  | POST | `/v5/position/set-tpsl-mode` |
+| [switchPositionMode()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1226) | :closed_lock_with_key:  | POST | `/v5/position/switch-mode` |
+| [setRiskLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1240) | :closed_lock_with_key:  | POST | `/v5/position/set-risk-limit` |
+| [setTradingStop()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1255) | :closed_lock_with_key:  | POST | `/v5/position/trading-stop` |
+| [setAutoAddMargin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1266) | :closed_lock_with_key:  | POST | `/v5/position/set-auto-add-margin` |
+| [addOrReduceMargin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1278) | :closed_lock_with_key:  | POST | `/v5/position/add-margin` |
+| [getClosedPnL()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1290) | :closed_lock_with_key:  | GET | `/v5/position/closed-pnl` |
+| [getClosedOptionsPositions()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1304) | :closed_lock_with_key:  | GET | `/v5/position/get-closed-positions` |
+| [movePosition()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1329) | :closed_lock_with_key:  | POST | `/v5/position/move-positions` |
+| [getMovePositionHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1340) | :closed_lock_with_key:  | GET | `/v5/position/move-history` |
+| [confirmNewRiskLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1359) | :closed_lock_with_key:  | POST | `/v5/position/confirm-pending-mmr` |
+| [getPreUpgradeOrderHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1379) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/order/history` |
+| [getPreUpgradeTradeHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1394) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/execution/list` |
+| [getPreUpgradeClosedPnl()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1405) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/position/closed-pnl` |
+| [getPreUpgradeTransactions()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1419) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/account/transaction-log` |
+| [getPreUpgradeOptionDeliveryRecord()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1436) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/asset/delivery-record` |
+| [getPreUpgradeUSDCSessionSettlements()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1450) | :closed_lock_with_key:  | GET | `/v5/pre-upgrade/asset/settlement-record` |
+| [getWalletBalance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1471) | :closed_lock_with_key:  | GET | `/v5/account/wallet-balance` |
+| [getTransferableAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1482) | :closed_lock_with_key:  | GET | `/v5/account/withdrawal` |
+| [getAccountInstrumentsInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1498) | :closed_lock_with_key:  | GET | `/v5/account/instruments-info` |
+| [upgradeToUnifiedAccount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1509) | :closed_lock_with_key:  | POST | `/v5/account/upgrade-to-uta` |
+| [getBorrowHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1520) | :closed_lock_with_key:  | GET | `/v5/account/borrow-history` |
+| [repayLiability()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1534) | :closed_lock_with_key:  | POST | `/v5/account/quick-repayment` |
+| [manualRepay()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1551) | :closed_lock_with_key:  | POST | `/v5/account/repay` |
+| [setCollateralCoin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1560) | :closed_lock_with_key:  | POST | `/v5/account/set-collateral-switch` |
+| [batchSetCollateralCoin()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1566) | :closed_lock_with_key:  | POST | `/v5/account/set-collateral-switch-batch` |
+| [getCollateralInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1576) | :closed_lock_with_key:  | GET | `/v5/account/collateral-info` |
+| [getCoinGreeks()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1585) | :closed_lock_with_key:  | GET | `/v5/asset/coin-greeks` |
+| [getFeeRate()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1598) | :closed_lock_with_key:  | GET | `/v5/account/fee-rate` |
+| [getAccountInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1607) | :closed_lock_with_key:  | GET | `/v5/account/info` |
+| [getDCPInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1620) | :closed_lock_with_key:  | GET | `/v5/account/query-dcp-info` |
+| [getTransactionLog()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1627) | :closed_lock_with_key:  | GET | `/v5/account/transaction-log` |
+| [getClassicTransactionLogs()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1638) | :closed_lock_with_key:  | GET | `/v5/account/contract-transaction-log` |
+| [getSMPGroup()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1649) | :closed_lock_with_key:  | GET | `/v5/account/smp-group` |
+| [setMarginMode()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1662) | :closed_lock_with_key:  | POST | `/v5/account/set-margin-mode` |
+| [setSpotHedging()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1679) | :closed_lock_with_key:  | POST | `/v5/account/set-hedging-mode` |
+| [setLimitPriceAction()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1692) | :closed_lock_with_key:  | POST | `/v5/account/set-limit-px-action` |
+| [getLimitPriceAction()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1702) | :closed_lock_with_key:  | GET | `/v5/account/user-setting-config` |
+| [setMMP()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1714) | :closed_lock_with_key:  | POST | `/v5/account/mmp-modify` |
+| [resetMMP()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1721) | :closed_lock_with_key:  | POST | `/v5/account/mmp-reset` |
+| [getMMPState()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1728) | :closed_lock_with_key:  | GET | `/v5/account/mmp-state` |
+| [getDeliveryRecord()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1745) | :closed_lock_with_key:  | GET | `/v5/asset/delivery-record` |
+| [getSettlementRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1756) | :closed_lock_with_key:  | GET | `/v5/asset/settlement-record` |
+| [getCoinExchangeRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1769) | :closed_lock_with_key:  | GET | `/v5/asset/exchange/order-record` |
+| [getCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1781) | :closed_lock_with_key:  | GET | `/v5/asset/coin/query-info` |
+| [getSubUID()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1795) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-sub-member-list` |
+| [getAssetInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1810) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-asset-info` |
+| [getAllCoinsBalance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1821) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-account-coins-balance` |
+| [getCoinBalance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1835) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-account-coin-balance` |
+| [getWithdrawableAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1847) | :closed_lock_with_key:  | GET | `/v5/asset/withdraw/withdrawable-amount` |
+| [getTransferableCoinList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1856) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-transfer-coin-list` |
+| [createInternalTransfer()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1872) | :closed_lock_with_key:  | POST | `/v5/asset/transfer/inter-transfer` |
+| [getInternalTransferRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1891) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-inter-transfer-list` |
+| [enableUniversalTransferForSubUIDs()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1911) | :closed_lock_with_key:  | POST | `/v5/asset/transfer/save-transfer-sub-member` |
+| [createUniversalTransfer()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1922) | :closed_lock_with_key:  | POST | `/v5/asset/transfer/universal-transfer` |
+| [getUniversalTransferRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1934) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-universal-transfer-list` |
+| [getAllowedDepositCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1947) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-allowed-list` |
+| [setDepositAccount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1961) | :closed_lock_with_key:  | POST | `/v5/asset/deposit/deposit-to-account` |
+| [getDepositRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1977) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-record` |
+| [getSubAccountDepositRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L1992) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-sub-member-record` |
+| [getInternalDepositRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2008) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-internal-record` |
+| [getMasterDepositAddress()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2020) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-address` |
+| [getSubDepositAddress()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2038) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-sub-member-address` |
+| [querySubMemberAddress()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2063) | :closed_lock_with_key:  | GET | `/v5/asset/deposit/query-sub-member-address` |
+| [getWithdrawalRecords()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2083) | :closed_lock_with_key:  | GET | `/v5/asset/withdraw/query-record` |
+| [getWithdrawalAddressList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2095) | :closed_lock_with_key:  | GET | `/v5/asset/withdraw/query-address` |
+| [getExchangeEntities()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2109) | :closed_lock_with_key:  | GET | `/v5/asset/withdraw/vasp/list` |
+| [submitWithdrawal()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2122) | :closed_lock_with_key:  | POST | `/v5/asset/withdraw/create` |
+| [cancelWithdrawal()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2133) | :closed_lock_with_key:  | POST | `/v5/asset/withdraw/cancel` |
+| [getConvertCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2142) | :closed_lock_with_key:  | GET | `/v5/asset/exchange/query-coin-list` |
+| [requestConvertQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2153) | :closed_lock_with_key:  | POST | `/v5/asset/exchange/quote-apply` |
+| [confirmConvertQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2162) | :closed_lock_with_key:  | POST | `/v5/asset/exchange/convert-execute` |
+| [getConvertStatus()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2174) | :closed_lock_with_key:  | GET | `/v5/asset/exchange/convert-result-query` |
+| [getConvertHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2193) | :closed_lock_with_key:  | GET | `/v5/asset/exchange/query-convert-history` |
+| [getSmallBalanceList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2210) | :closed_lock_with_key:  | GET | `/v5/asset/covert/small-balance-list` |
+| [getFiatTradingPairList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2224) | :closed_lock_with_key:  | GET | `/v5/fiat/query-coin-list` |
+| [createSubMember()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2242) | :closed_lock_with_key:  | POST | `/v5/user/create-sub-member` |
+| [createSubUIDAPIKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2254) | :closed_lock_with_key:  | POST | `/v5/user/create-sub-api` |
+| [getSubUIDList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2263) | :closed_lock_with_key:  | GET | `/v5/user/query-sub-members` |
+| [getSubUIDListUnlimited()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2272) | :closed_lock_with_key:  | GET | `/v5/user/submembers` |
+| [setSubUIDFrozenState()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2290) | :closed_lock_with_key:  | POST | `/v5/user/frozen-sub-member` |
+| [getQueryApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2303) | :closed_lock_with_key:  | GET | `/v5/user/query-api` |
+| [getSubAccountAllApiKeys()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2310) | :closed_lock_with_key:  | GET | `/v5/user/sub-apikeys` |
+| [getUIDWalletType()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2319) | :closed_lock_with_key:  | GET | `/v5/user/get-member-type` |
+| [updateMasterApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2336) | :closed_lock_with_key:  | POST | `/v5/user/update-api` |
+| [updateSubApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2350) | :closed_lock_with_key:  | POST | `/v5/user/update-sub-api` |
+| [deleteSubMember()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2363) | :closed_lock_with_key:  | POST | `/v5/user/del-submember` |
+| [deleteMasterApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2378) | :closed_lock_with_key:  | POST | `/v5/user/delete-api` |
+| [deleteSubApiKey()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2392) | :closed_lock_with_key:  | POST | `/v5/user/delete-sub-api` |
+| [getAffiliateUserList()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2412) | :closed_lock_with_key:  | GET | `/v5/affiliate/aff-user-list` |
+| [getAffiliateUserInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2431) | :closed_lock_with_key:  | GET | `/v5/user/aff-customer-info` |
+| [getVIPMarginData()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2451) |  | GET | `/v5/spot-margin-trade/data` |
+| [getHistoricalInterestRate()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2462) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/interest-rate-history` |
+| [toggleSpotMarginTrade()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2489) | :closed_lock_with_key:  | POST | `/v5/spot-margin-trade/switch-mode` |
+| [setSpotMarginLeverage()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2500) | :closed_lock_with_key:  | POST | `/v5/spot-margin-trade/set-leverage` |
+| [setSpotMarginLeverageV2()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2508) | :closed_lock_with_key:  | POST | `/v5/spot-margin-trade/set-leverage` |
+| [getSpotMarginState()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2519) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/state` |
+| [manualBorrow()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2526) | :closed_lock_with_key:  | POST | `/v5/account/borrow` |
+| [getMaxBorrowableAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2535) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/max-borrowable` |
+| [getPositionTiers()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2544) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/position-tiers` |
+| [getCoinState()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2555) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/coinstate` |
+| [getAvailableAmountToRepay()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2566) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/repayment-available-amount` |
+| [manualRepayWithoutConversion()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2581) | :closed_lock_with_key:  | POST | `/v5/account/no-convert-repay` |
+| [getAutoRepayMode()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2594) | :closed_lock_with_key:  | GET | `/v5/spot-margin-trade/get-auto-repay-mode` |
+| [setAutoRepayMode()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2610) | :closed_lock_with_key:  | POST | `/v5/spot-margin-trade/set-auto-repay-mode` |
+| [getSpotMarginCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2628) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/pledge-token` |
+| [getSpotMarginBorrowableCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2645) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/borrow-token` |
+| [getSpotMarginInterestAndQuota()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2662) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/loan-info` |
+| [getSpotMarginLoanAccountInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2680) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/account` |
+| [spotMarginBorrow()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2704) | :closed_lock_with_key:  | POST | `/v5/spot-cross-margin-trade/loan` |
+| [spotMarginRepay()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2715) | :closed_lock_with_key:  | POST | `/v5/spot-cross-margin-trade/repay` |
+| [getSpotMarginBorrowOrderDetail()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2730) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/orders` |
+| [getSpotMarginRepaymentOrderDetail()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2759) | :closed_lock_with_key:  | GET | `/v5/spot-cross-margin-trade/repay-history` |
+| [toggleSpotCrossMarginTrade()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2788) | :closed_lock_with_key:  | POST | `/v5/spot-cross-margin-trade/switch` |
+| [getCollateralCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2808) |  | GET | `/v5/crypto-loan/collateral-data` |
+| [getBorrowableCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2825) |  | GET | `/v5/crypto-loan/loanable-data` |
+| [getAccountBorrowCollateralLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2843) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/borrowable-collateralisable-number` |
+| [borrowCryptoLoan()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2863) | :closed_lock_with_key:  | POST | `/v5/crypto-loan/borrow` |
+| [repayCryptoLoan()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2884) | :closed_lock_with_key:  | POST | `/v5/crypto-loan/repay` |
+| [getUnpaidLoanOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2900) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/ongoing-orders` |
+| [getRepaymentHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2921) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/repayment-history` |
+| [getCompletedLoanOrderHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2941) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/borrow-history` |
+| [getMaxAllowedReductionCollateralAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2960) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/max-collateral-amount` |
+| [adjustCollateralAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L2979) | :closed_lock_with_key:  | POST | `/v5/crypto-loan/adjust-ltv` |
+| [getLoanLTVAdjustmentHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3003) | :closed_lock_with_key:  | GET | `/v5/crypto-loan/adjustment-history` |
+| [getLoanBorrowableCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3024) |  | GET | `/v5/crypto-loan-common/loanable-data` |
+| [getLoanCollateralCoins()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3036) |  | GET | `/v5/crypto-loan-common/collateral-data` |
+| [getMaxCollateralAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3046) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-common/max-collateral-amount` |
+| [getMaxLoanAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3065) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-common/max-loan` |
+| [updateCollateralAmount()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3075) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-common/adjust-ltv` |
+| [getCollateralAdjustmentHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3086) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-common/adjustment-history` |
+| [getCryptoLoanPosition()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3101) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-common/position` |
+| [borrowFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3118) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-flexible/borrow` |
+| [repayFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3129) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-flexible/repay` |
+| [repayCollateralFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3139) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-flexible/repay-collateral` |
+| [getOngoingFlexibleLoans()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3153) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-flexible/ongoing-coin` |
+| [getBorrowHistoryFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3165) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-flexible/borrow-history` |
+| [getRepaymentHistoryFlexible()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3178) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-flexible/repayment-history` |
+| [getSupplyOrderQuoteFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3203) |  | GET | `/v5/crypto-loan-fixed/supply-order-quote` |
+| [getBorrowOrderQuoteFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3216) |  | GET | `/v5/crypto-loan-fixed/borrow-order-quote` |
+| [createBorrowOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3229) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/borrow` |
+| [createSupplyOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3240) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/supply` |
+| [cancelBorrowOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3250) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/borrow-order-cancel` |
+| [cancelSupplyOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3262) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/supply-order-cancel` |
+| [getBorrowContractInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3275) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/borrow-contract-info` |
+| [getSupplyContractInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3293) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/supply-contract-info` |
+| [getBorrowOrderInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3311) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/borrow-order-info` |
+| [getSupplyOrderInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3324) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/supply-order-info` |
+| [repayFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3338) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/fully-repay` |
+| [repayCollateralFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3349) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-flexible/repay-collateral` |
+| [getRepaymentHistoryFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3362) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/repayment-history` |
+| [renewBorrowOrderFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3379) | :closed_lock_with_key:  | POST | `/v5/crypto-loan-fixed/renew` |
+| [getRenewOrderInfoFixed()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3392) | :closed_lock_with_key:  | GET | `/v5/crypto-loan-fixed/renew-info` |
+| [getInstitutionalLendingProductInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3410) |  | GET | `/v5/ins-loan/product-infos` |
+| [getInstitutionalLendingMarginCoinInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3420) |  | GET | `/v5/ins-loan/ensure-tokens` |
+| [getInstitutionalLendingMarginCoinInfoWithConversionRate()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3429) |  | GET | `/v5/ins-loan/ensure-tokens-convert` |
+| [getInstitutionalLendingLoanOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3438) | :closed_lock_with_key:  | GET | `/v5/ins-loan/loan-order` |
+| [getInstitutionalLendingRepayOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3450) | :closed_lock_with_key:  | GET | `/v5/ins-loan/repaid-history` |
+| [getInstitutionalLendingLTV()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3462) | :closed_lock_with_key:  | GET | `/v5/ins-loan/ltv` |
+| [getInstitutionalLendingLTVWithLadderConversionRate()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3471) | :closed_lock_with_key:  | GET | `/v5/ins-loan/ltv-convert` |
+| [bindOrUnbindUID()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3486) | :closed_lock_with_key:  | POST | `/v5/ins-loan/association-uid` |
+| [repayInstitutionalLoan()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3506) | :closed_lock_with_key:  | POST | `/v5/ins-loan/repay-loan` |
+| [getExchangeBrokerEarnings()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3527) | :closed_lock_with_key:  | GET | `/v5/broker/earnings-info` |
+| [getExchangeBrokerAccountInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3540) | :closed_lock_with_key:  | GET | `/v5/broker/account-info` |
+| [getBrokerSubAccountDeposits()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3556) | :closed_lock_with_key:  | GET | `/v5/broker/asset/query-sub-member-deposit-record` |
+| [getBrokerVoucherSpec()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3571) | :closed_lock_with_key:  | POST | `/v5/broker/award/info` |
+| [issueBrokerVoucher()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3583) | :closed_lock_with_key:  | POST | `/v5/broker/award/distribute-award` |
+| [getBrokerIssuedVoucher()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3595) | :closed_lock_with_key:  | POST | `/v5/broker/award/distribution-record` |
+| [getEarnProduct()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3612) |  | GET | `/v5/earn/product` |
+| [submitStakeRedeem()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3630) | :closed_lock_with_key:  | POST | `/v5/earn/place-order` |
+| [getEarnOrderHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3649) | :closed_lock_with_key:  | GET | `/v5/earn/order` |
+| [getEarnPosition()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3665) | :closed_lock_with_key:  | GET | `/v5/earn/position` |
+| [getEarnYieldHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3678) | :closed_lock_with_key:  | GET | `/v5/earn/yield` |
+| [getEarnHourlyYieldHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3692) | :closed_lock_with_key:  | GET | `/v5/earn/hourly-yield` |
+| [createRFQ()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3711) | :closed_lock_with_key:  | POST | `/v5/rfq/create-rfq` |
+| [getRFQConfig()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3722) | :closed_lock_with_key:  | GET | `/v5/rfq/config` |
+| [cancelRFQ()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3731) | :closed_lock_with_key:  | POST | `/v5/rfq/cancel-rfq` |
+| [cancelAllRFQ()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3741) | :closed_lock_with_key:  | POST | `/v5/rfq/cancel-all-rfq` |
+| [createRFQQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3750) | :closed_lock_with_key:  | POST | `/v5/rfq/create-quote` |
+| [executeRFQQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3761) | :closed_lock_with_key:  | POST | `/v5/rfq/execute-quote` |
+| [cancelRFQQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3772) | :closed_lock_with_key:  | POST | `/v5/rfq/cancel-quote` |
+| [cancelAllRFQQuotes()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3782) | :closed_lock_with_key:  | POST | `/v5/rfq/cancel-all-quotes` |
+| [getRFQRealtimeInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3796) | :closed_lock_with_key:  | GET | `/v5/rfq/rfq-realtime` |
+| [getRFQHistory()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3808) | :closed_lock_with_key:  | GET | `/v5/rfq/rfq-list` |
+| [getRFQRealtimeQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3822) | :closed_lock_with_key:  | GET | `/v5/rfq/quote-realtime` |
+| [getRFQHistoryQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3837) | :closed_lock_with_key:  | GET | `/v5/rfq/quote-list` |
+| [getRFQTrades()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3850) | :closed_lock_with_key:  | GET | `/v5/rfq/trade-list` |
+| [getRFQPublicTrades()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3863) | :closed_lock_with_key:  | GET | `/v5/rfq/public-trades` |
+| [acceptNonLPQuote()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3879) | :closed_lock_with_key:  | POST | `/v5/rfq/accept-other-quote` |
+| [getP2PAccountCoinsBalance()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3901) | :closed_lock_with_key:  | GET | `/v5/asset/transfer/query-account-coins-balance` |
+| [getP2POnlineAds()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3918) | :closed_lock_with_key:  | POST | `/v5/p2p/item/online` |
+| [createP2PAd()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3927) | :closed_lock_with_key:  | POST | `/v5/p2p/item/create` |
+| [cancelP2PAd()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3936) | :closed_lock_with_key:  | POST | `/v5/p2p/item/cancel` |
+| [updateP2PAd()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3950) | :closed_lock_with_key:  | POST | `/v5/p2p/item/update` |
+| [getP2PPersonalAds()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3960) | :closed_lock_with_key:  | POST | `/v5/p2p/item/personal/list` |
+| [getP2PAdDetail()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3969) | :closed_lock_with_key:  | POST | `/v5/p2p/item/info` |
+| [getP2POrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3984) | :closed_lock_with_key:  | POST | `/v5/p2p/order/simplifyList` |
+| [getP2POrderDetail()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L3994) | :closed_lock_with_key:  | POST | `/v5/p2p/order/info` |
+| [getP2PPendingOrders()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4003) | :closed_lock_with_key:  | POST | `/v5/p2p/order/pending/simplifyList` |
+| [markP2POrderAsPaid()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4012) | :closed_lock_with_key:  | POST | `/v5/p2p/order/pay` |
+| [releaseP2POrder()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4021) | :closed_lock_with_key:  | POST | `/v5/p2p/order/finish` |
+| [sendP2POrderMessage()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4030) | :closed_lock_with_key:  | POST | `/v5/p2p/order/message/send` |
+| [getP2POrderMessages()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4064) | :closed_lock_with_key:  | POST | `/v5/p2p/order/message/listpage` |
+| [getP2PUserInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4078) | :closed_lock_with_key:  | POST | `/v5/p2p/user/personal/info` |
+| [getP2PCounterpartyUserInfo()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4085) | :closed_lock_with_key:  | POST | `/v5/p2p/user/order/personal/info` |
+| [getP2PUserPayments()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4094) | :closed_lock_with_key:  | POST | `/v5/p2p/user/payment/list` |
+| [setApiRateLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4114) | :closed_lock_with_key:  | POST | `/v5/apilimit/set` |
+| [queryApiRateLimit()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4143) | :closed_lock_with_key:  | GET | `/v5/apilimit/query` |
+| [getRateLimitCap()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4162) | :closed_lock_with_key:  | GET | `/v5/apilimit/query-cap` |
+| [getAllRateLimits()](https://github.com/tiagosiebler/bybit-api/blob/master/src/rest-client-v5.ts#L4181) | :closed_lock_with_key:  | GET | `/v5/apilimit/query-all` |
 
 # websocket-api-client.ts
 

--- a/examples/apidoc/V5/Asset/get-fiat-trading-pair-list.js
+++ b/examples/apidoc/V5/Asset/get-fiat-trading-pair-list.js
@@ -1,0 +1,20 @@
+// https://api.bybit.com/v5/fiat/query-coin-list
+
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getFiatTradingPairList({
+    side: 0,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-small-balance-list.js
+++ b/examples/apidoc/V5/Asset/get-small-balance-list.js
@@ -1,0 +1,21 @@
+// https://api.bybit.com/v5/asset/covert/small-balance-list
+
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getSmallBalanceList({
+    accountType: 'eb_convert_uta',
+    fromCoin: 'XRP',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Crypto-Loan-New/get-max-loan-amount.js
+++ b/examples/apidoc/V5/Crypto-Loan-New/get-max-loan-amount.js
@@ -1,0 +1,30 @@
+// https://api.bybit.com/v5/crypto-loan-common/max-loan
+
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getMaxLoanAmount({
+    currency: 'BTC',
+    collateralList: [
+      {
+        ccy: 'XRP',
+        amount: '1000',
+      },
+      {
+        ccy: 'USDT',
+        amount: '1000',
+      },
+    ],
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Institutional-Loan/repay-loan.js
+++ b/examples/apidoc/V5/Institutional-Loan/repay-loan.js
@@ -1,0 +1,21 @@
+// https://api.bybit.com/v5/ins-loan/repay-loan
+
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .repayInstitutionalLoan({
+    token: 'USDT',
+    quantity: '500000',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/RFQ/accept-non-lp-quote.js
+++ b/examples/apidoc/V5/RFQ/accept-non-lp-quote.js
@@ -1,0 +1,20 @@
+// https://api.bybit.com/v5/rfq/accept-other-quote
+
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .acceptNonLPQuote({
+    rfqId: '1754364447601610516653123084412812',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/RFQ/get-rfq-history.js
+++ b/examples/apidoc/V5/RFQ/get-rfq-history.js
@@ -1,0 +1,23 @@
+// https://api.bybit.com/v5/rfq/rfq-list
+
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getRFQHistory({
+    rfqId: '1756885055799241492396882271696580', 
+    traderType: 'quote', 
+    status: 'Active',
+    limit: 50,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/RFQ/get-rfq-realtime.js
+++ b/examples/apidoc/V5/RFQ/get-rfq-realtime.js
@@ -1,0 +1,21 @@
+// https://api.bybit.com/v5/rfq/rfq-realtime
+
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getRFQRealtimeInfo({
+    rfqId: '1756885055799241492396882271696580', 
+    traderType: 'request', 
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Margin-Trade-(UTA)/get-auto-repay-mode.js
+++ b/examples/apidoc/V5/Spot-Margin-Trade-(UTA)/get-auto-repay-mode.js
@@ -1,0 +1,20 @@
+// https://api.bybit.com/v5/spot-margin-trade/get-auto-repay-mode
+
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getAutoRepayMode({
+    currency: 'ETH', // optional
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Margin-Trade-(UTA)/set-auto-repay-mode.js
+++ b/examples/apidoc/V5/Spot-Margin-Trade-(UTA)/set-auto-repay-mode.js
@@ -1,0 +1,21 @@
+// https://api.bybit.com/v5/spot-margin-trade/set-auto-repay-mode
+
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .setAutoRepayMode({
+    currency: 'ETH', // optional: if not passed, applies to all currencies
+    autoRepayMode: '1', // 0: Off, 1: On
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/llms.txt
+++ b/llms.txt
@@ -38,7 +38,7 @@ Notes:
 ------
 - Some files may have been excluded based on .gitignore rules and Repomix's configuration
 - Binary files are not included in this packed representation. Please refer to the Repository Structure section for a complete list of file paths, including binary files
-- Files matching these patterns are excluded: .github/, examples/apidoc/, docs/images/, docs/endpointFunctionList.md, test/, src/util/
+- Files matching these patterns are excluded: .github/, examples/apidoc/, docs/images/, docs/endpointFunctionList.md, test/, src/util/, dist/, lib/
 - Files matching patterns in .gitignore are excluded
 - Files matching default ignore patterns are excluded
 - Content has been compressed - code blocks are separated by ⋮---- delimiter
@@ -215,6 +215,76 @@ function setWsClientEventListeners(
 // Trade USDT linear perps
 
 ================
+File: examples/fasterHmacSign.ts
+================
+import { createHmac } from 'crypto';
+⋮----
+import { DefaultLogger, RestClientV5, WebsocketClient } from '../src/index';
+⋮----
+// or
+// import { createHmac } from 'crypto';
+// import { DefaultLogger, RestClientV5, WebsocketClient } from 'bybit-api';
+⋮----
+/**
+ * Injecting a custom signMessage function.
+ *
+ * As of version 4.0.0 of the bybit-api Node.js/TypeScript/JavaScript
+ * SDK for Bybit, the SDK uses the Web Crypto API for signing requests.
+ * While it is compatible with Node and Browser environments, it is
+ * slightly slower than using Node's native crypto module (only
+ * available in backend Node environments).
+ *
+ * For latency sensitive users, you can inject the previous node crypto sign
+ * method (or your own even faster-implementation), if this change affects you.
+ *
+ * This example demonstrates how to inject a custom sign function, to achieve
+ * the same peformance as seen before the Web Crypto API was introduced.
+ *
+ * For context on standard usage, the "signMessage" function is used:
+ * - During every single API call
+ * - After opening a new private WebSocket connection
+ *
+ */
+⋮----
+/**
+   * Set this to true to enable demo trading:
+   */
+⋮----
+/**
+   * Overkill in almost every case, but if you need any optimisation available,
+   * you can inject a faster sign mechanism such as node's native createHmac:
+   */
+⋮----
+// Optional, uncomment the "trace" override to log a lot more info about what the WS client is doing
+⋮----
+// trace: (...params) => console.log('trace', ...params),
+⋮----
+/**
+     * Set this to true to enable demo trading for the private account data WS
+     * Topics: order,execution,position,wallet,greeks
+     */
+⋮----
+/**
+     * Overkill in almost every case, but if you need any optimisation available,
+     * you can inject a faster sign mechanism such as node's native createHmac:
+     */
+⋮----
+function setWsClientEventListeners(
+  websocketClient: WebsocketClient,
+  accountRef: string,
+): Promise<void>
+⋮----
+// console.log('raw message received ', JSON.stringify(data, null, 2));
+⋮----
+// Simple promise to ensure we're subscribed before trying anything else
+⋮----
+// Start trading
+⋮----
+/** Simple examples for private REST API calls with bybit's V5 REST APIs */
+⋮----
+// Trade USDT linear perps
+
+================
 File: examples/README.md
 ================
 # Examples
@@ -303,6 +373,18 @@ limit: 50, // Maximum page size per request
 cursor: nextCursor || undefined, // Only send cursor if we have one
 ⋮----
 // Optional: Add a small delay to avoid rate limits
+
+================
+File: examples/rest-v5-private.ts
+================
+import { RestClientV5 } from '../src/index';
+⋮----
+// or
+// import { RestClientV5 } from 'bybit-api';
+⋮----
+/** Simple examples for private REST API calls with bybit's V5 REST APIs */
+⋮----
+// Trade USDT linear perps
 
 ================
 File: examples/rest-v5-proxies.ts
@@ -489,6 +571,319 @@ logger, // Optional: inject a custom logger
 // Optional: prepare the WebSocket API connection in advance.
 // This happens automatically but you can do this early before making any API calls, to prevent delays from a cold start.
 // await wsClient.getWSClient().connectWSAPI();
+
+================
+File: examples/ws-api-raw-events.ts
+================
+import { DefaultLogger, WebsocketClient, WS_KEY_MAP } from '../src';
+⋮----
+// or
+// import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from 'bybit-api';
+⋮----
+// For a more detailed view of the WebsocketClient, enable the `trace` level by uncommenting the below line:
+// trace: (...params) => console.log('trace', ...params),
+⋮----
+// testnet: true, // Whether to use the testnet environment: https://testnet.bybit.com/app/user/api-management
+// demoTrading: false, // note: As of Jan 2025, demo trading does NOT support the WS API
+⋮----
+logger, // Optional: inject a custom logger
+⋮----
+/**
+ * General event handlers for monitoring the WebsocketClient
+ */
+⋮----
+async function main()
+⋮----
+/**
+   *
+   * This SDK's WebSocket API integration is event-driven at its core. You can treat the sentWSAPIRquest(...) method as
+   * a fire-and-forget method, to submit commands (create/amend/cancel order) via a WebSocket Connection.
+   *
+   * Replies to commands will show in the `response` event from the WebsocketClient's EventEmitter. Exceptions, however,
+   * will show in the `error` event from the WebsocketClient's EventEmitter.
+   *
+   * - Fire-and-forget a command.
+   * - Handle command results in the `response` event handler asynchronously as desired.
+   * - Handle any exceptions in a catch block.
+   *
+   * This is a more "raw" workflow in how WebSockets behave. For a more convenient & REST-like approach, using the
+   * promise-driven interface is recommended. See the `ws-api-raw-promises.ts` and `ws-api-client.ts` examples for a
+   * demonstration you can compare.
+   *
+   * Note: even without using promises, you should still tie on a .catch handler to each sendWSAPIRequest call, to prevent
+   * any unnecessary "unhandled promise rejection" exceptions.
+   *
+   */
+⋮----
+// To make it easier to watch, wait a few seconds before sending the amend order
+⋮----
+// Then wait a few more before sending the cancel order
+⋮----
+// Exceptions including rejected commands will show here (as well as the catch handler used below)
+⋮----
+// Replies to commands will show here
+⋮----
+/**
+   *
+   * If you haven't connected yet, the WebsocketClient will automatically connect and authenticate you as soon as you send
+   * your first command. That connection will then be reused for every command you send, unless the connection drops - then
+   * it will automatically be replaced with a healthy connection.
+   *
+   * This "not connected yet" scenario can add an initial delay to your first command. If you want to prepare a connection
+   * in advance, you can ask the WebsocketClient to prepare it before you start submitting commands. This is optional.
+   *
+   * Repeated note: even without using promises, you should still tie on a .catch handler to each sendWSAPIRequest call, to prevent
+   * any unnecessary "unhandled promise rejection" exceptions.
+   *
+   */
+⋮----
+// Optional, see above. Can be used to prepare a connection before sending commands
+⋮----
+// Fire and forget the create.order command
+// Even without using promises, you should still "catch" exceptions (although no need to await anything you send)
+⋮----
+//
+⋮----
+// Fire and forget the order.amend command
+// For simplicity, the orderId is hardcoded here (and will probably not work)
+⋮----
+//
+⋮----
+// Fire and forget the order.cancel command
+// For simplicity, the orderId is hardcoded here (and will probably not work)
+⋮----
+// Start executing the example workflow
+
+================
+File: examples/ws-api-raw-promises.ts
+================
+import { DefaultLogger, WebsocketClient, WS_KEY_MAP } from '../src';
+⋮----
+// or
+// import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from 'bybit-api';
+⋮----
+// For a more detailed view of the WebsocketClient, enable the `trace` level by uncommenting the below line:
+// trace: (...params) => console.log('trace', ...params),
+⋮----
+// testnet: true, // Whether to use the testnet environment: https://testnet.bybit.com/app/user/api-management
+// demoTrading: false, // note: As of Jan 2025, demo trading does NOT support the WS API
+⋮----
+logger, // Optional: inject a custom logger
+⋮----
+/**
+ * General event handlers for monitoring the WebsocketClient
+ */
+⋮----
+async function main()
+⋮----
+/**
+   *
+   * This SDK's WebSocket API integration can connect WS API responses to the request that caused them. Each call
+   * to the `sendWSAPIRequest(...)` method returns a promise.
+   *
+   * This promise will resolve when the matching response is detected, and reject if an exception for that request
+   * is detected. This allows using Bybit's Websocket API in the same way that a REST API normally works.
+   *
+   * Send a command and immediately await the result. Handle any exceptions in a catch block.
+   *
+   * TypeScript users can benefit from smart type flowing for increased type safety & convenience:
+   * - Request parameters are fully typed, depending on the operation in the second parameter to the call. E.g.
+   * the `order.create` operation will automatically require the params to match the `OrderParamsV5` interface.
+   *
+   * - Response parameters are fully typed, depending on the operation in the second parameter. E.g the `order.create`
+   * operation will automatically map the returned value to `WSAPIResponse<OrderResultV5, "order.create">`.
+   *
+   */
+⋮----
+// To make it easier to watch, wait a few seconds before sending the amend order
+⋮----
+// Then wait a few more before sending the cancel order
+⋮----
+/**
+   *
+   * If you haven't connected yet, the WebsocketClient will automatically connect and authenticate you as soon as you send
+   * your first command. That connection will then be reused for every command you send, unless the connection drops - then
+   * it will automatically be replaced with a healthy connection.
+   *
+   * This "not connected yet" scenario can add an initial delay to your first command. If you want to prepare a connection
+   * in advance, you can ask the WebsocketClient to prepare it before you start submitting commands. This is optional.
+   *
+   */
+⋮----
+// Optional, see above. Can be used to prepare a connection before sending commands
+⋮----
+/**
+   * Create a new order
+   */
+⋮----
+// The type for `wsAPISubmitOrderResult` is automatically resolved to `WSAPIResponse<OrderResultV5, "order.create">`
+⋮----
+// Save the orderId for the next call
+⋮----
+// The type for `wsAPIAmendOrderResult` is automatically resolved to `WSAPIResponse<OrderResultV5, "order.amend">`
+⋮----
+// Save the orderId for the next call
+⋮----
+// The type for `wsAPICancelOrderResult` is automatically resolved to `WSAPIResponse<OrderResultV5, "order.cancel">`
+⋮----
+// Start executing the example workflow
+
+================
+File: examples/ws-private-v5.ts
+================
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { DefaultLogger, WebsocketClient, WS_KEY_MAP } from '../src';
+⋮----
+// or
+// import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from 'bybit-api';
+⋮----
+// Create & inject a custom logger to enable the trace logging level (empty function)
+⋮----
+// trace: (...params) => console.log('trace', ...params),
+⋮----
+/**
+ * Prepare an instance of the WebSocket client. This client handles all aspects of connectivity for you:
+ * - Connections are opened when you subscribe to topics
+ * - If key & secret are provided, authentication is handled automatically
+ * - If you subscribe to topics from different v5 products (e.g. spot and linear perps),
+ *    subscription events are automatically routed to the different ws endpoints on bybit's side
+ * - Heartbeats/ping/pong/reconnects are all handled automatically.
+ *    If a connection drops, the client will clean it up, respawn a fresh connection and resubscribe for you.
+ */
+⋮----
+// testnet: false,
+// demoTrading: false, // set testnet to false, if you plan on using demo trading
+⋮----
+// console.log('raw message received ', JSON.stringify(data, null, 2));
+⋮----
+// wsClient.on('exception', (data) => {
+//   console.error('ws exception: ', data);
+// });
+⋮----
+/**
+ * For private V5 topics, us the subscribeV5() method on the ws client or use the original subscribe() method.
+ *
+ * Note: for private endpoints the "category" field is ignored since there is only one private endpoint
+ * (compared to one public one per category).
+ * The "category" is only needed for public topics since bybit has one endpoint for public events per category.
+ */
+⋮----
+// wsClient.subscribeV5('execution.fast', 'linear');
+// wsClient.subscribeV5('execution.fast.linear', 'linear');
+⋮----
+/**
+ * The following has the same effect as above, since there's only one private endpoint for V5 account topics:
+ */
+// wsClient.subscribe('position');
+// wsClient.subscribe('execution');
+// wsClient.subscribe(['order', 'wallet', 'greek']);
+⋮----
+// To unsubscribe from topics (after a 5 second delay, in this example):
+// setTimeout(() => {
+//   console.log('unsubscribing');
+//   wsClient.unsubscribeV5('execution', 'linear');
+// }, 5 * 1000);
+⋮----
+// Topics are tracked per websocket type
+// Get a list of subscribed topics (e.g. for public v3 spot topics) (after a 5 second delay)
+
+================
+File: examples/ws-public-allLiquidations.ts
+================
+import { isWsAllLiquidationEvent, RestClientV5, WebsocketClient } from '../src';
+⋮----
+// or
+// import {
+//   RestClientV5,
+//   WebsocketClient,
+//   isWsAllLiquidationEvent,
+// } from 'bybit-api';
+⋮----
+function onAllLiquidationEvent(event)
+⋮----
+/**
+ *
+ * If you want to receive data for all available symbols, this websocket topic
+ * requires you to subscribe to each symbol individually.
+ *
+ * This can be easily automated by fetching a list of symbols via the REST client,
+ * generating a list of topics (one per symbol), before simply passing an
+ * array of topics to the websocket client per product group (linear & inverse perps).
+ *
+ */
+async function start()
+⋮----
+// Make an array of topics ready for submission
+⋮----
+// subscribe to all linear symbols
+⋮----
+// subscribe to all inverse symbols
+
+================
+File: examples/ws-public-v5.ts
+================
+import { DefaultLogger, WebsocketClient, WS_KEY_MAP } from '../src';
+⋮----
+// or
+// import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from 'bybit-api';
+⋮----
+/**
+ * Prepare an instance of the WebSocket client. This client handles all aspects of connectivity for you:
+ * - Connections are opened when you subscribe to topics
+ * - If key & secret are provided, authentication is handled automatically
+ * - If you subscribe to topics from different v5 products (e.g. spot and linear perps),
+ *    subscription events are automatically routed to the different ws endpoints on bybit's side
+ * - Heartbeats/ping/pong/reconnects are all handled automatically.
+ *    If a connection drops, the client will clean it up, respawn a fresh connection and resubscribe for you.
+ */
+⋮----
+/**
+ * For public V5 topics, use the subscribeV5 method and include the API category this topic is for.
+ * Category is required, since each category has a different websocket endpoint.
+ */
+⋮----
+// Linear v5
+// -> Just one topic per call
+// wsClient.subscribeV5('orderbook.50.BTCUSDT', 'linear');
+⋮----
+// -> Or multiple topics in one call
+// wsClient.subscribeV5(
+//   ['orderbook.50.BTCUSDT', 'orderbook.50.ETHUSDT'],
+//   'linear'
+// );
+⋮----
+// Inverse v5
+// wsClient.subscribeV5('orderbook.50.BTCUSD', 'inverse');
+⋮----
+// Spot v5
+// wsClient.subscribeV5('orderbook.50.BTCUSDT', 'spot');
+⋮----
+// Option v5
+// wsClient.subscribeV5('publicTrade.BTC', 'option');
+⋮----
+// Use the subscribeV5() call for most subscribe calls with v5 websockets
+⋮----
+// Alternatively, you can also use objects in the wsClient.subscribe() call
+// wsClient.subscribe({
+//   topic: 'orderook.50.BTCUSDT',
+//   category: 'spot',
+// });
+⋮----
+/**
+ * For private V5 topics, just call the same subscribeV5() method on the ws client or use the original subscribe() method.
+ *
+ * Note: for private endpoints the "category" field is ignored since there is only one private endpoint
+ * (compared to one public one per category)
+ */
+⋮----
+// wsClient.subscribeV5('position', 'linear');
+// wsClient.subscribeV5('execution', 'linear');
+// wsClient.subscribeV5(['order', 'wallet', 'greek'], 'linear');
+⋮----
+// To unsubscribe from topics (after a 5 second delay, in this example):
+⋮----
+// Topics are tracked per websocket type
+// Get a list of subscribed topics (e.g. for public v3 spot topics) (after a 5 second delay)
 
 ================
 File: src/constants/enum.ts
@@ -3412,6 +3807,11 @@ export interface PreUpgradeUSDCSessionSettlement {
 }
 
 ================
+File: src/types/websockets/index.ts
+================
+
+
+================
 File: src/types/websockets/ws-api.ts
 ================
 import { APIID, WS_KEY_MAP } from '../../util';
@@ -3594,397 +3994,14 @@ export interface WebsocketFailedTopicSubscriptionConfirmationEvent
 }
 
 ================
-File: src/types/websockets/ws-general.ts
+File: src/types/index.ts
 ================
-import { RestClientOptions, WS_KEY_MAP } from '../../util';
-⋮----
-/** For spot markets, spotV3 is recommended */
-export type APIMarket = 'v5';
-⋮----
-// Same as inverse futures
-export type WsPublicInverseTopic =
-  | 'orderBookL2_25'
-  | 'orderBookL2_200'
-  | 'trade'
-  | 'insurance'
-  | 'instrument_info'
-  | 'klineV2';
-⋮----
-export type WsPublicUSDTPerpTopic =
-  | 'orderBookL2_25'
-  | 'orderBookL2_200'
-  | 'trade'
-  | 'insurance'
-  | 'instrument_info'
-  | 'kline';
-⋮----
-export type WsPublicSpotV1Topic =
-  | 'trade'
-  | 'realtimes'
-  | 'kline'
-  | 'depth'
-  | 'mergedDepth'
-  | 'diffDepth';
-⋮----
-export type WsPublicSpotV2Topic =
-  | 'depth'
-  | 'kline'
-  | 'trade'
-  | 'bookTicker'
-  | 'realtimes';
-⋮----
-export type WsPublicTopics =
-  | WsPublicInverseTopic
-  | WsPublicUSDTPerpTopic
-  | WsPublicSpotV1Topic
-  | WsPublicSpotV2Topic
-  | string;
-⋮----
-// Same as inverse futures
-export type WsPrivateInverseTopic =
-  | 'position'
-  | 'execution'
-  | 'order'
-  | 'stop_order';
-⋮----
-export type WsPrivateUSDTPerpTopic =
-  | 'position'
-  | 'execution'
-  | 'order'
-  | 'stop_order'
-  | 'wallet';
-⋮----
-export type WsPrivateSpotTopic =
-  | 'outboundAccountInfo'
-  | 'executionReport'
-  | 'ticketInfo';
-⋮----
-export type WsPrivateTopic =
-  | WsPrivateInverseTopic
-  | WsPrivateUSDTPerpTopic
-  | WsPrivateSpotTopic
-  | string;
-⋮----
-export type WsTopic = WsPublicTopics | WsPrivateTopic;
-⋮----
-/** This is used to differentiate between each of the available websocket streams (as bybit has multiple websockets) */
-export type WsKey = (typeof WS_KEY_MAP)[keyof typeof WS_KEY_MAP];
-export type WsMarket = 'all';
-⋮----
-export interface WSClientConfigurableOptions {
-  /** Your API key */
-  key?: string;
 
-  /** Your API secret */
-  secret?: string;
-
-  /**
-   * Set to `true` to connect to Bybit's testnet environment.
-   *
-   * Notes:
-   *
-   * - If demo trading, `testnet` should be set to false!
-   * - If testing a strategy, use demo trading instead. Testnet market data is very different from real market conditions.
-   */
-  testnet?: boolean;
-
-  /**
-   * Set to `true` to connect to Bybit's V5 demo trading: https://bybit-exchange.github.io/docs/v5/demo
-   *
-   * Only the "V5" "market" is supported here.
-   */
-  demoTrading?: boolean;
-
-  /**
-   * The API group this client should connect to. The V5 market is currently used by default.
-   *
-   * Only the "V5" "market" is supported here.
-   */
-  market?: APIMarket;
-
-  /** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
-  recvWindow?: number;
-
-  /** How often to check if the connection is alive */
-  pingInterval?: number;
-
-  /** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
-  pongTimeout?: number;
-
-  /** Delay in milliseconds before respawning the connection */
-  reconnectTimeout?: number;
-
-  restOptions?: RestClientOptions;
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  requestOptions?: any;
-
-  wsUrl?: string;
-
-  /**
-   * Default: false.
-   *
-   * When enabled, any calls to the subscribe method will return a promise.
-   * Note: internally, subscription requests are sent in batches. This may not behave as expected when
-   * subscribing to a large number of topics, especially if you are not yet connected when subscribing.
-   */
-  promiseSubscribeRequests?: boolean;
-
-  /**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
-}
-⋮----
-/** Your API key */
-⋮----
-/** Your API secret */
-⋮----
-/**
-   * Set to `true` to connect to Bybit's testnet environment.
-   *
-   * Notes:
-   *
-   * - If demo trading, `testnet` should be set to false!
-   * - If testing a strategy, use demo trading instead. Testnet market data is very different from real market conditions.
-   */
-⋮----
-/**
-   * Set to `true` to connect to Bybit's V5 demo trading: https://bybit-exchange.github.io/docs/v5/demo
-   *
-   * Only the "V5" "market" is supported here.
-   */
-⋮----
-/**
-   * The API group this client should connect to. The V5 market is currently used by default.
-   *
-   * Only the "V5" "market" is supported here.
-   */
-⋮----
-/** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
-⋮----
-/** How often to check if the connection is alive */
-⋮----
-/** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
-⋮----
-/** Delay in milliseconds before respawning the connection */
-⋮----
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-⋮----
-/**
-   * Default: false.
-   *
-   * When enabled, any calls to the subscribe method will return a promise.
-   * Note: internally, subscription requests are sent in batches. This may not behave as expected when
-   * subscribing to a large number of topics, especially if you are not yet connected when subscribing.
-   */
-⋮----
-/**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-⋮----
-/**
- * WS configuration that's always defined, regardless of user configuration
- * (usually comes from defaults if there's no user-provided values)
- */
-export interface WebsocketClientOptions extends WSClientConfigurableOptions {
-  market: APIMarket;
-  pongTimeout: number;
-  pingInterval: number;
-  reconnectTimeout: number;
-  recvWindow: number;
-  authPrivateConnectionsOnConnect: boolean;
-  authPrivateRequests: boolean;
-}
 
 ================
-File: src/types/shared.ts
+File: src/index.ts
 ================
-import { RestClientV5 } from '../rest-client-v5';
-import { SpotClientV3 } from '../spot-client-v3';
-⋮----
-export type RESTClient = SpotClientV3 | RestClientV5;
-⋮----
-export type numberInString = string;
-⋮----
-export type OrderSide = 'Buy' | 'Sell';
-⋮----
-export type KlineInterval =
-  | '1m'
-  | '3m'
-  | '5m'
-  | '15m'
-  | '30m'
-  | '1h'
-  | '2h'
-  | '4h'
-  | '6h'
-  | '12h'
-  | '1d'
-  | '1w'
-  | '1M';
-⋮----
-export type KlineIntervalV3 =
-  | '1'
-  | '3'
-  | '5'
-  | '15'
-  | '30'
-  | '60'
-  | '120'
-  | '240'
-  | '360'
-  | '720'
-  | 'D'
-  | 'W'
-  | 'M';
-⋮----
-export interface APIRateLimit {
-  /** Remaining requests to this endpoint before the next reset */
-  remainingRequests: number;
-  /** Max requests for this endpoint per rollowing window (before next reset) */
-  maxRequests: number;
-  /**
-   * Timestamp when the rate limit resets if you have exceeded your current maxRequests.
-   * Otherwise, this is approximately your current timestamp.
-   */
-  resetAtTimestamp: number;
-}
-⋮----
-/** Remaining requests to this endpoint before the next reset */
-⋮----
-/** Max requests for this endpoint per rollowing window (before next reset) */
-⋮----
-/**
-   * Timestamp when the rate limit resets if you have exceeded your current maxRequests.
-   * Otherwise, this is approximately your current timestamp.
-   */
-⋮----
-export interface APIResponseV3<TResult, TExtInfo = {}> {
-  retCode: number;
-  retMsg: 'OK' | string;
-  result: TResult;
-  retExtInfo: TExtInfo;
-  /**
-   * These are per-UID per-endpoint rate limits, automatically parsed from response headers if available.
-   *
-   * Note:
-   * - this is primarily for V5 (or newer) APIs.
-   * - these rate limits are per-endpoint per-account, so will not appear for public API calls
-   */
-  rateLimitApi?: APIRateLimit;
-}
-⋮----
-/**
-   * These are per-UID per-endpoint rate limits, automatically parsed from response headers if available.
-   *
-   * Note:
-   * - this is primarily for V5 (or newer) APIs.
-   * - these rate limits are per-endpoint per-account, so will not appear for public API calls
-   */
-⋮----
-export type APIResponseV3WithTime<TResult, TExtInfo = {}> = APIResponseV3<
-  TResult,
-  TExtInfo
-> & { time: number };
-/**
- * Request Parameter Types
- */
-export interface SymbolParam {
-  symbol: string;
-}
-⋮----
-export interface SymbolLimitParam<TLimit = number> {
-  symbol: string;
-  limit?: TLimit;
-}
-⋮----
-export interface SymbolPeriodLimitParam<TLimit = number> {
-  symbol: string;
-  period: string;
-  limit?: TLimit;
-}
-⋮----
-export interface SymbolFromLimitParam {
-  symbol: string;
-  from?: number;
-  limit?: number;
-}
-⋮----
-export interface SymbolIntervalFromLimitParam {
-  symbol: string;
-  interval: string;
-  from: number;
-  limit?: number;
-}
-⋮----
-export interface CoinParam {
-  coin: string;
-}
-⋮----
-export interface WalletFundRecordsReq {
-  start_date?: string;
-  end_date?: string;
-  currency?: string;
-  coin?: string;
-  wallet_fund_type?: string;
-  page?: number;
-  limit?: number;
-}
-⋮----
-export interface WithdrawRecordsReq {
-  start_date?: string;
-  end_date?: string;
-  coin?: string;
-  status?: string;
-  page?: number;
-  limit?: number;
-}
-⋮----
-export interface AssetExchangeRecordsReq {
-  limit?: number;
-  from?: number;
-  direction?: string;
-}
-⋮----
-/**
- * Response types
- */
-⋮----
-export interface LeverageFilter {
-  min_leverage: numberInString;
-  max_leverage: numberInString;
-  leverage_step: numberInString;
-}
-export interface PriceFilter {
-  min_price: numberInString;
-  max_price: numberInString;
-  tick_size: numberInString;
-}
-⋮----
-export interface LotSizeFilter {
-  max_trading_qty: number;
-  min_trading_qty: number;
-  qty_step: number;
-}
-⋮----
-export interface SymbolInfo {
-  name: string;
-  alias: string;
-  status: 'Trading' | string;
-  base_currency: string;
-  quote_currency: string;
-  price_scale: number;
-  taker_fee: numberInString;
-  maker_fee: numberInString;
-  leverage_filter: LeverageFilter;
-  price_filter: PriceFilter;
-  lot_size_filter: LotSizeFilter;
-}
+
 
 ================
 File: src/spot-client-v3.ts
@@ -4035,15 +4052,13 @@ getMergedOrderBook(
 getServerTime(): Promise<
 
 ================
-File: webpack/webpack.config.js
+File: .eslintrc.cjs
 ================
-function generateConfig(name)
+// 'require-extensions', // only once moved to ESM
 ⋮----
-// Add '.ts' and '.tsx' as resolvable extensions.
+// 'plugin:require-extensions/recommended', // only once moved to ESM
 ⋮----
-// All files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'.
-⋮----
-// All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
+// 'no-unused-vars': ['warn'],
 
 ================
 File: .jshintrc
@@ -4393,401 +4408,6 @@ File: tsconfig.test.json
 }
 
 ================
-File: examples/fasterHmacSign.ts
-================
-import { createHmac } from 'crypto';
-⋮----
-import { DefaultLogger, RestClientV5, WebsocketClient } from '../src/index';
-⋮----
-// or
-// import { createHmac } from 'crypto';
-// import { DefaultLogger, RestClientV5, WebsocketClient } from 'bybit-api';
-⋮----
-/**
- * Injecting a custom signMessage function.
- *
- * As of version 4.0.0 of the bybit-api Node.js/TypeScript/JavaScript
- * SDK for Bybit, the SDK uses the Web Crypto API for signing requests.
- * While it is compatible with Node and Browser environments, it is
- * slightly slower than using Node's native crypto module (only
- * available in backend Node environments).
- *
- * For latency sensitive users, you can inject the previous node crypto sign
- * method (or your own even faster-implementation), if this change affects you.
- *
- * This example demonstrates how to inject a custom sign function, to achieve
- * the same peformance as seen before the Web Crypto API was introduced.
- *
- * For context on standard usage, the "signMessage" function is used:
- * - During every single API call
- * - After opening a new private WebSocket connection
- *
- */
-⋮----
-/**
-   * Set this to true to enable demo trading:
-   */
-⋮----
-/**
-   * Overkill in almost every case, but if you need any optimisation available,
-   * you can inject a faster sign mechanism such as node's native createHmac:
-   */
-⋮----
-// Optional, uncomment the "trace" override to log a lot more info about what the WS client is doing
-⋮----
-// trace: (...params) => console.log('trace', ...params),
-⋮----
-/**
-     * Set this to true to enable demo trading for the private account data WS
-     * Topics: order,execution,position,wallet,greeks
-     */
-⋮----
-/**
-     * Overkill in almost every case, but if you need any optimisation available,
-     * you can inject a faster sign mechanism such as node's native createHmac:
-     */
-⋮----
-function setWsClientEventListeners(
-  websocketClient: WebsocketClient,
-  accountRef: string,
-): Promise<void>
-⋮----
-// console.log('raw message received ', JSON.stringify(data, null, 2));
-⋮----
-// Simple promise to ensure we're subscribed before trying anything else
-⋮----
-// Start trading
-⋮----
-/** Simple examples for private REST API calls with bybit's V5 REST APIs */
-⋮----
-// Trade USDT linear perps
-
-================
-File: examples/rest-v5-private.ts
-================
-import { RestClientV5 } from '../src/index';
-⋮----
-// or
-// import { RestClientV5 } from 'bybit-api';
-⋮----
-/** Simple examples for private REST API calls with bybit's V5 REST APIs */
-⋮----
-// Trade USDT linear perps
-
-================
-File: examples/ws-api-raw-events.ts
-================
-import { DefaultLogger, WebsocketClient, WS_KEY_MAP } from '../src';
-⋮----
-// or
-// import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from 'bybit-api';
-⋮----
-// For a more detailed view of the WebsocketClient, enable the `trace` level by uncommenting the below line:
-// trace: (...params) => console.log('trace', ...params),
-⋮----
-// testnet: true, // Whether to use the testnet environment: https://testnet.bybit.com/app/user/api-management
-// demoTrading: false, // note: As of Jan 2025, demo trading does NOT support the WS API
-⋮----
-logger, // Optional: inject a custom logger
-⋮----
-/**
- * General event handlers for monitoring the WebsocketClient
- */
-⋮----
-async function main()
-⋮----
-/**
-   *
-   * This SDK's WebSocket API integration is event-driven at its core. You can treat the sentWSAPIRquest(...) method as
-   * a fire-and-forget method, to submit commands (create/amend/cancel order) via a WebSocket Connection.
-   *
-   * Replies to commands will show in the `response` event from the WebsocketClient's EventEmitter. Exceptions, however,
-   * will show in the `error` event from the WebsocketClient's EventEmitter.
-   *
-   * - Fire-and-forget a command.
-   * - Handle command results in the `response` event handler asynchronously as desired.
-   * - Handle any exceptions in a catch block.
-   *
-   * This is a more "raw" workflow in how WebSockets behave. For a more convenient & REST-like approach, using the
-   * promise-driven interface is recommended. See the `ws-api-raw-promises.ts` and `ws-api-client.ts` examples for a
-   * demonstration you can compare.
-   *
-   * Note: even without using promises, you should still tie on a .catch handler to each sendWSAPIRequest call, to prevent
-   * any unnecessary "unhandled promise rejection" exceptions.
-   *
-   */
-⋮----
-// To make it easier to watch, wait a few seconds before sending the amend order
-⋮----
-// Then wait a few more before sending the cancel order
-⋮----
-// Exceptions including rejected commands will show here (as well as the catch handler used below)
-⋮----
-// Replies to commands will show here
-⋮----
-/**
-   *
-   * If you haven't connected yet, the WebsocketClient will automatically connect and authenticate you as soon as you send
-   * your first command. That connection will then be reused for every command you send, unless the connection drops - then
-   * it will automatically be replaced with a healthy connection.
-   *
-   * This "not connected yet" scenario can add an initial delay to your first command. If you want to prepare a connection
-   * in advance, you can ask the WebsocketClient to prepare it before you start submitting commands. This is optional.
-   *
-   * Repeated note: even without using promises, you should still tie on a .catch handler to each sendWSAPIRequest call, to prevent
-   * any unnecessary "unhandled promise rejection" exceptions.
-   *
-   */
-⋮----
-// Optional, see above. Can be used to prepare a connection before sending commands
-⋮----
-// Fire and forget the create.order command
-// Even without using promises, you should still "catch" exceptions (although no need to await anything you send)
-⋮----
-//
-⋮----
-// Fire and forget the order.amend command
-// For simplicity, the orderId is hardcoded here (and will probably not work)
-⋮----
-//
-⋮----
-// Fire and forget the order.cancel command
-// For simplicity, the orderId is hardcoded here (and will probably not work)
-⋮----
-// Start executing the example workflow
-
-================
-File: examples/ws-api-raw-promises.ts
-================
-import { DefaultLogger, WebsocketClient, WS_KEY_MAP } from '../src';
-⋮----
-// or
-// import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from 'bybit-api';
-⋮----
-// For a more detailed view of the WebsocketClient, enable the `trace` level by uncommenting the below line:
-// trace: (...params) => console.log('trace', ...params),
-⋮----
-// testnet: true, // Whether to use the testnet environment: https://testnet.bybit.com/app/user/api-management
-// demoTrading: false, // note: As of Jan 2025, demo trading does NOT support the WS API
-⋮----
-logger, // Optional: inject a custom logger
-⋮----
-/**
- * General event handlers for monitoring the WebsocketClient
- */
-⋮----
-async function main()
-⋮----
-/**
-   *
-   * This SDK's WebSocket API integration can connect WS API responses to the request that caused them. Each call
-   * to the `sendWSAPIRequest(...)` method returns a promise.
-   *
-   * This promise will resolve when the matching response is detected, and reject if an exception for that request
-   * is detected. This allows using Bybit's Websocket API in the same way that a REST API normally works.
-   *
-   * Send a command and immediately await the result. Handle any exceptions in a catch block.
-   *
-   * TypeScript users can benefit from smart type flowing for increased type safety & convenience:
-   * - Request parameters are fully typed, depending on the operation in the second parameter to the call. E.g.
-   * the `order.create` operation will automatically require the params to match the `OrderParamsV5` interface.
-   *
-   * - Response parameters are fully typed, depending on the operation in the second parameter. E.g the `order.create`
-   * operation will automatically map the returned value to `WSAPIResponse<OrderResultV5, "order.create">`.
-   *
-   */
-⋮----
-// To make it easier to watch, wait a few seconds before sending the amend order
-⋮----
-// Then wait a few more before sending the cancel order
-⋮----
-/**
-   *
-   * If you haven't connected yet, the WebsocketClient will automatically connect and authenticate you as soon as you send
-   * your first command. That connection will then be reused for every command you send, unless the connection drops - then
-   * it will automatically be replaced with a healthy connection.
-   *
-   * This "not connected yet" scenario can add an initial delay to your first command. If you want to prepare a connection
-   * in advance, you can ask the WebsocketClient to prepare it before you start submitting commands. This is optional.
-   *
-   */
-⋮----
-// Optional, see above. Can be used to prepare a connection before sending commands
-⋮----
-/**
-   * Create a new order
-   */
-⋮----
-// The type for `wsAPISubmitOrderResult` is automatically resolved to `WSAPIResponse<OrderResultV5, "order.create">`
-⋮----
-// Save the orderId for the next call
-⋮----
-// The type for `wsAPIAmendOrderResult` is automatically resolved to `WSAPIResponse<OrderResultV5, "order.amend">`
-⋮----
-// Save the orderId for the next call
-⋮----
-// The type for `wsAPICancelOrderResult` is automatically resolved to `WSAPIResponse<OrderResultV5, "order.cancel">`
-⋮----
-// Start executing the example workflow
-
-================
-File: examples/ws-private-v5.ts
-================
-/* eslint-disable @typescript-eslint/no-empty-function */
-import { DefaultLogger, WebsocketClient, WS_KEY_MAP } from '../src';
-⋮----
-// or
-// import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from 'bybit-api';
-⋮----
-// Create & inject a custom logger to enable the trace logging level (empty function)
-⋮----
-// trace: (...params) => console.log('trace', ...params),
-⋮----
-/**
- * Prepare an instance of the WebSocket client. This client handles all aspects of connectivity for you:
- * - Connections are opened when you subscribe to topics
- * - If key & secret are provided, authentication is handled automatically
- * - If you subscribe to topics from different v5 products (e.g. spot and linear perps),
- *    subscription events are automatically routed to the different ws endpoints on bybit's side
- * - Heartbeats/ping/pong/reconnects are all handled automatically.
- *    If a connection drops, the client will clean it up, respawn a fresh connection and resubscribe for you.
- */
-⋮----
-// testnet: false,
-// demoTrading: false, // set testnet to false, if you plan on using demo trading
-⋮----
-// console.log('raw message received ', JSON.stringify(data, null, 2));
-⋮----
-// wsClient.on('exception', (data) => {
-//   console.error('ws exception: ', data);
-// });
-⋮----
-/**
- * For private V5 topics, us the subscribeV5() method on the ws client or use the original subscribe() method.
- *
- * Note: for private endpoints the "category" field is ignored since there is only one private endpoint
- * (compared to one public one per category).
- * The "category" is only needed for public topics since bybit has one endpoint for public events per category.
- */
-⋮----
-// wsClient.subscribeV5('execution.fast', 'linear');
-// wsClient.subscribeV5('execution.fast.linear', 'linear');
-⋮----
-/**
- * The following has the same effect as above, since there's only one private endpoint for V5 account topics:
- */
-// wsClient.subscribe('position');
-// wsClient.subscribe('execution');
-// wsClient.subscribe(['order', 'wallet', 'greek']);
-⋮----
-// To unsubscribe from topics (after a 5 second delay, in this example):
-// setTimeout(() => {
-//   console.log('unsubscribing');
-//   wsClient.unsubscribeV5('execution', 'linear');
-// }, 5 * 1000);
-⋮----
-// Topics are tracked per websocket type
-// Get a list of subscribed topics (e.g. for public v3 spot topics) (after a 5 second delay)
-
-================
-File: examples/ws-public-allLiquidations.ts
-================
-import { isWsAllLiquidationEvent, RestClientV5, WebsocketClient } from '../src';
-⋮----
-// or
-// import {
-//   RestClientV5,
-//   WebsocketClient,
-//   isWsAllLiquidationEvent,
-// } from 'bybit-api';
-⋮----
-function onAllLiquidationEvent(event)
-⋮----
-/**
- *
- * If you want to receive data for all available symbols, this websocket topic
- * requires you to subscribe to each symbol individually.
- *
- * This can be easily automated by fetching a list of symbols via the REST client,
- * generating a list of topics (one per symbol), before simply passing an
- * array of topics to the websocket client per product group (linear & inverse perps).
- *
- */
-async function start()
-⋮----
-// Make an array of topics ready for submission
-⋮----
-// subscribe to all linear symbols
-⋮----
-// subscribe to all inverse symbols
-
-================
-File: examples/ws-public-v5.ts
-================
-import { DefaultLogger, WebsocketClient, WS_KEY_MAP } from '../src';
-⋮----
-// or
-// import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from 'bybit-api';
-⋮----
-/**
- * Prepare an instance of the WebSocket client. This client handles all aspects of connectivity for you:
- * - Connections are opened when you subscribe to topics
- * - If key & secret are provided, authentication is handled automatically
- * - If you subscribe to topics from different v5 products (e.g. spot and linear perps),
- *    subscription events are automatically routed to the different ws endpoints on bybit's side
- * - Heartbeats/ping/pong/reconnects are all handled automatically.
- *    If a connection drops, the client will clean it up, respawn a fresh connection and resubscribe for you.
- */
-⋮----
-/**
- * For public V5 topics, use the subscribeV5 method and include the API category this topic is for.
- * Category is required, since each category has a different websocket endpoint.
- */
-⋮----
-// Linear v5
-// -> Just one topic per call
-// wsClient.subscribeV5('orderbook.50.BTCUSDT', 'linear');
-⋮----
-// -> Or multiple topics in one call
-// wsClient.subscribeV5(
-//   ['orderbook.50.BTCUSDT', 'orderbook.50.ETHUSDT'],
-//   'linear'
-// );
-⋮----
-// Inverse v5
-// wsClient.subscribeV5('orderbook.50.BTCUSD', 'inverse');
-⋮----
-// Spot v5
-// wsClient.subscribeV5('orderbook.50.BTCUSDT', 'spot');
-⋮----
-// Option v5
-// wsClient.subscribeV5('publicTrade.BTC', 'option');
-⋮----
-// Use the subscribeV5() call for most subscribe calls with v5 websockets
-⋮----
-// Alternatively, you can also use objects in the wsClient.subscribe() call
-// wsClient.subscribe({
-//   topic: 'orderook.50.BTCUSDT',
-//   category: 'spot',
-// });
-⋮----
-/**
- * For private V5 topics, just call the same subscribeV5() method on the ws client or use the original subscribe() method.
- *
- * Note: for private endpoints the "category" field is ignored since there is only one private endpoint
- * (compared to one public one per category)
- */
-⋮----
-// wsClient.subscribeV5('position', 'linear');
-// wsClient.subscribeV5('execution', 'linear');
-// wsClient.subscribeV5(['order', 'wallet', 'greek'], 'linear');
-⋮----
-// To unsubscribe from topics (after a 5 second delay, in this example):
-⋮----
-// Topics are tracked per websocket type
-// Get a list of subscribed topics (e.g. for public v3 spot topics) (after a 5 second delay)
-
-================
 File: src/types/request/index.ts
 ================
 
@@ -4887,12 +4507,15 @@ export interface GetExecutionListParamsV5 {
   orderId?: string;
   orderLinkId?: string;
   baseCoin?: string;
+  settleCoin?: string; // Settle coin, uppercase only. For linear, inverse, option
   startTime?: number;
   endTime?: number;
   execType?: ExecTypeV5;
   limit?: number;
   cursor?: string;
 }
+⋮----
+settleCoin?: string; // Settle coin, uppercase only. For linear, inverse, option
 ⋮----
 export interface GetClosedPnLParamsV5 {
   category: CategoryV5;
@@ -5126,6 +4749,12 @@ startTime?: number; // Timestamp in milliseconds, time range is 7 days
 endTime?: number; // Timestamp in milliseconds, time range is 7 days
 limit?: number; // Return number of items, max 100, default 50
 cursor?: string; // Page turning mark
+⋮----
+export interface AcceptNonLPQuoteParamsV5 {
+  rfqId: string; // Inquiry ID
+}
+⋮----
+rfqId: string; // Inquiry ID
 
 ================
 File: src/types/request/v5-spot-leverage-token.ts
@@ -5189,6 +4818,189 @@ export interface SetSpotMarginLeverageParamsV5 {
 export interface ManualRepayWithoutConversionParamsV5 {
   coin: string;
   amount?: string;
+}
+⋮----
+export interface GetAutoRepayModeParamsV5 {
+  currency?: string; // Coin name, uppercase only. If not passed, returns all currencies
+}
+⋮----
+currency?: string; // Coin name, uppercase only. If not passed, returns all currencies
+⋮----
+export interface SetAutoRepayModeParamsV5 {
+  currency?: string; // Coin name, uppercase only. If not passed, enables for all currencies
+  autoRepayMode: '0' | '1'; // 0: Off, 1: On
+}
+⋮----
+currency?: string; // Coin name, uppercase only. If not passed, enables for all currencies
+autoRepayMode: '0' | '1'; // 0: Off, 1: On
+
+================
+File: src/types/request/v5-trade.ts
+================
+import {
+  CategoryV5,
+  OrderFilterV5,
+  OrderSideV5,
+  OrderSMPTypeV5,
+  OrderStatusV5,
+  OrderTimeInForceV5,
+  OrderTriggerByV5,
+  OrderTypeV5,
+  PositionIdx,
+  StopOrderTypeV5,
+} from '../shared-v5';
+⋮----
+export interface OrderParamsV5 {
+  category: CategoryV5;
+  symbol: string;
+  isLeverage?: 0 | 1;
+  side: OrderSideV5;
+  orderType: OrderTypeV5;
+  qty: string;
+  marketUnit?: 'baseCoin' | 'quoteCoin';
+  slippageToleranceType?: string;
+  slippageTolerance?: string;
+  price?: string;
+  triggerDirection?: 1 | 2;
+  orderFilter?: OrderFilterV5;
+  triggerPrice?: string;
+  triggerBy?: OrderTriggerByV5;
+  orderIv?: string;
+  timeInForce?: OrderTimeInForceV5;
+  positionIdx?: PositionIdx;
+  orderLinkId?: string;
+  takeProfit?: string;
+  stopLoss?: string;
+  tpTriggerBy?: OrderTriggerByV5;
+  slTriggerBy?: OrderTriggerByV5;
+  reduceOnly?: boolean;
+  closeOnTrigger?: boolean;
+  smpType?: OrderSMPTypeV5;
+  mmp?: boolean;
+  tpslMode?: 'Full' | 'Partial';
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
+  tpOrderType?: OrderTypeV5;
+  slOrderType?: OrderTypeV5;
+  bboSideType?: 'Queue' | 'Counterparty';
+  bboLevel?: '1' | '2' | '3' | '4' | '5';
+}
+⋮----
+export interface AmendOrderParamsV5 {
+  category: CategoryV5;
+  symbol: string;
+  orderId?: string;
+  orderLinkId?: string;
+  orderIv?: string;
+  triggerPrice?: string;
+  qty?: string;
+  price?: string;
+  tpslMode?: 'Full' | 'Partial';
+  takeProfit?: string;
+  stopLoss?: string;
+  tpTriggerBy?: OrderTriggerByV5;
+  slTriggerBy?: OrderTriggerByV5;
+  triggerBy?: OrderTriggerByV5;
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
+}
+⋮----
+export interface CancelOrderParamsV5 {
+  category: CategoryV5;
+  symbol: string;
+  orderId?: string;
+  orderLinkId?: string;
+  orderFilter?: OrderFilterV5;
+}
+⋮----
+export interface GetAccountOrdersParamsV5 {
+  category: CategoryV5;
+  symbol?: string;
+  baseCoin?: string;
+  settleCoin?: string;
+  orderId?: string;
+  orderLinkId?: string;
+  openOnly?: 0 | 1 | 2;
+  orderFilter?: OrderFilterV5;
+  orderStatus?: OrderStatusV5;
+  limit?: number;
+  cursor?: string;
+}
+⋮----
+export interface GetAccountHistoricOrdersParamsV5 {
+  category: CategoryV5;
+  symbol?: string;
+  baseCoin?: string;
+  settleCoin?: string;
+  orderId?: string;
+  orderLinkId?: string;
+  orderFilter?: OrderFilterV5;
+  orderStatus?: OrderStatusV5;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
+}
+⋮----
+export interface CancelAllOrdersParamsV5 {
+  category: CategoryV5;
+  symbol?: string;
+  baseCoin?: string;
+  settleCoin?: string;
+  orderFilter?: OrderFilterV5;
+  stopOrderType?: StopOrderTypeV5;
+}
+⋮----
+export interface BatchOrderParamsV5 {
+  symbol: string;
+  side: OrderSideV5;
+  isLeverage?: 0 | 1;
+  orderType: OrderTypeV5;
+  qty: string;
+  price?: string;
+  triggerDirection?: 1 | 2;
+  triggerBy?: OrderTriggerByV5;
+  orderIv?: string;
+  timeInForce?: OrderTimeInForceV5;
+  positionIdx?: PositionIdx;
+  orderLinkId?: string;
+  takeProfit?: string;
+  stopLoss?: string;
+  tpTriggerBy?: OrderTriggerByV5;
+  slTriggerBy?: OrderTriggerByV5;
+  reduceOnly?: boolean;
+  closeOnTrigger?: boolean;
+  smpType?: OrderSMPTypeV5;
+  mmp?: boolean;
+  tpslMode?: 'Full' | 'Partial';
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
+  tpOrderType?: OrderTypeV5;
+  slOrderType?: OrderTypeV5;
+}
+⋮----
+export interface BatchAmendOrderParamsV5 {
+  symbol: string;
+  orderId?: string;
+  orderLinkId?: string;
+  orderIv?: string;
+  triggerPrice?: string;
+  qty?: string;
+  price?: string;
+  tpslMode?: 'Full' | 'Partial';
+  takeProfit?: string;
+  stopLoss?: string;
+  tpTriggerBy?: OrderTriggerByV5;
+  slTriggerBy?: OrderTriggerByV5;
+  triggerBy?: OrderTriggerByV5;
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
+}
+⋮----
+export interface BatchCancelOrderParamsV5 {
+  symbol: string;
+  orderId?: string;
+  orderLinkId?: string;
 }
 
 ================
@@ -5259,6 +5071,11 @@ export interface GetAffiliateUserListParamsV5 {
   startDate?: string;
   endDate?: string;
 }
+
+================
+File: src/types/response/index.ts
+================
+
 
 ================
 File: src/types/response/v5-asset.ts
@@ -5547,6 +5364,82 @@ export interface ConvertHistoryRecordV5 {
   convertRate: string;
   createdAt: string;
 }
+⋮----
+export interface SmallBalanceCoinV5 {
+  fromCoin: string; // Source currency
+  supportConvert: 1 | 2; // 1: support, 2: not supported
+  availableBalance: string; // Available balance
+  baseValue: string; // USDT equivalent value
+  toAmount: string; // Reserved field
+  exchangeRate: string; // Reserved field
+  feeInfo: null; // Reserved field
+  taxFeeInfo: null; // Reserved field
+}
+⋮----
+fromCoin: string; // Source currency
+supportConvert: 1 | 2; // 1: support, 2: not supported
+availableBalance: string; // Available balance
+baseValue: string; // USDT equivalent value
+toAmount: string; // Reserved field
+exchangeRate: string; // Reserved field
+feeInfo: null; // Reserved field
+taxFeeInfo: null; // Reserved field
+⋮----
+export interface SmallBalanceListV5 {
+  smallAssetCoins: SmallBalanceCoinV5[]; // Small balance info
+  supportToCoins: string[]; // Supported target coins (e.g., ["MNT","USDT","USDC"])
+}
+⋮----
+smallAssetCoins: SmallBalanceCoinV5[]; // Small balance info
+supportToCoins: string[]; // Supported target coins (e.g., ["MNT","USDT","USDC"])
+⋮----
+export interface FiatCoinInfoV5 {
+  coin: string; // Fiat coin code
+  fullName: string; // Fiat full coin name
+  icon: string; // Coin icon url
+  iconNight: string; // Coin icon url (dark mode)
+  precision: number; // Fiat precision
+  disable: boolean; // true: the coin is disabled, false: the coin is allowed
+  singleFromMinLimit: string; // For buy side, minimum amount of fiatCoin per transaction
+  singleFromMaxLimit: string; // For buy side, maximum amount of fiatCoin per transaction
+}
+⋮----
+coin: string; // Fiat coin code
+fullName: string; // Fiat full coin name
+icon: string; // Coin icon url
+iconNight: string; // Coin icon url (dark mode)
+precision: number; // Fiat precision
+disable: boolean; // true: the coin is disabled, false: the coin is allowed
+singleFromMinLimit: string; // For buy side, minimum amount of fiatCoin per transaction
+singleFromMaxLimit: string; // For buy side, maximum amount of fiatCoin per transaction
+⋮----
+export interface CryptoCoinInfoV5 {
+  coin: string; // Crypto coin code
+  fullName: string; // Crypto full coin name
+  icon: string; // Coin icon url
+  iconNight: string; // Coin icon url (dark mode)
+  precision: number; // Crypto precision
+  disable: boolean; // true: the coin is disabled, false: the coin is allowed
+  singleFromMinLimit: string; // For sell side, minimum amount of cryptoCoin per transaction
+  singleFromMaxLimit: string; // For sell side, maximum amount of cryptoCoin per transaction
+}
+⋮----
+coin: string; // Crypto coin code
+fullName: string; // Crypto full coin name
+icon: string; // Coin icon url
+iconNight: string; // Coin icon url (dark mode)
+precision: number; // Crypto precision
+disable: boolean; // true: the coin is disabled, false: the coin is allowed
+singleFromMinLimit: string; // For sell side, minimum amount of cryptoCoin per transaction
+singleFromMaxLimit: string; // For sell side, maximum amount of cryptoCoin per transaction
+⋮----
+export interface FiatTradingPairListV5 {
+  fiats: FiatCoinInfoV5[]; // Fiat coin list
+  cryptos: CryptoCoinInfoV5[]; // Crypto coin list
+}
+⋮----
+fiats: FiatCoinInfoV5[]; // Fiat coin list
+cryptos: CryptoCoinInfoV5[]; // Crypto coin list
 
 ================
 File: src/types/response/v5-earn.ts
@@ -5638,6 +5531,7 @@ export interface PositionV5 {
   autoAddMargin?: number;
   positionStatus: PositionStatusV5;
   leverage?: string;
+  breakEvenPrice?: string; // Break even price, only for linear & inverse
   markPrice: string;
   liqPrice: string | '';
   bustPrice?: string;
@@ -5666,6 +5560,8 @@ export interface PositionV5 {
   positionMMByMp: string;
   seq: number;
 }
+⋮----
+breakEvenPrice?: string; // Break even price, only for linear & inverse
 ⋮----
 export interface SetRiskLimitResultV5 {
   category: CategoryV5;
@@ -5796,136 +5692,162 @@ export interface ClosedOptionsPositionV5 {
 }
 
 ================
-File: src/types/response/v5-trade.ts
+File: src/types/response/v5-spot-leverage-token.ts
 ================
 import {
-  CategoryV5,
-  OrderCancelTypeV5,
-  OrderCreateTypeV5,
-  OrderRejectReasonV5,
-  OrderSideV5,
-  OrderStatusV5,
-  OrderTimeInForceV5,
-  OrderTriggerByV5,
-  OrderTypeV5,
-  PositionIdx,
-  StopOrderTypeV5,
+  LeverageTokenStatusV5,
+  LTOrderStatusV5,
+  LTOrderTypeV5,
 } from '../shared-v5';
 ⋮----
-export interface OrderResultV5 {
-  orderId: string;
-  orderLinkId: string;
+export interface LeverageTokenInfoV5 {
+  ltCoin: string;
+  ltName: string;
+  maxPurchase: string;
+  minPurchase: string;
+  maxPurchaseDaily: string;
+  maxRedeem: string;
+  minRedeem: string;
+  maxRedeemDaily: string;
+  purchaseFeeRate: string;
+  redeemFeeRate: string;
+  ltStatus: LeverageTokenStatusV5;
+  fundFee: string;
+  fundFeeTime: string;
+  manageFeeRate: string;
+  manageFeeTime: string;
+  value: string;
+  netValue: string;
+  total: string;
 }
 ⋮----
-export interface AccountOrderV5 {
-  orderId: string;
-  orderLinkId: string;
-  blockTradeId: string;
-  symbol: string;
-  price: string;
-  qty: string;
-  side: OrderSideV5;
-  isLeverage: '0' | '1';
-  positionIdx: PositionIdx;
-  orderStatus: OrderStatusV5;
-  createType: OrderCreateTypeV5;
-  cancelType: OrderCancelTypeV5;
-  rejectReason: OrderRejectReasonV5;
-  avgPrice: string;
-  leavesQty: string;
-  leavesValue: string;
-  cumExecQty: string;
-  cumExecValue: string;
-  cumExecFee: string;
-  timeInForce: OrderTimeInForceV5;
-  orderType: OrderTypeV5;
-  stopOrderType: StopOrderTypeV5;
-  orderIv: string;
-  marketUnit: 'baseCoin' | 'quoteCoin';
-  slippageToleranceType: string;
-  slippageTolerance: string;
-  triggerPrice: string;
-  takeProfit: string;
-  stopLoss: string;
-  tpslMode: 'Full' | 'Partial' | '';
-  ocoTriggerType:
-    | 'OcoTriggerByUnknown'
-    | 'OcoTriggerTp'
-    | 'OcoTriggerBySl'
-    | '';
-  tpLimitPrice: string;
-  slLimitPrice: string;
-  tpTriggerBy: OrderTriggerByV5;
-  slTriggerBy: OrderTriggerByV5;
-  triggerDirection: 1 | 2;
-  triggerBy: OrderTriggerByV5;
-  lastPriceOnCreated: string;
-  reduceOnly: boolean;
-  closeOnTrigger: boolean;
-  placeType: 'iv' | 'price' | '';
-  smpType: string;
-  smpGroup: number;
-  smpOrderId: string;
-  createdTime: string;
-  updatedTime: string;
-  extraFees: string;
-  cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee
+export interface LeveragedTokenMarketResultV5 {
+  ltCoin: string;
+  nav: string;
+  navTime: string;
+  circulation: string;
+  basket: string;
+  leverage: string;
 }
 ⋮----
-cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee
-⋮----
-export interface BatchCreateOrderResultV5 {
-  category: CategoryV5;
-  symbol: string;
-  orderId: string;
-  orderLinkId: string;
-  createAt?: string;
+export interface PurchaseSpotLeveragedTokenResultV5 {
+  ltCoin: string;
+  ltOrderStatus: LTOrderStatusV5;
+  execQty: string;
+  execAmt: string;
+  amount: string;
+  purchaseId: string;
+  serialNo: string;
+  valueCoin: string;
+}
+export interface RedeemSpotLeveragedTokenResultV5 {
+  ltCoin: string;
+  ltOrderStatus: LTOrderStatusV5;
+  quantity: string;
+  execQty: string;
+  execAmt: string;
+  redeemId: string;
+  serialNo: string;
+  valueCoin: string;
 }
 ⋮----
-export interface BatchOrdersRetExtInfoV5 {
-  list: {
-    code: number;
-    msg: string;
+export interface SpotLeveragedTokenOrderHistoryV5 {
+  ltCoin: string;
+  orderId: string;
+  ltOrderType: LTOrderTypeV5;
+  orderTime: number;
+  updateTime: number;
+  ltOrderStatus: LTOrderStatusV5;
+  fee: string;
+  amount: string;
+  value: string;
+  valueCoin: string;
+  serialNo: string;
+}
+⋮----
+export interface VIPMarginDataV5 {
+  vipCoinList: {
+    list: {
+      borrowable: boolean;
+      collateralRatio: string;
+      currency: string;
+      hourlyBorrowRate: string;
+      liquidationOrder: string;
+      marginCollateral: boolean;
+      maxBorrowingAmount: string;
+    }[];
+    vipLevel: string;
   }[];
 }
 ⋮----
-export interface BatchAmendOrderResultV5 {
-  category: CategoryV5;
-  symbol: string;
-  orderId: string;
-  orderLinkId: string;
+export interface SpotMarginStateV5 {
+  spotLeverage: string;
+  spotMarginMode: '1' | '0';
+  effectiveLeverage: string;
 }
 ⋮----
-export interface BatchCancelOrderResultV5 {
-  category: CategoryV5;
-  symbol: string;
-  orderId: string;
-  orderLinkId: string;
+// Spot Margin Trade (UTA) response types
+export interface ManualBorrowResultV5 {
+  coin: string;
+  amount: string;
 }
 ⋮----
-export interface SpotBorrowCheckResultV5 {
-  symbol: string;
-  side: OrderSideV5;
-  maxTradeQty: string;
-  maxTradeAmount: string;
-  spotMaxTradeQty: string;
-  spotMaxTradeAmount: string;
-  borrowCoin: string;
+export interface MaxBorrowableAmountV5 {
+  currency: string;
+  maxLoan: string;
 }
 ⋮----
-export interface PreCheckOrderResultV5 {
-  orderId: string;
-  orderLinkId: string;
-  preImrE4: number; // Initial margin rate before checking (in basis points)
-  preMmrE4: number; // Maintenance margin rate before checking (in basis points)
-  postImrE4: number; // Initial margin rate after checking (in basis points)
-  postMmrE4: number; // Maintenance margin rate after checking (in basis points)
+export interface PositionTierV5 {
+  tier: string;
+  borrowLimit: string;
+  positionMMR: string;
+  positionIMR: string;
+  maxLeverage: string;
 }
 ⋮----
-preImrE4: number; // Initial margin rate before checking (in basis points)
-preMmrE4: number; // Maintenance margin rate before checking (in basis points)
-postImrE4: number; // Initial margin rate after checking (in basis points)
-postMmrE4: number; // Maintenance margin rate after checking (in basis points)
+export interface CurrencyPositionTiersV5 {
+  currency: string;
+  positionTiersRatioList: PositionTierV5[];
+}
+⋮----
+export interface CoinStateV5 {
+  currency: string;
+  spotLeverage: string;
+}
+⋮----
+export interface AvailableAmountToRepayV5 {
+  currency: string;
+  lossLessRepaymentAmount: string;
+}
+⋮----
+export interface ManualRepayWithoutConversionResultV5 {
+  /**
+   * Result status:
+   * - P: Processing
+   * - SU: Success
+   * - FA: Failed
+   */
+  resultStatus: 'P' | 'SU' | 'FA';
+}
+⋮----
+/**
+   * Result status:
+   * - P: Processing
+   * - SU: Success
+   * - FA: Failed
+   */
+⋮----
+export interface AutoRepayModeItemV5 {
+  currency: string; // Coin name, uppercase only
+  autoRepayMode: '0' | '1'; // 0: Off, 1: On
+}
+⋮----
+currency: string; // Coin name, uppercase only
+autoRepayMode: '0' | '1'; // 0: Off, 1: On
+⋮----
+export interface AutoRepayModeResultV5 {
+  data: AutoRepayModeItemV5[];
+}
 
 ================
 File: src/types/response/v5-user.ts
@@ -6073,19 +5995,206 @@ export interface AffiliateUserInfoV5 {
 }
 
 ================
-File: src/types/websockets/index.ts
+File: src/types/shared.ts
 ================
-
-
-================
-File: src/types/index.ts
-================
-
-
-================
-File: src/index.ts
-================
-
+import { RestClientV5 } from '../rest-client-v5';
+import { SpotClientV3 } from '../spot-client-v3';
+⋮----
+export type RESTClient = SpotClientV3 | RestClientV5;
+⋮----
+export type numberInString = string;
+⋮----
+export type OrderSide = 'Buy' | 'Sell';
+⋮----
+export type KlineInterval =
+  | '1m'
+  | '3m'
+  | '5m'
+  | '15m'
+  | '30m'
+  | '1h'
+  | '2h'
+  | '4h'
+  | '6h'
+  | '12h'
+  | '1d'
+  | '1w'
+  | '1M';
+⋮----
+export type KlineIntervalV3 =
+  | '1'
+  | '3'
+  | '5'
+  | '15'
+  | '30'
+  | '60'
+  | '120'
+  | '240'
+  | '360'
+  | '720'
+  | 'D'
+  | 'W'
+  | 'M';
+⋮----
+export interface APIRateLimit {
+  /** Remaining requests to this endpoint before the next reset */
+  remainingRequests: number;
+  /** Max requests for this endpoint per rollowing window (before next reset) */
+  maxRequests: number;
+  /**
+   * Timestamp when the rate limit resets if you have exceeded your current maxRequests.
+   * Otherwise, this is approximately your current timestamp.
+   */
+  resetAtTimestamp: number;
+}
+⋮----
+/** Remaining requests to this endpoint before the next reset */
+⋮----
+/** Max requests for this endpoint per rollowing window (before next reset) */
+⋮----
+/**
+   * Timestamp when the rate limit resets if you have exceeded your current maxRequests.
+   * Otherwise, this is approximately your current timestamp.
+   */
+⋮----
+export interface APIResponseV3<TResult, TExtInfo = {}> {
+  retCode: number;
+  retMsg: 'OK' | string;
+  result: TResult;
+  retExtInfo: TExtInfo;
+  /**
+   * These are per-UID per-endpoint rate limits, automatically parsed from response headers if available.
+   *
+   * Note:
+   * - this is primarily for V5 (or newer) APIs.
+   * - these rate limits are per-endpoint per-account, so will not appear for public API calls
+   */
+  rateLimitApi?: APIRateLimit;
+}
+⋮----
+/**
+   * These are per-UID per-endpoint rate limits, automatically parsed from response headers if available.
+   *
+   * Note:
+   * - this is primarily for V5 (or newer) APIs.
+   * - these rate limits are per-endpoint per-account, so will not appear for public API calls
+   */
+⋮----
+export type APIResponseV3WithTime<TResult, TExtInfo = {}> = APIResponseV3<
+  TResult,
+  TExtInfo
+> & { time: number };
+⋮----
+export interface APIP2PResponse<TResult, TExtInfo = {}> {
+  ret_code: number;
+  ret_msg: string;
+  result: {
+    result: TResult;
+    totalRows: string;
+    totalPages: string;
+    currentPage: string;
+    dayLimit: string;
+    showDayLimit: boolean;
+  };
+  ext_code: string;
+  ext_info: TExtInfo;
+  time_now: string;
+}
+⋮----
+/**
+ * Request Parameter Types
+ */
+export interface SymbolParam {
+  symbol: string;
+}
+⋮----
+export interface SymbolLimitParam<TLimit = number> {
+  symbol: string;
+  limit?: TLimit;
+}
+⋮----
+export interface SymbolPeriodLimitParam<TLimit = number> {
+  symbol: string;
+  period: string;
+  limit?: TLimit;
+}
+⋮----
+export interface SymbolFromLimitParam {
+  symbol: string;
+  from?: number;
+  limit?: number;
+}
+⋮----
+export interface SymbolIntervalFromLimitParam {
+  symbol: string;
+  interval: string;
+  from: number;
+  limit?: number;
+}
+⋮----
+export interface CoinParam {
+  coin: string;
+}
+⋮----
+export interface WalletFundRecordsReq {
+  start_date?: string;
+  end_date?: string;
+  currency?: string;
+  coin?: string;
+  wallet_fund_type?: string;
+  page?: number;
+  limit?: number;
+}
+⋮----
+export interface WithdrawRecordsReq {
+  start_date?: string;
+  end_date?: string;
+  coin?: string;
+  status?: string;
+  page?: number;
+  limit?: number;
+}
+⋮----
+export interface AssetExchangeRecordsReq {
+  limit?: number;
+  from?: number;
+  direction?: string;
+}
+⋮----
+/**
+ * Response types
+ */
+⋮----
+export interface LeverageFilter {
+  min_leverage: numberInString;
+  max_leverage: numberInString;
+  leverage_step: numberInString;
+}
+export interface PriceFilter {
+  min_price: numberInString;
+  max_price: numberInString;
+  tick_size: numberInString;
+}
+⋮----
+export interface LotSizeFilter {
+  max_trading_qty: number;
+  min_trading_qty: number;
+  qty_step: number;
+}
+⋮----
+export interface SymbolInfo {
+  name: string;
+  alias: string;
+  status: 'Trading' | string;
+  base_currency: string;
+  quote_currency: string;
+  price_scale: number;
+  taker_fee: numberInString;
+  maker_fee: numberInString;
+  leverage_filter: LeverageFilter;
+  price_filter: PriceFilter;
+  lot_size_filter: LotSizeFilter;
+}
 
 ================
 File: src/websocket-api-client.ts
@@ -6306,6 +6415,385 @@ private setupDefaultEventListeners()
 // Blind JSON.stringify can fail on circular references
 ⋮----
 // JSON.stringify({ ...data, target: 'WebSocket' }),
+
+================
+File: src/websocket-client.ts
+================
+import WebSocket from 'isomorphic-ws';
+⋮----
+import {
+  CategoryV5,
+  MessageEventLike,
+  WsKey,
+  WsMarket,
+  WsTopic,
+} from './types';
+import {
+  Exact,
+  WSAPIOperation,
+  WsAPIOperationResponseMap,
+  WSAPIRequest,
+  WsAPITopicRequestParamMap,
+  WsAPIWsKeyTopicMap,
+  WsOperation,
+  WsRequestOperationBybit,
+} from './types/websockets/ws-api';
+import {
+  APIID,
+  getMaxTopicsPerSubscribeEvent,
+  getNormalisedTopicRequests,
+  getPromiseRefForWSAPIRequest,
+  getTopicsPerWSKey,
+  getWsKeyForTopic,
+  getWsUrl,
+  isPrivateWsTopic,
+  isTopicSubscriptionConfirmation,
+  isTopicSubscriptionSuccess,
+  isWSAPIResponse,
+  isWsPong,
+  neverGuard,
+  WS_AUTH_ON_CONNECT_KEYS,
+  WS_KEY_MAP,
+  WS_LOGGER_CATEGORY,
+  WSConnectedResult,
+  WsTopicRequest,
+} from './util';
+import {
+  BaseWebsocketClient,
+  EmittableEvent,
+  MidflightWsRequestEvent,
+} from './util/BaseWSClient';
+import { SignAlgorithm, signMessage } from './util/webCryptoAPI';
+⋮----
+export class WebsocketClient extends BaseWebsocketClient<
+⋮----
+/**
+   * Request connection of all dependent (public & private) websockets, instead of waiting
+   * for automatic connection by SDK.
+   */
+public connectAll(): Promise<WSConnectedResult | undefined>[]
+⋮----
+/**
+   * Ensures the WS API connection is active and ready.
+   *
+   * You do not need to call this, but if you call this before making any WS API requests,
+   * it can accelerate the first request (by preparing the connection in advance).
+   */
+public connectWSAPI(): Promise<unknown>
+⋮----
+/** This call automatically ensures the connection is active AND authenticated before resolving */
+⋮----
+public connectPublic(): Promise<WSConnectedResult | undefined>[]
+⋮----
+public connectPrivate(): Promise<WebSocket | undefined>
+⋮----
+/**
+   * Subscribe to V5 topics & track/persist them.
+   * @param wsTopics - topic or list of topics
+   * @param category - the API category this topic is for (e.g. "linear").
+   * The value is only important when connecting to public topics and will be ignored for private topics.
+   * @param isPrivateTopic - optional - the library will try to detect private topics, you can use this
+   * to mark a topic as private (if the topic isn't recognised yet)
+   */
+public subscribeV5(
+    wsTopics: WsTopic[] | WsTopic,
+    category: CategoryV5,
+    isPrivateTopic?: boolean,
+): Promise<unknown>[]
+⋮----
+// Sort into per-WsKey batches, in case there is a mix of topics here
+⋮----
+// Prevent duplicate requests to the same topic
+⋮----
+// Batch sub topics per ws key
+⋮----
+// Return promise to resolve midflight WS request (only works if already connected before request)
+⋮----
+/**
+   * Unsubscribe from V5 topics & remove them from memory. They won't be re-subscribed to if the
+   * connection reconnects.
+   *
+   * @param wsTopics - topic or list of topics
+   * @param category - the API category this topic is for (e.g. "linear"). The value is only
+   * important when connecting to public topics and will be ignored for private topics.
+   * @param isPrivateTopic - optional - the library will try to detect private topics, you can
+   * use this to mark a topic as private (if the topic isn't recognised yet)
+   */
+public unsubscribeV5(
+    wsTopics: WsTopic[] | WsTopic,
+    category: CategoryV5,
+    isPrivateTopic?: boolean,
+): Promise<unknown>[]
+⋮----
+// Sort into per-WsKey batches, in case there is a mix of topics here
+⋮----
+// Batch sub topics per ws key
+⋮----
+// Return promise to resolve midflight WS request (only works if already connected before request)
+⋮----
+/**
+   * Note: subscribeV5() might be simpler to use. The end result is the same.
+   *
+   * Request subscription to one or more topics. Pass topics as either an array of strings,
+   * or array of objects (if the topic has parameters).
+   *
+   * Objects should be formatted as {topic: string, params: object, category: CategoryV5}.
+   *
+   * - Subscriptions are automatically routed to the correct websocket connection.
+   * - Authentication/connection is automatic.
+   * - Resubscribe after network issues is automatic.
+   *
+   * Call `unsubscribe(topics)` to remove topics
+   */
+public subscribe(
+    requests:
+      | (WsTopicRequest<WsTopic> | WsTopic)
+      | (WsTopicRequest<WsTopic> | WsTopic)[],
+    requestedWsKey?: WsKey,
+)
+⋮----
+// Batch sub topics per ws key
+⋮----
+/**
+   * Note: unsubscribe() might be simpler to use. The end result is the same.
+   * Unsubscribe from one or more topics. Similar to subscribe() but in reverse.
+   *
+   * - Requests are automatically routed to the correct websocket connection.
+   * - These topics will be removed from the topic cache, so they won't be subscribed to again.
+   */
+public unsubscribe(
+    requests:
+      | (WsTopicRequest<WsTopic> | WsTopic)
+      | (WsTopicRequest<WsTopic> | WsTopic)[],
+    wsKey?: WsKey,
+)
+⋮----
+// Batch sub topics per ws key
+⋮----
+/**
+   *
+   *
+   *
+   * WS API Methods - similar to the REST API, but via WebSockets
+   * https://bybit-exchange.github.io/docs/v5/websocket/trade/guideline
+   *
+   *
+   *
+   */
+⋮----
+/**
+   * Send a Websocket API command/request on a connection. Returns a promise that resolves on reply.
+   *
+   * WS API Documentation for list of operations and parameters:
+   * https://bybit-exchange.github.io/docs/v5/websocket/trade/guideline
+   *
+   * Returned promise is rejected if:
+   * - an exception is detected in the reply, OR
+   * - the connection disconnects for any reason (even if automatic reconnect will happen).
+   *
+   * Authentication is automatic. If you didn't request authentication yourself, there might
+   * be a small delay after your first request, while the SDK automatically authenticates.
+   *
+   * @param wsKey - The connection this event is for. Currently only "v5PrivateTrade" is supported
+   * for Bybit, since that is the dedicated WS API connection.
+   * @param operation - The command being sent, e.g. "order.create" to submit a new order.
+   * @param params - Any request parameters for the command. E.g. `OrderParamsV5` to submit a new
+   * order. Only send parameters for the request body. Everything else is automatically handled.
+   * @returns Promise - tries to resolve with async WS API response. Rejects if disconnected or exception is seen in async WS API response
+   */
+⋮----
+// This overload allows the caller to omit the 3rd param, if it isn't required
+sendWSAPIRequest<
+    TWSKey extends keyof WsAPIWsKeyTopicMap,
+    TWSOperation extends WsAPIWsKeyTopicMap[TWSKey],
+    TWSParams extends Exact<WsAPITopicRequestParamMap[TWSOperation]>,
+  >(
+    wsKey: TWSKey,
+    operation: TWSOperation,
+    ...params: TWSParams extends undefined ? [] : [TWSParams]
+  ): Promise<WsAPIOperationResponseMap[TWSOperation]>;
+⋮----
+// These overloads give stricter types than mapped generics, since generic constraints
+// do not trigger excess property checks
+// Without these overloads, TypeScript won't complain if you include an
+// unexpected property with your request (if it doesn't clash with an existing property)
+sendWSAPIRequest<TWSOperation extends WSAPIOperation = 'order.create'>(
+    wsKey: typeof WS_KEY_MAP.v5PrivateTrade,
+    operation: TWSOperation,
+    params: WsAPITopicRequestParamMap[TWSOperation],
+  ): Promise<WsAPIOperationResponseMap[TWSOperation]>;
+⋮----
+sendWSAPIRequest<TWSOperation extends WSAPIOperation = 'order.amend'>(
+    wsKey: typeof WS_KEY_MAP.v5PrivateTrade,
+    operation: TWSOperation,
+    params: WsAPITopicRequestParamMap[TWSOperation],
+  ): Promise<WsAPIOperationResponseMap[TWSOperation]>;
+⋮----
+sendWSAPIRequest<TWSOperation extends WSAPIOperation = 'order.cancel'>(
+    wsKey: typeof WS_KEY_MAP.v5PrivateTrade,
+    operation: TWSOperation,
+    params: WsAPITopicRequestParamMap[TWSOperation],
+  ): Promise<WsAPIOperationResponseMap[TWSOperation]>;
+⋮----
+async sendWSAPIRequest<
+    TWSKey extends keyof WsAPIWsKeyTopicMap,
+    TWSOperation extends WsAPIWsKeyTopicMap[TWSKey],
+    TWSParams extends Exact<WsAPITopicRequestParamMap[TWSOperation]>,
+    TWSAPIResponse extends
+      WsAPIOperationResponseMap[TWSOperation] = WsAPIOperationResponseMap[TWSOperation],
+  >(
+    wsKey: WsKey = WS_KEY_MAP.v5PrivateTrade,
+    operation: TWSOperation,
+    params: TWSParams,
+): Promise<WsAPIOperationResponseMap[TWSOperation]>
+⋮----
+// Sign, if needed
+⋮----
+// Store deferred promise, resolved within the "resolveEmittableEvents" method while parsing incoming events
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+⋮----
+// Enrich returned promise with request context for easier debugging
+⋮----
+// throw e;
+⋮----
+// Send event
+⋮----
+// Return deferred promise, so caller can await this call
+⋮----
+/**
+   *
+   *
+   * Internal methods - not intended for public use
+   *
+   *
+   */
+⋮----
+/**
+   * @returns The WS URL to connect to for this WS key
+   */
+protected async getWsUrl(wsKey: WsKey): Promise<string>
+⋮----
+// If auth is needed for this wsKey URL, this returns a suffix
+⋮----
+/**
+   * Return params required to make authorized request
+   */
+private async getWsAuthURLSuffix(): Promise<string>
+⋮----
+private async signMessage(
+    paramsStr: string,
+    secret: string,
+    method?: 'hex' | 'base64',
+    algorithm: SignAlgorithm = 'SHA-256',
+): Promise<string>
+⋮----
+protected async getWsAuthRequestEvent(
+    wsKey: WsKey,
+): Promise<WsRequestOperationBybit<string>>
+⋮----
+private async getWsAuthSignature(
+    wsKey: WsKey,
+): Promise<
+⋮----
+undefined, // Let the function automatically determine encoding based on key type
+⋮----
+private async signWSAPIRequest<TRequestParams = object>(
+    requestEvent: WSAPIRequest<TRequestParams>,
+): Promise<WSAPIRequest<TRequestParams>>
+⋮----
+// Not needed for Bybit. Auth happens only on connection open, automatically.
+⋮----
+protected sendPingEvent(wsKey: WsKey)
+⋮----
+protected sendPongEvent(wsKey: WsKey)
+⋮----
+/** Force subscription requests to be sent in smaller batches, if a number is returned */
+protected getMaxTopicsPerSubscribeEvent(wsKey: WsKey): number | null
+⋮----
+/**
+   * @returns one or more correctly structured request events for performing a operations over WS. This can vary per exchange spec.
+   */
+protected async getWsRequestEvents(
+    market: WsMarket,
+    operation: WsOperation,
+    requests: WsTopicRequest<string>[],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
+    wsKey: WsKey,
+): Promise<MidflightWsRequestEvent<WsRequestOperationBybit<WsTopic>>[]>
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
+⋮----
+// Previously used to track topics in a request. Keeping this for subscribe/unsubscribe requests, no need for incremental values
+⋮----
+protected getPrivateWSKeys(): WsKey[]
+⋮----
+protected isAuthOnConnectWsKey(wsKey: WsKey): boolean
+⋮----
+/**
+   * Determines if a topic is for a private channel, using a hardcoded list of strings
+   */
+protected isPrivateTopicRequest(request: WsTopicRequest<string>): boolean
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+protected isWsPing(msg: any): boolean
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+protected isWsPong(msg: any): boolean
+⋮----
+// public ws connections
+⋮----
+// private ws connections
+⋮----
+/**
+   * Abstraction called to sort ws events into emittable event types (response to a request, data update, etc)
+   */
+protected resolveEmittableEvents(
+    wsKey: WsKey,
+    event: MessageEventLike,
+): EmittableEvent[]
+⋮----
+// this.logger.trace('resolveEmittableEvents', {
+//   ...WS_LOGGER_CATEGORY,
+//   wsKey,
+//   parsed: JSON.stringify(parsed),
+// });
+⋮----
+// Only applies to the V5 WS topics
+⋮----
+// WS API response
+⋮----
+// eslint-disable-next-line max-len
+⋮----
+// WS API Exception
+⋮----
+// WS API Success
+⋮----
+// Messages for a subscribed topic all include the "topic" property
+⋮----
+// Messages that are a "reply" to a request/command (e.g. subscribe to these topics) typically include the "op" property
+⋮----
+// Failed request
+⋮----
+// These are r  equest/reply pattern events (e.g. after subscribing to topics or authenticating)
+⋮----
+// Request/reply pattern for authentication success
+⋮----
+// In case of catastrophic failure, fallback to noisy emit update
+
+================
+File: webpack/webpack.config.js
+================
+function generateConfig(name)
+⋮----
+// Add '.ts' and '.tsx' as resolvable extensions.
+⋮----
+// Node.js core modules not available in browsers
+// The REST client's https.Agent (for keepAlive) is Node.js-only and won't work in browsers
+⋮----
+// All files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'.
+⋮----
+// All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
 
 ================
 File: examples/rest-v5-p2p.ts
@@ -6635,6 +7123,20 @@ export interface GetConvertHistoryParamsV5 {
   index?: number;
   limit?: number;
 }
+⋮----
+export interface GetSmallBalanceListParamsV5 {
+  accountType: 'eb_convert_uta'; // Wallet type, only supports Unified wallet
+  fromCoin?: string; // Source currency
+}
+⋮----
+accountType: 'eb_convert_uta'; // Wallet type, only supports Unified wallet
+fromCoin?: string; // Source currency
+⋮----
+export interface GetFiatTradingPairListParamsV5 {
+  side?: 0 | 1; // 0: buy (buy crypto, sell fiat), 1: sell (sell crypto, buy fiat)
+}
+⋮----
+side?: 0 | 1; // 0: buy (buy crypto, sell fiat), 1: sell (sell crypto, buy fiat)
 
 ================
 File: src/types/request/v5-earn.ts
@@ -6858,180 +7360,6 @@ export interface GetLongShortRatioParamsV5 {
 }
 
 ================
-File: src/types/request/v5-trade.ts
-================
-import {
-  CategoryV5,
-  OrderFilterV5,
-  OrderSideV5,
-  OrderSMPTypeV5,
-  OrderStatusV5,
-  OrderTimeInForceV5,
-  OrderTriggerByV5,
-  OrderTypeV5,
-  PositionIdx,
-  StopOrderTypeV5,
-} from '../shared-v5';
-⋮----
-export interface OrderParamsV5 {
-  category: CategoryV5;
-  symbol: string;
-  isLeverage?: 0 | 1;
-  side: OrderSideV5;
-  orderType: OrderTypeV5;
-  qty: string;
-  marketUnit?: 'baseCoin' | 'quoteCoin';
-  slippageToleranceType?: string;
-  slippageTolerance?: string;
-  price?: string;
-  triggerDirection?: 1 | 2;
-  orderFilter?: OrderFilterV5;
-  triggerPrice?: string;
-  triggerBy?: OrderTriggerByV5;
-  orderIv?: string;
-  timeInForce?: OrderTimeInForceV5;
-  positionIdx?: PositionIdx;
-  orderLinkId?: string;
-  takeProfit?: string;
-  stopLoss?: string;
-  tpTriggerBy?: OrderTriggerByV5;
-  slTriggerBy?: OrderTriggerByV5;
-  reduceOnly?: boolean;
-  closeOnTrigger?: boolean;
-  smpType?: OrderSMPTypeV5;
-  mmp?: boolean;
-  tpslMode?: 'Full' | 'Partial';
-  tpLimitPrice?: string;
-  slLimitPrice?: string;
-  tpOrderType?: OrderTypeV5;
-  slOrderType?: OrderTypeV5;
-  bboSideType?: 'Queue' | 'Counterparty';
-  bboLevel?: '1' | '2' | '3' | '4' | '5';
-}
-⋮----
-export interface AmendOrderParamsV5 {
-  category: CategoryV5;
-  symbol: string;
-  orderId?: string;
-  orderLinkId?: string;
-  orderIv?: string;
-  triggerPrice?: string;
-  qty?: string;
-  price?: string;
-  tpslMode?: 'Full' | 'Partial';
-  takeProfit?: string;
-  stopLoss?: string;
-  tpTriggerBy?: OrderTriggerByV5;
-  slTriggerBy?: OrderTriggerByV5;
-  triggerBy?: OrderTriggerByV5;
-  tpLimitPrice?: string;
-  slLimitPrice?: string;
-}
-⋮----
-export interface CancelOrderParamsV5 {
-  category: CategoryV5;
-  symbol: string;
-  orderId?: string;
-  orderLinkId?: string;
-  orderFilter?: OrderFilterV5;
-}
-⋮----
-export interface GetAccountOrdersParamsV5 {
-  category: CategoryV5;
-  symbol?: string;
-  baseCoin?: string;
-  settleCoin?: string;
-  orderId?: string;
-  orderLinkId?: string;
-  openOnly?: 0 | 1 | 2;
-  orderFilter?: OrderFilterV5;
-  orderStatus?: OrderStatusV5;
-  limit?: number;
-  cursor?: string;
-}
-⋮----
-export interface GetAccountHistoricOrdersParamsV5 {
-  category: CategoryV5;
-  symbol?: string;
-  baseCoin?: string;
-  settleCoin?: string;
-  orderId?: string;
-  orderLinkId?: string;
-  orderFilter?: OrderFilterV5;
-  orderStatus?: OrderStatusV5;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-  cursor?: string;
-}
-⋮----
-export interface CancelAllOrdersParamsV5 {
-  category: CategoryV5;
-  symbol?: string;
-  baseCoin?: string;
-  settleCoin?: string;
-  orderFilter?: OrderFilterV5;
-  stopOrderType?: StopOrderTypeV5;
-}
-⋮----
-export interface BatchOrderParamsV5 {
-  symbol: string;
-  side: OrderSideV5;
-  isLeverage?: 0 | 1;
-  orderType: OrderTypeV5;
-  qty: string;
-  price?: string;
-  triggerDirection?: 1 | 2;
-  triggerBy?: OrderTriggerByV5;
-  orderIv?: string;
-  timeInForce?: OrderTimeInForceV5;
-  positionIdx?: PositionIdx;
-  orderLinkId?: string;
-  takeProfit?: string;
-  stopLoss?: string;
-  tpTriggerBy?: OrderTriggerByV5;
-  slTriggerBy?: OrderTriggerByV5;
-  reduceOnly?: boolean;
-  closeOnTrigger?: boolean;
-  smpType?: OrderSMPTypeV5;
-  mmp?: boolean;
-  tpslMode?: 'Full' | 'Partial';
-  tpLimitPrice?: string;
-  slLimitPrice?: string;
-  tpOrderType?: OrderTypeV5;
-  slOrderType?: OrderTypeV5;
-}
-⋮----
-export interface BatchAmendOrderParamsV5 {
-  symbol: string;
-  orderId?: string;
-  orderLinkId?: string;
-  orderIv?: string;
-  triggerPrice?: string;
-  qty?: string;
-  price?: string;
-  tpslMode?: 'Full' | 'Partial';
-  takeProfit?: string;
-  stopLoss?: string;
-  tpTriggerBy?: OrderTriggerByV5;
-  slTriggerBy?: OrderTriggerByV5;
-  triggerBy?: OrderTriggerByV5;
-  tpLimitPrice?: string;
-  slLimitPrice?: string;
-}
-⋮----
-export interface BatchCancelOrderParamsV5 {
-  symbol: string;
-  orderId?: string;
-  orderLinkId?: string;
-}
-
-================
-File: src/types/response/index.ts
-================
-
-
-================
 File: src/types/response/v5-rfq.ts
 ================
 export interface RFQConfigV5 {
@@ -7193,6 +7521,7 @@ export interface RFQItemV5 {
     | 'Filled'
     | 'Expired'
     | 'Failed'; // Status
+  acceptOtherQuoteStatus?: string; // Whether to accept non-LP quotes. "false": do not accept, "true": accept
   deskCode: string; // Unique identification code of the inquiry party
   createdAt: number; // Time when the trade is created in epoch
   updatedAt: number; // Time when the trade is updated in epoch
@@ -7206,6 +7535,7 @@ expiresAt: string; // Expiration time in milliseconds Unix timestamp
 strategyType: string; // Inquiry label
 ⋮----
 | 'Failed'; // Status
+acceptOtherQuoteStatus?: string; // Whether to accept non-LP quotes. "false": do not accept, "true": accept
 deskCode: string; // Unique identification code of the inquiry party
 createdAt: number; // Time when the trade is created in epoch
 updatedAt: number; // Time when the trade is updated in epoch
@@ -7357,152 +7687,12 @@ strategyType: string; // Inquiry label
 createdAt: number; // Time when trade is created in epoch
 updatedAt: number; // Time when trade is updated in epoch
 legs: RFQPublicTradeLegV5[]; // Combination transaction
-
-================
-File: src/types/response/v5-spot-leverage-token.ts
-================
-import {
-  LeverageTokenStatusV5,
-  LTOrderStatusV5,
-  LTOrderTypeV5,
-} from '../shared-v5';
 ⋮----
-export interface LeverageTokenInfoV5 {
-  ltCoin: string;
-  ltName: string;
-  maxPurchase: string;
-  minPurchase: string;
-  maxPurchaseDaily: string;
-  maxRedeem: string;
-  minRedeem: string;
-  maxRedeemDaily: string;
-  purchaseFeeRate: string;
-  redeemFeeRate: string;
-  ltStatus: LeverageTokenStatusV5;
-  fundFee: string;
-  fundFeeTime: string;
-  manageFeeRate: string;
-  manageFeeTime: string;
-  value: string;
-  netValue: string;
-  total: string;
+export interface AcceptNonLPQuoteResultV5 {
+  rfqId: string; // Inquiry ID
 }
 ⋮----
-export interface LeveragedTokenMarketResultV5 {
-  ltCoin: string;
-  nav: string;
-  navTime: string;
-  circulation: string;
-  basket: string;
-  leverage: string;
-}
-⋮----
-export interface PurchaseSpotLeveragedTokenResultV5 {
-  ltCoin: string;
-  ltOrderStatus: LTOrderStatusV5;
-  execQty: string;
-  execAmt: string;
-  amount: string;
-  purchaseId: string;
-  serialNo: string;
-  valueCoin: string;
-}
-export interface RedeemSpotLeveragedTokenResultV5 {
-  ltCoin: string;
-  ltOrderStatus: LTOrderStatusV5;
-  quantity: string;
-  execQty: string;
-  execAmt: string;
-  redeemId: string;
-  serialNo: string;
-  valueCoin: string;
-}
-⋮----
-export interface SpotLeveragedTokenOrderHistoryV5 {
-  ltCoin: string;
-  orderId: string;
-  ltOrderType: LTOrderTypeV5;
-  orderTime: number;
-  updateTime: number;
-  ltOrderStatus: LTOrderStatusV5;
-  fee: string;
-  amount: string;
-  value: string;
-  valueCoin: string;
-  serialNo: string;
-}
-⋮----
-export interface VIPMarginDataV5 {
-  vipCoinList: {
-    list: {
-      borrowable: boolean;
-      collateralRatio: string;
-      currency: string;
-      hourlyBorrowRate: string;
-      liquidationOrder: string;
-      marginCollateral: boolean;
-      maxBorrowingAmount: string;
-    }[];
-    vipLevel: string;
-  }[];
-}
-⋮----
-export interface SpotMarginStateV5 {
-  spotLeverage: string;
-  spotMarginMode: '1' | '0';
-  effectiveLeverage: string;
-}
-⋮----
-// Spot Margin Trade (UTA) response types
-export interface ManualBorrowResultV5 {
-  coin: string;
-  amount: string;
-}
-⋮----
-export interface MaxBorrowableAmountV5 {
-  currency: string;
-  maxLoan: string;
-}
-⋮----
-export interface PositionTierV5 {
-  tier: string;
-  borrowLimit: string;
-  positionMMR: string;
-  positionIMR: string;
-  maxLeverage: string;
-}
-⋮----
-export interface CurrencyPositionTiersV5 {
-  currency: string;
-  positionTiersRatioList: PositionTierV5[];
-}
-⋮----
-export interface CoinStateV5 {
-  currency: string;
-  spotLeverage: string;
-}
-⋮----
-export interface AvailableAmountToRepayV5 {
-  currency: string;
-  lossLessRepaymentAmount: string;
-}
-⋮----
-export interface ManualRepayWithoutConversionResultV5 {
-  /**
-   * Result status:
-   * - P: Processing
-   * - SU: Success
-   * - FA: Failed
-   */
-  resultStatus: 'P' | 'SU' | 'FA';
-}
-⋮----
-/**
-   * Result status:
-   * - P: Processing
-   * - SU: Success
-   * - FA: Failed
-   */
+rfqId: string; // Inquiry ID
 
 ================
 File: src/types/response/v5-spreadtrading.ts
@@ -7667,13 +7857,356 @@ export interface SpreadTradeV5 {
 }
 
 ================
-File: .eslintrc.cjs
+File: src/types/response/v5-trade.ts
 ================
-// 'require-extensions', // only once moved to ESM
+import {
+  CategoryV5,
+  OrderCancelTypeV5,
+  OrderCreateTypeV5,
+  OrderRejectReasonV5,
+  OrderSideV5,
+  OrderStatusV5,
+  OrderTimeInForceV5,
+  OrderTriggerByV5,
+  OrderTypeV5,
+  PositionIdx,
+  StopOrderTypeV5,
+} from '../shared-v5';
 ⋮----
-// 'plugin:require-extensions/recommended', // only once moved to ESM
+export interface OrderResultV5 {
+  orderId: string;
+  orderLinkId: string;
+}
 ⋮----
-// 'no-unused-vars': ['warn'],
+export interface AccountOrderV5 {
+  orderId: string;
+  orderLinkId: string;
+  parentOrderLinkId?: string; // Linked parent order for attached TP/SL orders (futures & options)
+  blockTradeId: string;
+  symbol: string;
+  price: string;
+  qty: string;
+  side: OrderSideV5;
+  isLeverage: '0' | '1';
+  positionIdx: PositionIdx;
+  orderStatus: OrderStatusV5;
+  createType: OrderCreateTypeV5;
+  cancelType: OrderCancelTypeV5;
+  rejectReason: OrderRejectReasonV5;
+  avgPrice: string;
+  leavesQty: string;
+  leavesValue: string;
+  cumExecQty: string;
+  cumExecValue: string;
+  cumExecFee: string;
+  timeInForce: OrderTimeInForceV5;
+  orderType: OrderTypeV5;
+  stopOrderType: StopOrderTypeV5;
+  orderIv: string;
+  marketUnit: 'baseCoin' | 'quoteCoin';
+  slippageToleranceType: string;
+  slippageTolerance: string;
+  triggerPrice: string;
+  takeProfit: string;
+  stopLoss: string;
+  tpslMode: 'Full' | 'Partial' | '';
+  ocoTriggerType:
+    | 'OcoTriggerByUnknown'
+    | 'OcoTriggerTp'
+    | 'OcoTriggerBySl'
+    | '';
+  tpLimitPrice: string;
+  slLimitPrice: string;
+  tpTriggerBy: OrderTriggerByV5;
+  slTriggerBy: OrderTriggerByV5;
+  triggerDirection: 1 | 2;
+  triggerBy: OrderTriggerByV5;
+  lastPriceOnCreated: string;
+  basePrice: string;
+  reduceOnly: boolean;
+  closeOnTrigger: boolean;
+  placeType: 'iv' | 'price' | '';
+  smpType: string;
+  smpGroup: number;
+  smpOrderId: string;
+  createdTime: string;
+  updatedTime: string;
+  extraFees: string;
+  cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee
+}
+⋮----
+parentOrderLinkId?: string; // Linked parent order for attached TP/SL orders (futures & options)
+⋮----
+cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee
+⋮----
+export interface BatchCreateOrderResultV5 {
+  category: CategoryV5;
+  symbol: string;
+  orderId: string;
+  orderLinkId: string;
+  createAt?: string;
+}
+⋮----
+export interface BatchOrdersRetExtInfoV5 {
+  list: {
+    code: number;
+    msg: string;
+  }[];
+}
+⋮----
+export interface BatchAmendOrderResultV5 {
+  category: CategoryV5;
+  symbol: string;
+  orderId: string;
+  orderLinkId: string;
+}
+⋮----
+export interface BatchCancelOrderResultV5 {
+  category: CategoryV5;
+  symbol: string;
+  orderId: string;
+  orderLinkId: string;
+}
+⋮----
+export interface SpotBorrowCheckResultV5 {
+  symbol: string;
+  side: OrderSideV5;
+  maxTradeQty: string;
+  maxTradeAmount: string;
+  spotMaxTradeQty: string;
+  spotMaxTradeAmount: string;
+  borrowCoin: string;
+}
+⋮----
+export interface PreCheckOrderResultV5 {
+  orderId: string;
+  orderLinkId: string;
+  preImrE4: number; // Initial margin rate before checking (in basis points)
+  preMmrE4: number; // Maintenance margin rate before checking (in basis points)
+  postImrE4: number; // Initial margin rate after checking (in basis points)
+  postMmrE4: number; // Maintenance margin rate after checking (in basis points)
+}
+⋮----
+preImrE4: number; // Initial margin rate before checking (in basis points)
+preMmrE4: number; // Maintenance margin rate before checking (in basis points)
+postImrE4: number; // Initial margin rate after checking (in basis points)
+postMmrE4: number; // Maintenance margin rate after checking (in basis points)
+
+================
+File: src/types/websockets/ws-general.ts
+================
+import type { ClientRequestArgs } from 'http';
+import WebSocket from 'isomorphic-ws';
+⋮----
+import { RestClientOptions, WS_KEY_MAP } from '../../util';
+⋮----
+/** For spot markets, spotV3 is recommended */
+export type APIMarket = 'v5';
+⋮----
+// Same as inverse futures
+export type WsPublicInverseTopic =
+  | 'orderBookL2_25'
+  | 'orderBookL2_200'
+  | 'trade'
+  | 'insurance'
+  | 'instrument_info'
+  | 'klineV2';
+⋮----
+export type WsPublicUSDTPerpTopic =
+  | 'orderBookL2_25'
+  | 'orderBookL2_200'
+  | 'trade'
+  | 'insurance'
+  | 'instrument_info'
+  | 'kline';
+⋮----
+export type WsPublicSpotV1Topic =
+  | 'trade'
+  | 'realtimes'
+  | 'kline'
+  | 'depth'
+  | 'mergedDepth'
+  | 'diffDepth';
+⋮----
+export type WsPublicSpotV2Topic =
+  | 'depth'
+  | 'kline'
+  | 'trade'
+  | 'bookTicker'
+  | 'realtimes';
+⋮----
+export type WsPublicTopics =
+  | WsPublicInverseTopic
+  | WsPublicUSDTPerpTopic
+  | WsPublicSpotV1Topic
+  | WsPublicSpotV2Topic
+  | string;
+⋮----
+// Same as inverse futures
+export type WsPrivateInverseTopic =
+  | 'position'
+  | 'execution'
+  | 'order'
+  | 'stop_order';
+⋮----
+export type WsPrivateUSDTPerpTopic =
+  | 'position'
+  | 'execution'
+  | 'order'
+  | 'stop_order'
+  | 'wallet';
+⋮----
+export type WsPrivateSpotTopic =
+  | 'outboundAccountInfo'
+  | 'executionReport'
+  | 'ticketInfo';
+⋮----
+export type WsPrivateTopic =
+  | WsPrivateInverseTopic
+  | WsPrivateUSDTPerpTopic
+  | WsPrivateSpotTopic
+  | string;
+⋮----
+export type WsTopic = WsPublicTopics | WsPrivateTopic;
+⋮----
+/** This is used to differentiate between each of the available websocket streams (as bybit has multiple websockets) */
+export type WsKey = (typeof WS_KEY_MAP)[keyof typeof WS_KEY_MAP];
+export type WsMarket = 'all';
+⋮----
+export interface WSClientConfigurableOptions {
+  /** Your API key */
+  key?: string;
+
+  /** Your API secret */
+  secret?: string;
+
+  /**
+   * Set to `true` to connect to Bybit's testnet environment.
+   *
+   * Notes:
+   *
+   * - If demo trading, `testnet` should be set to false!
+   * - If testing a strategy, use demo trading instead. Testnet market data is very different from real market conditions.
+   */
+  testnet?: boolean;
+
+  /**
+   * Set to `true` to connect to Bybit's V5 demo trading: https://bybit-exchange.github.io/docs/v5/demo
+   *
+   * Only the "V5" "market" is supported here.
+   */
+  demoTrading?: boolean;
+
+  /**
+   * The API group this client should connect to. The V5 market is currently used by default.
+   *
+   * Only the "V5" "market" is supported here.
+   */
+  market?: APIMarket;
+
+  /** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
+  recvWindow?: number;
+
+  /** How often to check if the connection is alive */
+  pingInterval?: number;
+
+  /** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
+  pongTimeout?: number;
+
+  /** Delay in milliseconds before respawning the connection */
+  reconnectTimeout?: number;
+
+  restOptions?: RestClientOptions;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  requestOptions?: any;
+
+  wsOptions?: {
+    protocols?: string[];
+    agent?: any;
+  } & Partial<WebSocket.ClientOptions | ClientRequestArgs>;
+
+  wsUrl?: string;
+
+  /**
+   * Default: false.
+   *
+   * When enabled, any calls to the subscribe method will return a promise.
+   * Note: internally, subscription requests are sent in batches. This may not behave as expected when
+   * subscribing to a large number of topics, especially if you are not yet connected when subscribing.
+   */
+  promiseSubscribeRequests?: boolean;
+
+  /**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
+}
+⋮----
+/** Your API key */
+⋮----
+/** Your API secret */
+⋮----
+/**
+   * Set to `true` to connect to Bybit's testnet environment.
+   *
+   * Notes:
+   *
+   * - If demo trading, `testnet` should be set to false!
+   * - If testing a strategy, use demo trading instead. Testnet market data is very different from real market conditions.
+   */
+⋮----
+/**
+   * Set to `true` to connect to Bybit's V5 demo trading: https://bybit-exchange.github.io/docs/v5/demo
+   *
+   * Only the "V5" "market" is supported here.
+   */
+⋮----
+/**
+   * The API group this client should connect to. The V5 market is currently used by default.
+   *
+   * Only the "V5" "market" is supported here.
+   */
+⋮----
+/** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
+⋮----
+/** How often to check if the connection is alive */
+⋮----
+/** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
+⋮----
+/** Delay in milliseconds before respawning the connection */
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+⋮----
+/**
+   * Default: false.
+   *
+   * When enabled, any calls to the subscribe method will return a promise.
+   * Note: internally, subscription requests are sent in batches. This may not behave as expected when
+   * subscribing to a large number of topics, especially if you are not yet connected when subscribing.
+   */
+⋮----
+/**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+⋮----
+/**
+ * WS configuration that's always defined, regardless of user configuration
+ * (usually comes from defaults if there's no user-provided values)
+ */
+export interface WebsocketClientOptions extends WSClientConfigurableOptions {
+  market: APIMarket;
+  pongTimeout: number;
+  pingInterval: number;
+  reconnectTimeout: number;
+  recvWindow: number;
+  authPrivateConnectionsOnConnect: boolean;
+  authPrivateRequests: boolean;
+}
 
 ================
 File: src/types/response/v5-account.ts
@@ -7838,6 +8371,521 @@ export interface DCPInfoV5 {
 export interface ManualRepayResultV5 {
   resultStatus: 'P' | 'SU' | 'FA';
 }
+
+================
+File: src/types/shared-v5.ts
+================
+export type CategoryV5 = 'spot' | 'linear' | 'inverse' | 'option';
+export type ContractTypeV5 =
+  | 'InversePerpetual'
+  | 'LinearPerpetual'
+  | 'InverseFutures';
+export type CopyTradingV5 = 'none' | 'both' | 'utaOnly' | 'normalOnly';
+⋮----
+export type InstrumentStatusV5 =
+  | 'PreLaunch'
+  | 'Trading'
+  | 'Settling'
+  | 'Delivering'
+  | 'Closed';
+⋮----
+export type MarginTradingV5 = 'none' | 'both' | 'utaOnly' | 'normalSpotOnly';
+⋮----
+export type OrderFilterV5 = 'Order' | 'tpslOrder' | 'StopOrder';
+export type OrderSideV5 = 'Buy' | 'Sell';
+export type OrderTypeV5 = 'Market' | 'Limit';
+export type OrderTimeInForceV5 = 'GTC' | 'IOC' | 'FOK' | 'PostOnly' | 'RPI';
+export type OrderTriggerByV5 = 'LastPrice' | 'IndexPrice' | 'MarkPrice';
+export type OCOTriggerTypeV5 =
+  | 'OcoTriggerByUnknown'
+  | 'OcoTriggerTp'
+  | 'OcoTriggerBySl';
+⋮----
+export type OrderSMPTypeV5 =
+  | 'None'
+  | 'CancelMaker'
+  | 'CancelTaker'
+  | 'CancelBoth';
+⋮----
+export type OrderStatusV5 =
+  | 'Created'
+  | 'New'
+  | 'Rejected'
+  | 'PartiallyFilled'
+  | 'PartiallyFilledCanceled'
+  | 'Filled'
+  | 'Cancelled'
+  | 'Untriggered'
+  | 'Triggered'
+  | 'Deactivated'
+  | 'Active';
+⋮----
+/**
+ * Defines the types of order creation mechanisms.
+ */
+export type OrderCreateTypeV5 =
+  /** Represents an order created by a user. */
+  | 'CreateByUser'
+  /** Represents an order created by an admin closing. */
+  | 'CreateByAdminClosing'
+  /** Futures conditional order. */
+  | 'CreateByStopOrder'
+  /** Futures take profit order. */
+  | 'CreateByTakeProfit'
+  /** Futures partial take profit order. */
+  | 'CreateByPartialTakeProfit'
+  /** Futures stop loss order. */
+  | 'CreateByStopLoss'
+  /** Futures partial stop loss order. */
+  | 'CreateByPartialStopLoss'
+  /** Futures trailing stop order. */
+  | 'CreateByTrailingStop'
+  /** Laddered liquidation to reduce the required maintenance margin. */
+  | 'CreateByLiq'
+  /**
+   * If the position is still subject to liquidation (i.e., does not meet the required maintenance margin level),
+   * the position shall be taken over by the liquidation engine and closed at the bankruptcy price.
+   */
+  | 'CreateByTakeOver_PassThrough'
+  /** Auto-Deleveraging(ADL) */
+  | 'CreateByAdl_PassThrough'
+  /** Order placed via Paradigm. */
+  | 'CreateByBlock_PassThrough'
+  /** Order created by move position. */
+  | 'CreateByBlockTradeMovePosition_PassThrough'
+  /** The close order placed via web or app position area - web/app. */
+  | 'CreateByClosing'
+  /** Order created via grid bot - web/app. */
+  | 'CreateByFGridBot'
+  /** Order closed via grid bot - web/app. */
+  | 'CloseByFGridBot'
+  /** Order created by TWAP - web/app. */
+  | 'CreateByTWAP'
+  /** Order created by TV webhook - web/app. */
+  | 'CreateByTVSignal'
+  /** Order created by Mm rate close function - web/app. */
+  | 'CreateByMmRateClose'
+  /** Order created by Martingale bot - web/app. */
+  | 'CreateByMartingaleBot'
+  /** Order closed by Martingale bot - web/app. */
+  | 'CloseByMartingaleBot'
+  /** Order created by Ice berg strategy - web/app. */
+  | 'CreateByIceBerg'
+  /** Order created by arbitrage - web/app. */
+  | 'CreateByArbitrage'
+  /** Option dynamic delta hedge order - web/app */
+  | 'CreateByDdh'
+  /** BBO Order - Best Bid/Offer order */
+  | 'CreateByBboOrder';
+⋮----
+/** Represents an order created by a user. */
+⋮----
+/** Represents an order created by an admin closing. */
+⋮----
+/** Futures conditional order. */
+⋮----
+/** Futures take profit order. */
+⋮----
+/** Futures partial take profit order. */
+⋮----
+/** Futures stop loss order. */
+⋮----
+/** Futures partial stop loss order. */
+⋮----
+/** Futures trailing stop order. */
+⋮----
+/** Laddered liquidation to reduce the required maintenance margin. */
+⋮----
+/**
+   * If the position is still subject to liquidation (i.e., does not meet the required maintenance margin level),
+   * the position shall be taken over by the liquidation engine and closed at the bankruptcy price.
+   */
+⋮----
+/** Auto-Deleveraging(ADL) */
+⋮----
+/** Order placed via Paradigm. */
+⋮----
+/** Order created by move position. */
+⋮----
+/** The close order placed via web or app position area - web/app. */
+⋮----
+/** Order created via grid bot - web/app. */
+⋮----
+/** Order closed via grid bot - web/app. */
+⋮----
+/** Order created by TWAP - web/app. */
+⋮----
+/** Order created by TV webhook - web/app. */
+⋮----
+/** Order created by Mm rate close function - web/app. */
+⋮----
+/** Order created by Martingale bot - web/app. */
+⋮----
+/** Order closed by Martingale bot - web/app. */
+⋮----
+/** Order created by Ice berg strategy - web/app. */
+⋮----
+/** Order created by arbitrage - web/app. */
+⋮----
+/** Option dynamic delta hedge order - web/app */
+⋮----
+/** BBO Order - Best Bid/Offer order */
+⋮----
+export type OrderCancelTypeV5 =
+  | 'CancelByUser'
+  | 'CancelByReduceOnly'
+  | 'CancelByPrepareLiq'
+  | 'CancelAllBeforeLiq'
+  | 'CancelByPrepareAdl'
+  | 'CancelAllBeforeAdl'
+  | 'CancelByAdmin'
+  | 'CancelByTpSlTsClear'
+  | 'CancelByPzSideCh'
+  | 'UNKNOWN';
+⋮----
+export type OrderRejectReasonV5 =
+  | 'EC_NoError'
+  | 'EC_Others'
+  | 'EC_UnknownMessageType'
+  | 'EC_MissingClOrdID'
+  | 'EC_MissingOrigClOrdID'
+  | 'EC_ClOrdIDOrigClOrdIDAreTheSame'
+  | 'EC_DuplicatedClOrdID'
+  | 'EC_OrigClOrdIDDoesNotExist'
+  | 'EC_TooLateToCancel'
+  | 'EC_UnknownOrderType'
+  | 'EC_UnknownSide'
+  | 'EC_UnknownTimeInForce'
+  | 'EC_WronglyRouted'
+  | 'EC_MarketOrderPriceIsNotZero'
+  | 'EC_LimitOrderInvalidPrice'
+  | 'EC_NoEnoughQtyToFill'
+  | 'EC_NoImmediateQtyToFill'
+  | 'EC_PerCancelRequest'
+  | 'EC_MarketOrderCannotBePostOnly'
+  | 'EC_PostOnlyWillTakeLiquidity'
+  | 'EC_CancelReplaceOrder'
+  | 'EC_InvalidSymbolStatus';
+⋮----
+export type StopOrderTypeV5 =
+  | 'TakeProfit'
+  | 'StopLoss'
+  | 'TrailingStop'
+  | 'Stop'
+  | 'PartialTakeProfit'
+  | 'PartialStopLoss'
+  | 'tpslOrder'
+  | 'OcoOrder'
+  | 'MmRateClose'
+  | 'BidirectionalTpslOrder';
+⋮----
+/**
+ * Position index. Used to identify positions in different position modes.
+ *
+ * - 0 one-way mode position
+ * - 1 Buy side of hedge-mode position
+ * - 2 Sell side of hedge-mode position
+ */
+export type PositionIdx = 0 | 1 | 2;
+⋮----
+/**
+ * Position status.
+ *
+ * - 'Normal'
+ * - 'Liq' in the liquidation progress
+ * - 'Adl' in the auto-deleverage progress
+ */
+export type PositionStatusV5 = 'Normal' | 'Liq' | 'Adl';
+export type PositionSideV5 = 'Buy' | 'Sell' | 'None' | '';
+⋮----
+export type OptionTypeV5 = 'Call' | 'Put';
+⋮----
+/**
+ * Trade mode.
+ *
+ * - 0 cross-margin,
+ * - 1 isolated margin
+ */
+export type TradeModeV5 = 0 | 1;
+⋮----
+export type TPSLModeV5 = 'Full' | 'Partial';
+export type AccountMarginModeV5 =
+  | 'ISOLATED_MARGIN'
+  | 'REGULAR_MARGIN'
+  | 'PORTFOLIO_MARGIN';
+export type UnifiedUpdateStatusV5 = 'FAIL' | 'PROCESS' | 'SUCCESS';
+⋮----
+export type AccountTypeV5 =
+  | 'CONTRACT'
+  | 'SPOT'
+  | 'INVESTMENT'
+  | 'OPTION'
+  | 'UNIFIED'
+  | 'FUND';
+⋮----
+export type TransactionTypeV5 =
+  | 'TRANSFER_IN'
+  | 'TRANSFER_OUT'
+  | 'TRADE'
+  | 'SETTLEMENT'
+  | 'DELIVERY'
+  | 'LIQUIDATION'
+  | 'ADL'
+  | 'AIRDROP'
+  | 'BONUS_RECOLLECT'
+  | 'BONUS_RECOLLECT'
+  | 'FEE_REFUND'
+  | 'INTEREST'
+  | 'CURRENCY_BUY'
+  | 'CURRENCY_SELL'
+  | 'BORROWED_AMOUNT_INS_LOAN'
+  | 'PRINCIPLE_REPAYMENT_INS_LOAN'
+  | 'INTEREST_REPAYMENT_INS_LOAN'
+  | 'AUTO_SOLD_COLLATERAL_INS_LOAN'
+  | 'AUTO_BUY_LIABILITY_INS_LOAN'
+  | 'AUTO_PRINCIPLE_REPAYMENT_INS_LOAN'
+  | 'AUTO_INTEREST_REPAYMENT_INS_LOAN'
+  | 'TRANSFER_IN_INS_LOAN'
+  | 'TRANSFER_OUT_INS_LOAN'
+  | 'SPOT_REPAYMENT_SELL'
+  | 'SPOT_REPAYMENT_BUY'
+  | 'TOKENS_SUBSCRIPTION'
+  | 'TOKENS_REDEMPTION'
+  | 'AUTO_DEDUCTION'
+  | 'FLEXIBLE_STAKING_SUBSCRIPTION'
+  | 'FLEXIBLE_STAKING_REDEMPTION'
+  | 'FIXED_STAKING_SUBSCRIPTION'
+  | 'BORROWED_AMOUNT_INS_LOAN'
+  | 'PRINCIPLE_REPAYMENT_INS_LOAN'
+  | 'INTEREST_REPAYMENT_INS_LOAN'
+  | 'AUTO_SOLD_COLLATERAL_INS_LOAN'
+  | 'AUTO_BUY_LIABILITY_INS_LOAN'
+  | 'AUTO_PRINCIPLE_REPAYMENT_INS_LOAN'
+  | 'AUTO_INTEREST_REPAYMENT_INS_LOAN'
+  | 'TRANSFER_IN_INS_LOAN'
+  | 'TRANSFER_OUT_INS_LOAN'
+  | 'SPOT_REPAYMENT_SELL'
+  | 'SPOT_REPAYMENT_BUY'
+  | 'TOKENS_SUBSCRIPTION'
+  | 'TOKENS_REDEMPTION'
+  | 'AUTO_DEDUCTION'
+  | 'FLEXIBLE_STAKING_SUBSCRIPTION'
+  | 'FLEXIBLE_STAKING_REDEMPTION'
+  | 'FIXED_STAKING_SUBSCRIPTION'
+  | 'FLEXIBLE_STAKING_REFUND'
+  | 'FIXED_STAKING_REFUND'
+  | 'PREMARKET_TRANSFER_OUT'
+  | 'PREMARKET_DELIVERY_SELL_NEW_COIN'
+  | 'PREMARKET_DELIVERY_BUY_NEW_COIN'
+  | 'PREMARKET_DELIVERY_PLEDGE_PAY_SELLER'
+  | 'PREMARKET_DELIVERY_PLEDGE_BACK'
+  | 'PREMARKET_ROLLBACK_PLEDGE_BACK'
+  | 'PREMARKET_ROLLBACK_PLEDGE_PENALTY_TO_BUYER'
+  | 'CUSTODY_NETWORK_FEE'
+  | 'CUSTODY_SETTLE_FEE'
+  | 'CUSTODY_LOCK'
+  | 'CUSTODY_UNLOCK'
+  | 'CUSTODY_UNLOCK_REFUND'
+  | 'LOANS_BORROW_FUNDS'
+  | 'LOANS_PLEDGE_ASSET'
+  | 'BONUS_TRANSFER_IN'
+  | 'BONUS_TRANSFER_OUT'
+  | 'PEF_TRANSFER_IN'
+  | 'PEF_TRANSFER_OUT'
+  | 'PEF_PROFIT_SHARE'
+  | 'ONCHAINEARN_SUBSCRIPTION'
+  | 'ONCHAINEARN_REDEMPTION'
+  | 'ONCHAINEARN_REFUND'
+  | 'STRUCTURE_PRODUCT_SUBSCRIPTION'
+  | 'STRUCTURE_PRODUCT_REFUND'
+  | 'CLASSIC_WEALTH_MANAGEMENT_SUBSCRIPTION'
+  | 'PREMIMUM_WEALTH_MANAGEMENT_SUBSCRIPTION'
+  | 'PREMIMUM_WEALTH_MANAGEMENT_REFUND'
+  | 'LIQUIDITY_MINING_SUBSCRIPTION'
+  | 'LIQUIDITY_MINING_REFUND'
+  | 'PWM_SUBSCRIPTION'
+  | 'PWM_REFUND'
+  | 'DEFI_INVESTMENT_SUBSCRIPTION'
+  | 'DEFI_INVESTMENT_REFUND'
+  | 'DEFI_INVESTMENT_REDEMPTION'
+  | 'INSTITUTION_LOAN_IN'
+  | 'INSTITUTION_PAYBACK_PRINCIPAL_OUT'
+  | 'INSTITUTION_PAYBACK_INTEREST_OUT'
+  | 'INSTITUTION_EXCHANGE_SELL'
+  | 'INSTITUTION_EXCHANGE_BUY'
+  | 'INSTITUTION_LIQ_PRINCIPAL_OUT'
+  | 'INSTITUTION_LIQ_INTEREST_OUT'
+  | 'INSTITUTION_LOAN_TRANSFER_IN'
+  | 'INSTITUTION_LOAN_TRANSFER_OUT'
+  | 'INSTITUTION_LOAN_WITHOUT_WITHDRAW'
+  | 'INSTITUTION_LOAN_RESERVE_IN'
+  | 'INSTITUTION_LOAN_RESERVE_OUT'
+  | 'PLATFORM_TOKEN_MNT_LIQRECALLEDMMNT'
+  | 'PLATFORM_TOKEN_MNT_LIQRETURNEDMNT';
+⋮----
+export type PermissionTypeV5 =
+  | 'ContractTrade'
+  | 'Spot'
+  | 'Wallet'
+  | 'Options'
+  | 'Derivatives'
+  | 'Exchange'
+  | 'NFT';
+⋮----
+/**
+ * Leveraged token status:
+ *
+ * - '1' LT can be purchased and redeemed
+ * - '2' LT can be purchased, but not redeemed
+ * - '3' LT can be redeemed, but not purchased
+ * - '4' LT cannot be purchased nor redeemed
+ * - '5' Adjusting position
+ */
+export type LeverageTokenStatusV5 = '1' | '2' | '3' | '4' | '5';
+⋮----
+/**
+ * Leveraged token order type: '1': purchase, '2': redeem
+ */
+export type LTOrderTypeV5 = '1' | '2';
+⋮----
+/**
+ * Leveraged token order status: '1': completed, '2': in progress, '3': failed
+ */
+export type LTOrderStatusV5 = '1' | '2' | '3';
+⋮----
+export type ExecTypeV5 =
+  | 'Trade'
+  | 'AdlTrade'
+  | 'Funding'
+  | 'BustTrade'
+  | 'Settle'
+  | 'BlockTrade'
+  | 'MovePosition'
+  | 'UNKNOWN';
+⋮----
+/**
+ * Withdraw type. 0(default): on chain. 1: off chain. 2: all.
+ */
+export type WithdrawalTypeV5 = '0' | '1' | '2';
+⋮----
+export interface PermissionsV5 {
+  ContractTrade?: string[];
+  Spot?: string[];
+  Wallet?: string[];
+  Options?: string[];
+  Derivatives?: string[];
+  CopyTrading?: string[];
+  BlockTrade?: string[];
+  Exchange?: string[];
+  /** @deprecated , always returns []*/
+  NFT?: string[];
+}
+⋮----
+/** @deprecated , always returns []*/
+⋮----
+export interface CategoryCursorListV5<
+  T extends unknown[],
+  TCategory extends CategoryV5 = CategoryV5,
+> {
+  category: TCategory;
+  list: T;
+  nextPageCursor?: string;
+}
+⋮----
+/**
+ * Next page cursor does not exist for spot!
+ */
+export interface CursorListV5<T extends unknown[]> {
+  nextPageCursor: string;
+  list: T;
+}
+⋮----
+/**
+ * A wrapper type for any responses that have a "nextPageCursor" property, and a "rows" property with an array of elements
+ *
+ * ```{ nextPageCursor: "something", rows: someData[] }```
+ */
+export interface CursorRowsV5<T extends unknown[]> {
+  nextPageCursor: string;
+  rows: T;
+}
+⋮----
+export interface CategoryListV5<
+  T extends unknown[],
+  TCategory extends CategoryV5,
+> {
+  category: TCategory;
+  list: T;
+}
+⋮----
+export interface CategorySymbolListV5<
+  T extends unknown[],
+  TCategory extends CategoryV5,
+> {
+  category: TCategory;
+  symbol: string;
+  list: T;
+}
+⋮----
+export interface GetSystemStatusParamsV5 {
+  id?: string;
+  state?: string;
+}
+⋮----
+export interface SystemStatusItemV5 {
+  id: string;
+  title: string;
+  state: string;
+  begin: string;
+  end: string;
+  href: string;
+  serviceTypes: number[];
+  product: number[];
+  uidSuffix: number[];
+  maintainType: string;
+  env: string;
+}
+
+================
+File: .gitignore
+================
+!.gitkeep
+.DS_STORE
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+pids
+*.pid
+*.seed
+*.pid.lock
+node_modules/
+.npm
+.eslintcache
+.node_repl_history
+*.tgz
+.yarn-integrity
+.env
+.env.test
+.cache
+lib
+dist
+doc
+bundleReport.html
+.history/
+rawReq.ts
+localtest.sh
+localtest.ts
+privaterepotracker
+restClientRegex.ts
+repomix.sh
+
+examples/ignored
+examples/ts-testnet-private.ts
+examples/ts-testnet-trade.ts
+examples/ts-testnet.ts
 
 ================
 File: src/types/response/v5-market.ts
@@ -8351,1526 +9399,6 @@ export interface FeeGroupStructureResponseV5 {
 list: FeeGroupItemV5[]; // List of fee group objects
 
 ================
-File: src/types/shared-v5.ts
-================
-export type CategoryV5 = 'spot' | 'linear' | 'inverse' | 'option';
-export type ContractTypeV5 =
-  | 'InversePerpetual'
-  | 'LinearPerpetual'
-  | 'InverseFutures';
-export type CopyTradingV5 = 'none' | 'both' | 'utaOnly' | 'normalOnly';
-⋮----
-export type InstrumentStatusV5 =
-  | 'PreLaunch'
-  | 'Trading'
-  | 'Settling'
-  | 'Delivering'
-  | 'Closed';
-⋮----
-export type MarginTradingV5 = 'none' | 'both' | 'utaOnly' | 'normalSpotOnly';
-⋮----
-export type OrderFilterV5 = 'Order' | 'tpslOrder' | 'StopOrder';
-export type OrderSideV5 = 'Buy' | 'Sell';
-export type OrderTypeV5 = 'Market' | 'Limit';
-export type OrderTimeInForceV5 = 'GTC' | 'IOC' | 'FOK' | 'PostOnly' | 'RPI';
-export type OrderTriggerByV5 = 'LastPrice' | 'IndexPrice' | 'MarkPrice';
-export type OCOTriggerTypeV5 =
-  | 'OcoTriggerByUnknown'
-  | 'OcoTriggerTp'
-  | 'OcoTriggerBySl';
-⋮----
-export type OrderSMPTypeV5 =
-  | 'None'
-  | 'CancelMaker'
-  | 'CancelTaker'
-  | 'CancelBoth';
-⋮----
-export type OrderStatusV5 =
-  | 'Created'
-  | 'New'
-  | 'Rejected'
-  | 'PartiallyFilled'
-  | 'PartiallyFilledCanceled'
-  | 'Filled'
-  | 'Cancelled'
-  | 'Untriggered'
-  | 'Triggered'
-  | 'Deactivated'
-  | 'Active';
-⋮----
-/**
- * Defines the types of order creation mechanisms.
- */
-export type OrderCreateTypeV5 =
-  /** Represents an order created by a user. */
-  | 'CreateByUser'
-  /** Represents an order created by an admin closing. */
-  | 'CreateByAdminClosing'
-  /** Futures conditional order. */
-  | 'CreateByStopOrder'
-  /** Futures take profit order. */
-  | 'CreateByTakeProfit'
-  /** Futures partial take profit order. */
-  | 'CreateByPartialTakeProfit'
-  /** Futures stop loss order. */
-  | 'CreateByStopLoss'
-  /** Futures partial stop loss order. */
-  | 'CreateByPartialStopLoss'
-  /** Futures trailing stop order. */
-  | 'CreateByTrailingStop'
-  /** Laddered liquidation to reduce the required maintenance margin. */
-  | 'CreateByLiq'
-  /**
-   * If the position is still subject to liquidation (i.e., does not meet the required maintenance margin level),
-   * the position shall be taken over by the liquidation engine and closed at the bankruptcy price.
-   */
-  | 'CreateByTakeOver_PassThrough'
-  /** Auto-Deleveraging(ADL) */
-  | 'CreateByAdl_PassThrough'
-  /** Order placed via Paradigm. */
-  | 'CreateByBlock_PassThrough'
-  /** Order created by move position. */
-  | 'CreateByBlockTradeMovePosition_PassThrough'
-  /** The close order placed via web or app position area - web/app. */
-  | 'CreateByClosing'
-  /** Order created via grid bot - web/app. */
-  | 'CreateByFGridBot'
-  /** Order closed via grid bot - web/app. */
-  | 'CloseByFGridBot'
-  /** Order created by TWAP - web/app. */
-  | 'CreateByTWAP'
-  /** Order created by TV webhook - web/app. */
-  | 'CreateByTVSignal'
-  /** Order created by Mm rate close function - web/app. */
-  | 'CreateByMmRateClose'
-  /** Order created by Martingale bot - web/app. */
-  | 'CreateByMartingaleBot'
-  /** Order closed by Martingale bot - web/app. */
-  | 'CloseByMartingaleBot'
-  /** Order created by Ice berg strategy - web/app. */
-  | 'CreateByIceBerg'
-  /** Order created by arbitrage - web/app. */
-  | 'CreateByArbitrage'
-  /** Option dynamic delta hedge order - web/app */
-  | 'CreateByDdh'
-  /** BBO Order - Best Bid/Offer order */
-  | 'CreateByBboOrder';
-⋮----
-/** Represents an order created by a user. */
-⋮----
-/** Represents an order created by an admin closing. */
-⋮----
-/** Futures conditional order. */
-⋮----
-/** Futures take profit order. */
-⋮----
-/** Futures partial take profit order. */
-⋮----
-/** Futures stop loss order. */
-⋮----
-/** Futures partial stop loss order. */
-⋮----
-/** Futures trailing stop order. */
-⋮----
-/** Laddered liquidation to reduce the required maintenance margin. */
-⋮----
-/**
-   * If the position is still subject to liquidation (i.e., does not meet the required maintenance margin level),
-   * the position shall be taken over by the liquidation engine and closed at the bankruptcy price.
-   */
-⋮----
-/** Auto-Deleveraging(ADL) */
-⋮----
-/** Order placed via Paradigm. */
-⋮----
-/** Order created by move position. */
-⋮----
-/** The close order placed via web or app position area - web/app. */
-⋮----
-/** Order created via grid bot - web/app. */
-⋮----
-/** Order closed via grid bot - web/app. */
-⋮----
-/** Order created by TWAP - web/app. */
-⋮----
-/** Order created by TV webhook - web/app. */
-⋮----
-/** Order created by Mm rate close function - web/app. */
-⋮----
-/** Order created by Martingale bot - web/app. */
-⋮----
-/** Order closed by Martingale bot - web/app. */
-⋮----
-/** Order created by Ice berg strategy - web/app. */
-⋮----
-/** Order created by arbitrage - web/app. */
-⋮----
-/** Option dynamic delta hedge order - web/app */
-⋮----
-/** BBO Order - Best Bid/Offer order */
-⋮----
-export type OrderCancelTypeV5 =
-  | 'CancelByUser'
-  | 'CancelByReduceOnly'
-  | 'CancelByPrepareLiq'
-  | 'CancelAllBeforeLiq'
-  | 'CancelByPrepareAdl'
-  | 'CancelAllBeforeAdl'
-  | 'CancelByAdmin'
-  | 'CancelByTpSlTsClear'
-  | 'CancelByPzSideCh'
-  | 'UNKNOWN';
-⋮----
-export type OrderRejectReasonV5 =
-  | 'EC_NoError'
-  | 'EC_Others'
-  | 'EC_UnknownMessageType'
-  | 'EC_MissingClOrdID'
-  | 'EC_MissingOrigClOrdID'
-  | 'EC_ClOrdIDOrigClOrdIDAreTheSame'
-  | 'EC_DuplicatedClOrdID'
-  | 'EC_OrigClOrdIDDoesNotExist'
-  | 'EC_TooLateToCancel'
-  | 'EC_UnknownOrderType'
-  | 'EC_UnknownSide'
-  | 'EC_UnknownTimeInForce'
-  | 'EC_WronglyRouted'
-  | 'EC_MarketOrderPriceIsNotZero'
-  | 'EC_LimitOrderInvalidPrice'
-  | 'EC_NoEnoughQtyToFill'
-  | 'EC_NoImmediateQtyToFill'
-  | 'EC_PerCancelRequest'
-  | 'EC_MarketOrderCannotBePostOnly'
-  | 'EC_PostOnlyWillTakeLiquidity'
-  | 'EC_CancelReplaceOrder'
-  | 'EC_InvalidSymbolStatus';
-⋮----
-export type StopOrderTypeV5 =
-  | 'TakeProfit'
-  | 'StopLoss'
-  | 'TrailingStop'
-  | 'Stop'
-  | 'PartialTakeProfit'
-  | 'PartialStopLoss'
-  | 'tpslOrder'
-  | 'OcoOrder'
-  | 'MmRateClose'
-  | 'BidirectionalTpslOrder';
-⋮----
-/**
- * Position index. Used to identify positions in different position modes.
- *
- * - 0 one-way mode position
- * - 1 Buy side of hedge-mode position
- * - 2 Sell side of hedge-mode position
- */
-export type PositionIdx = 0 | 1 | 2;
-⋮----
-/**
- * Position status.
- *
- * - 'Normal'
- * - 'Liq' in the liquidation progress
- * - 'Adl' in the auto-deleverage progress
- */
-export type PositionStatusV5 = 'Normal' | 'Liq' | 'Adl';
-export type PositionSideV5 = 'Buy' | 'Sell' | 'None' | '';
-⋮----
-export type OptionTypeV5 = 'Call' | 'Put';
-⋮----
-/**
- * Trade mode.
- *
- * - 0 cross-margin,
- * - 1 isolated margin
- */
-export type TradeModeV5 = 0 | 1;
-⋮----
-export type TPSLModeV5 = 'Full' | 'Partial';
-export type AccountMarginModeV5 =
-  | 'ISOLATED_MARGIN'
-  | 'REGULAR_MARGIN'
-  | 'PORTFOLIO_MARGIN';
-export type UnifiedUpdateStatusV5 = 'FAIL' | 'PROCESS' | 'SUCCESS';
-⋮----
-export type AccountTypeV5 =
-  | 'CONTRACT'
-  | 'SPOT'
-  | 'INVESTMENT'
-  | 'OPTION'
-  | 'UNIFIED'
-  | 'FUND';
-⋮----
-export type TransactionTypeV5 =
-  | 'TRANSFER_IN'
-  | 'TRANSFER_OUT'
-  | 'TRADE'
-  | 'SETTLEMENT'
-  | 'DELIVERY'
-  | 'LIQUIDATION'
-  | 'ADL'
-  | 'AIRDROP'
-  | 'BONUS_RECOLLECT'
-  | 'BONUS_RECOLLECT'
-  | 'FEE_REFUND'
-  | 'INTEREST'
-  | 'CURRENCY_BUY'
-  | 'CURRENCY_SELL'
-  | 'BORROWED_AMOUNT_INS_LOAN'
-  | 'PRINCIPLE_REPAYMENT_INS_LOAN'
-  | 'INTEREST_REPAYMENT_INS_LOAN'
-  | 'AUTO_SOLD_COLLATERAL_INS_LOAN'
-  | 'AUTO_BUY_LIABILITY_INS_LOAN'
-  | 'AUTO_PRINCIPLE_REPAYMENT_INS_LOAN'
-  | 'AUTO_INTEREST_REPAYMENT_INS_LOAN'
-  | 'TRANSFER_IN_INS_LOAN'
-  | 'TRANSFER_OUT_INS_LOAN'
-  | 'SPOT_REPAYMENT_SELL'
-  | 'SPOT_REPAYMENT_BUY'
-  | 'TOKENS_SUBSCRIPTION'
-  | 'TOKENS_REDEMPTION'
-  | 'AUTO_DEDUCTION'
-  | 'FLEXIBLE_STAKING_SUBSCRIPTION'
-  | 'FLEXIBLE_STAKING_REDEMPTION'
-  | 'FIXED_STAKING_SUBSCRIPTION'
-  | 'BORROWED_AMOUNT_INS_LOAN'
-  | 'PRINCIPLE_REPAYMENT_INS_LOAN'
-  | 'INTEREST_REPAYMENT_INS_LOAN'
-  | 'AUTO_SOLD_COLLATERAL_INS_LOAN'
-  | 'AUTO_BUY_LIABILITY_INS_LOAN'
-  | 'AUTO_PRINCIPLE_REPAYMENT_INS_LOAN'
-  | 'AUTO_INTEREST_REPAYMENT_INS_LOAN'
-  | 'TRANSFER_IN_INS_LOAN'
-  | 'TRANSFER_OUT_INS_LOAN'
-  | 'SPOT_REPAYMENT_SELL'
-  | 'SPOT_REPAYMENT_BUY'
-  | 'TOKENS_SUBSCRIPTION'
-  | 'TOKENS_REDEMPTION'
-  | 'AUTO_DEDUCTION'
-  | 'FLEXIBLE_STAKING_SUBSCRIPTION'
-  | 'FLEXIBLE_STAKING_REDEMPTION'
-  | 'FIXED_STAKING_SUBSCRIPTION'
-  | 'FLEXIBLE_STAKING_REFUND'
-  | 'FIXED_STAKING_REFUND'
-  | 'PREMARKET_TRANSFER_OUT'
-  | 'PREMARKET_DELIVERY_SELL_NEW_COIN'
-  | 'PREMARKET_DELIVERY_BUY_NEW_COIN'
-  | 'PREMARKET_DELIVERY_PLEDGE_PAY_SELLER'
-  | 'PREMARKET_DELIVERY_PLEDGE_BACK'
-  | 'PREMARKET_ROLLBACK_PLEDGE_BACK'
-  | 'PREMARKET_ROLLBACK_PLEDGE_PENALTY_TO_BUYER'
-  | 'CUSTODY_NETWORK_FEE'
-  | 'CUSTODY_SETTLE_FEE'
-  | 'CUSTODY_LOCK'
-  | 'CUSTODY_UNLOCK'
-  | 'CUSTODY_UNLOCK_REFUND'
-  | 'LOANS_BORROW_FUNDS'
-  | 'LOANS_PLEDGE_ASSET'
-  | 'BONUS_TRANSFER_IN'
-  | 'BONUS_TRANSFER_OUT'
-  | 'PEF_TRANSFER_IN'
-  | 'PEF_TRANSFER_OUT'
-  | 'PEF_PROFIT_SHARE'
-  | 'ONCHAINEARN_SUBSCRIPTION'
-  | 'ONCHAINEARN_REDEMPTION'
-  | 'ONCHAINEARN_REFUND'
-  | 'STRUCTURE_PRODUCT_SUBSCRIPTION'
-  | 'STRUCTURE_PRODUCT_REFUND'
-  | 'CLASSIC_WEALTH_MANAGEMENT_SUBSCRIPTION'
-  | 'PREMIMUM_WEALTH_MANAGEMENT_SUBSCRIPTION'
-  | 'PREMIMUM_WEALTH_MANAGEMENT_REFUND'
-  | 'LIQUIDITY_MINING_SUBSCRIPTION'
-  | 'LIQUIDITY_MINING_REFUND'
-  | 'PWM_SUBSCRIPTION'
-  | 'PWM_REFUND'
-  | 'DEFI_INVESTMENT_SUBSCRIPTION'
-  | 'DEFI_INVESTMENT_REFUND'
-  | 'DEFI_INVESTMENT_REDEMPTION'
-  | 'INSTITUTION_LOAN_IN'
-  | 'INSTITUTION_PAYBACK_PRINCIPAL_OUT'
-  | 'INSTITUTION_PAYBACK_INTEREST_OUT'
-  | 'INSTITUTION_EXCHANGE_SELL'
-  | 'INSTITUTION_EXCHANGE_BUY'
-  | 'INSTITUTION_LIQ_PRINCIPAL_OUT'
-  | 'INSTITUTION_LIQ_INTEREST_OUT'
-  | 'INSTITUTION_LOAN_TRANSFER_IN'
-  | 'INSTITUTION_LOAN_TRANSFER_OUT'
-  | 'INSTITUTION_LOAN_WITHOUT_WITHDRAW'
-  | 'INSTITUTION_LOAN_RESERVE_IN'
-  | 'INSTITUTION_LOAN_RESERVE_OUT'
-  | 'PLATFORM_TOKEN_MNT_LIQRECALLEDMMNT'
-  | 'PLATFORM_TOKEN_MNT_LIQRETURNEDMNT';
-⋮----
-export type PermissionTypeV5 =
-  | 'ContractTrade'
-  | 'Spot'
-  | 'Wallet'
-  | 'Options'
-  | 'Derivatives'
-  | 'Exchange'
-  | 'NFT';
-⋮----
-/**
- * Leveraged token status:
- *
- * - '1' LT can be purchased and redeemed
- * - '2' LT can be purchased, but not redeemed
- * - '3' LT can be redeemed, but not purchased
- * - '4' LT cannot be purchased nor redeemed
- * - '5' Adjusting position
- */
-export type LeverageTokenStatusV5 = '1' | '2' | '3' | '4' | '5';
-⋮----
-/**
- * Leveraged token order type: '1': purchase, '2': redeem
- */
-export type LTOrderTypeV5 = '1' | '2';
-⋮----
-/**
- * Leveraged token order status: '1': completed, '2': in progress, '3': failed
- */
-export type LTOrderStatusV5 = '1' | '2' | '3';
-⋮----
-export type ExecTypeV5 =
-  | 'Trade'
-  | 'AdlTrade'
-  | 'Funding'
-  | 'BustTrade'
-  | 'Settle'
-  | 'BlockTrade'
-  | 'MovePosition'
-  | 'UNKNOWN';
-⋮----
-/**
- * Withdraw type. 0(default): on chain. 1: off chain. 2: all.
- */
-export type WithdrawalTypeV5 = '0' | '1' | '2';
-⋮----
-export interface PermissionsV5 {
-  ContractTrade?: string[];
-  Spot?: string[];
-  Wallet?: string[];
-  Options?: string[];
-  Derivatives?: string[];
-  CopyTrading?: string[];
-  BlockTrade?: string[];
-  Exchange?: string[];
-  /** @deprecated , always returns []*/
-  NFT?: string[];
-}
-⋮----
-/** @deprecated , always returns []*/
-⋮----
-export interface CategoryCursorListV5<
-  T extends unknown[],
-  TCategory extends CategoryV5 = CategoryV5,
-> {
-  category: TCategory;
-  list: T;
-  nextPageCursor?: string;
-}
-⋮----
-/**
- * Next page cursor does not exist for spot!
- */
-export interface CursorListV5<T extends unknown[]> {
-  nextPageCursor: string;
-  list: T;
-}
-⋮----
-/**
- * A wrapper type for any responses that have a "nextPageCursor" property, and a "rows" property with an array of elements
- *
- * ```{ nextPageCursor: "something", rows: someData[] }```
- */
-export interface CursorRowsV5<T extends unknown[]> {
-  nextPageCursor: string;
-  rows: T;
-}
-⋮----
-export interface CategoryListV5<
-  T extends unknown[],
-  TCategory extends CategoryV5,
-> {
-  category: TCategory;
-  list: T;
-}
-⋮----
-export interface CategorySymbolListV5<
-  T extends unknown[],
-  TCategory extends CategoryV5,
-> {
-  category: TCategory;
-  symbol: string;
-  list: T;
-}
-⋮----
-export interface GetSystemStatusParamsV5 {
-  id?: string;
-  state?: string;
-}
-⋮----
-export interface SystemStatusItemV5 {
-  id: string;
-  title: string;
-  state: string;
-  begin: string;
-  end: string;
-  href: string;
-  serviceTypes: number[];
-  product: number[];
-  uidSuffix: number[];
-  maintainType: string;
-  env: string;
-}
-
-================
-File: .gitignore
-================
-!.gitkeep
-.DS_STORE
-*.log
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-lerna-debug.log*
-report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
-pids
-*.pid
-*.seed
-*.pid.lock
-node_modules/
-.npm
-.eslintcache
-.node_repl_history
-*.tgz
-.yarn-integrity
-.env
-.env.test
-.cache
-lib
-bundleReport.html
-.history/
-rawReq.ts
-localtest.sh
-localtest.ts
-privaterepotracker
-restClientRegex.ts
-repomix.sh
-
-examples/ignored
-examples/ts-testnet-private.ts
-examples/ts-testnet-trade.ts
-examples/ts-testnet.ts
-
-================
-File: src/types/websockets/ws-events.ts
-================
-import WebSocket from 'isomorphic-ws';
-⋮----
-import {
-  RFQItemV5,
-  RFQPublicTradeV5,
-  RFQQuoteItemV5,
-  RFQTradeV5,
-} from '../response/v5-rfq';
-import {
-  CategoryV5,
-  ExecTypeV5,
-  OCOTriggerTypeV5,
-  OrderCancelTypeV5,
-  OrderCreateTypeV5,
-  OrderRejectReasonV5,
-  OrderSideV5,
-  OrderSMPTypeV5,
-  OrderStatusV5,
-  OrderTimeInForceV5,
-  OrderTriggerByV5,
-  OrderTypeV5,
-  PositionIdx,
-  PositionSideV5,
-  PositionStatusV5,
-  StopOrderTypeV5,
-  SystemStatusItemV5,
-  TPSLModeV5,
-  TradeModeV5,
-} from '../shared-v5';
-import { WsKey } from './ws-general';
-⋮----
-export interface MessageEventLike {
-  target: WebSocket;
-  type: 'message';
-  data: string;
-}
-⋮----
-export function isMessageEvent(msg: unknown): msg is MessageEventLike
-⋮----
-export interface WSPublicTopicEventV5<TTopic extends string, TType, TData> {
-  id?: string;
-  topic: TTopic;
-  type: TType;
-  /** Cross sequence */
-  cs?: number;
-  /** Event timestamp */
-  ts: number;
-  data: TData;
-  /**
-   * matching engine timestamp (correlated with T from public trade channel)
-   */
-  cts: number;
-  /**
-   * Internal reference, can be used to determine if this is spot/linear/inverse/etc
-   */
-  wsKey: WsKey;
-}
-⋮----
-/** Cross sequence */
-⋮----
-/** Event timestamp */
-⋮----
-/**
-   * matching engine timestamp (correlated with T from public trade channel)
-   */
-⋮----
-/**
-   * Internal reference, can be used to determine if this is spot/linear/inverse/etc
-   */
-⋮----
-export interface WSPrivateTopicEventV5<TTopic extends string, TData> {
-  id?: string;
-  topic: TTopic;
-  creationTime: number;
-  data: TData;
-  wsKey: WsKey;
-}
-⋮----
-export interface WSOrderbookV5 {
-  /** Symbol */
-  s: string;
-  /** [price, qty][] */
-  b: [string, string][];
-  /** [price, qty][] */
-  a: [string, string][];
-  /** Update ID */
-  u: number;
-  /** Cross sequence */
-  seq: number;
-}
-⋮----
-/** Symbol */
-⋮----
-/** [price, qty][] */
-⋮----
-/** [price, qty][] */
-⋮----
-/** Update ID */
-⋮----
-/** Cross sequence */
-⋮----
-export type WSOrderbookEventV5 = WSPublicTopicEventV5<
-  string,
-  'delta' | 'snapshot',
-  WSOrderbookV5
->;
-⋮----
-export interface WSTradeV5 {
-  T: number;
-  s: string;
-  S: OrderSideV5;
-  v: string;
-  p: string;
-  L?: string;
-  i: string;
-  BT: boolean;
-  RPI?: boolean;
-  mP?: string;
-  iP?: string;
-  mIv?: string;
-  iv?: string;
-}
-⋮----
-export type WSTradeEventV5 = WSPublicTopicEventV5<
-  string,
-  'snapshot',
-  WSTradeV5[]
->;
-⋮----
-/**
- *  WSTickerV5 is the data structure for the "linear" ticker channel
- *  */
-export interface WSTickerV5 {
-  symbol: string;
-  tickDirection: string;
-  price24hPcnt: string;
-  lastPrice: string;
-  prevPrice24h: string;
-  highPrice24h: string;
-  lowPrice24h: string;
-  prevPrice1h: string;
-  markPrice: string;
-  indexPrice: string;
-  openInterest: string;
-  openInterestValue: string;
-  turnover24h: string;
-  volume24h: string;
-  nextFundingTime: string;
-  fundingRate: string;
-  bid1Price: string;
-  bid1Size: string;
-  ask1Price: string;
-  ask1Size: string;
-  deliveryTime?: string;
-  basisRate?: string;
-  deliveryFeeRate?: string;
-  predictedDeliveryPrice?: string;
-  preOpenPrice?: string;
-  preQty?: string;
-  curPreListingPhase?: string;
-}
-⋮----
-export interface WSTickerOptionV5 {
-  symbol: string;
-  bidPrice: string;
-  bidSize: string;
-  bidIv: string;
-  askPrice: string;
-  askSize: string;
-  askIv: string;
-  lastPrice: string;
-  highPrice24h: string;
-  lowPrice24h: string;
-  markPrice: string;
-  indexPrice: string;
-  markPriceIv: string;
-  underlyingPrice: string;
-  openInterest: string;
-  turnover24h: string;
-  volume24h: string;
-  totalVolume: string;
-  totalTurnover: string;
-  delta: string;
-  gamma: string;
-  vega: string;
-  theta: string;
-  predictedDeliveryPrice: string;
-  change24h: string;
-}
-⋮----
-export interface WSTickerSpotV5 {
-  symbol: string;
-  lastPrice: string;
-  highPrice24h: string;
-  lowPrice24h: string;
-  prevPrice24h: string;
-  volume24h: string;
-  turnover24h: string;
-  price24hPcnt: string;
-  usdIndexPrice: string;
-}
-⋮----
-export type WSTickerEventV5 = WSPublicTopicEventV5<
-  string,
-  'snapshot' | 'delta',
-  WSTickerV5 | WSTickerOptionV5 | WSTickerSpotV5
->;
-⋮----
-export interface WSKlineV5 {
-  start: number;
-  end: number;
-  interval: string;
-  open: string;
-  close: string;
-  high: string;
-  low: string;
-  volume: string;
-  turnover: string;
-  confirm: boolean;
-  timestamp: number;
-}
-⋮----
-export type WSKlineEventV5 = WSPublicTopicEventV5<
-  string,
-  'snapshot',
-  WSKlineV5[]
->;
-⋮----
-export interface WSLiquidationV5 {
-  T: number;
-  s: string;
-  S: OrderSideV5;
-  v: string;
-  p: string;
-}
-⋮----
-export type WSLiquidationEventV5 = WSPublicTopicEventV5<
-  string,
-  'snapshot',
-  WSLiquidationV5[]
->;
-⋮----
-export interface WSPositionV5 {
-  category: string;
-  symbol: string;
-  side: PositionSideV5;
-  size: string;
-  positionIdx: PositionIdx;
-  tradeMode: TradeModeV5;
-  positionValue: string;
-  riskId: number;
-  riskLimitValue: string;
-  entryPrice: string;
-  markPrice: string;
-  leverage: string;
-  positionBalance: string;
-  autoAddMargin: number;
-  positionMM: string;
-  positionIM: string;
-  positionIMByMp: string;
-  positionMMByMp: string;
-  liqPrice: string;
-  bustPrice: string;
-  tpslMode: string;
-  takeProfit: string;
-  stopLoss: string;
-  trailingStop: string;
-  unrealisedPnl: string;
-  curRealisedPnl: string;
-  sessionAvgPrice: string;
-  delta: string;
-  gamma: string;
-  vega: string;
-  theta: string;
-  cumRealisedPnl: string;
-  positionStatus: PositionStatusV5;
-  adlRankIndicator: number;
-  isReduceOnly: boolean;
-  mmrSysUpdatedTime: string;
-  leverageSysUpdatedTime: string;
-  createdTime: string;
-  updatedTime: string;
-  seq: number;
-}
-⋮----
-export type WSPositionEventV5 = WSPrivateTopicEventV5<
-  'position',
-  WSPositionV5[]
->;
-⋮----
-export interface WSAccountOrderV5 {
-  category: CategoryV5;
-  orderId: string;
-  orderLinkId: string;
-  isLeverage: string;
-  blockTradeId: string;
-  symbol: string;
-  price: string;
-  qty: string;
-  side: OrderSideV5;
-  positionIdx: PositionIdx;
-  orderStatus: OrderStatusV5;
-  createType: OrderCreateTypeV5;
-  cancelType: OrderCancelTypeV5;
-  rejectReason?: OrderRejectReasonV5;
-  avgPrice?: string;
-  leavesQty?: string;
-  leavesValue?: string;
-  cumExecQty: string;
-  cumExecValue: string;
-  cumExecFee: string;
-  closedPnl: string;
-  feeCurrency: string;
-  timeInForce: OrderTimeInForceV5;
-  orderType: OrderTypeV5;
-  stopOrderType: StopOrderTypeV5;
-  ocoTriggerType?: OCOTriggerTypeV5;
-  orderIv: string;
-  marketUnit?: 'baseCoin' | 'quoteCoin';
-  triggerPrice: string;
-  takeProfit: string;
-  stopLoss: string;
-  tpslMode?: TPSLModeV5;
-  tpLimitPrice?: string;
-  slLimitPrice?: string;
-  tpTriggerBy: string;
-  slTriggerBy: string;
-  triggerDirection: number;
-  triggerBy: OrderTriggerByV5;
-  lastPriceOnCreated: string;
-  reduceOnly: boolean;
-  closeOnTrigger: boolean;
-  placeType: string;
-  smpType: OrderSMPTypeV5;
-  smpGroup: number;
-  smpOrderId: string;
-  createdTime: string;
-  updatedTime: string;
-  cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee and feeCurrency
-}
-⋮----
-cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee and feeCurrency
-⋮----
-export type WSAccountOrderEventV5 = WSPrivateTopicEventV5<
-  'order',
-  WSAccountOrderV5[]
->;
-⋮----
-export interface WSExecutionV5 {
-  category: CategoryV5;
-  symbol: string;
-  isLeverage: string;
-  orderId: string;
-  orderLinkId: string;
-  side: OrderSideV5;
-  orderPrice: string;
-  orderQty: string;
-  leavesQty: string;
-  createType: OrderCreateTypeV5;
-  orderType: OrderTypeV5;
-  stopOrderType: StopOrderTypeV5;
-  execFee: string;
-  feeCurrency: string; // Trading fee currency
-  execId: string;
-  execPrice: string;
-  execQty: string;
-  execPnl: string;
-  execType: ExecTypeV5;
-  execValue: string;
-  execTime: string;
-  isMaker: boolean;
-  feeRate: string;
-  tradeIv: string;
-  markIv: string;
-  markPrice: string;
-  indexPrice: string;
-  underlyingPrice: string;
-  blockTradeId: string;
-  closedSize: string;
-  extraFees: string;
-  seq: number;
-  marketUnit: string;
-}
-⋮----
-feeCurrency: string; // Trading fee currency
-⋮----
-export type WSExecutionEventV5 = WSPrivateTopicEventV5<
-  'execution',
-  WSExecutionV5[]
->;
-⋮----
-export interface WSExecutionFastV5 {
-  category: CategoryV5;
-  symbol: string;
-  execId: string;
-  execPrice: string;
-  execQty: string;
-  orderId: string;
-  isMaker: boolean;
-  orderLinkId: string;
-  side: OrderSideV5;
-  execTime: string;
-  seq: number;
-}
-⋮----
-export type WSExecutionFastEventV5 = WSPrivateTopicEventV5<
-  'execution.fast',
-  WSExecutionFastV5[]
->;
-⋮----
-export interface WSCoinV5 {
-  coin: string;
-  equity: string;
-  usdValue: string;
-  walletBalance: string;
-  free?: string;
-  locked: string;
-  spotHedgingQty: string;
-  borrowAmount: string;
-  availableToBorrow: string;
-  availableToWithdraw: string;
-  accruedInterest: string;
-  totalOrderIM: string;
-  totalPositionIM: string;
-  totalPositionMM: string;
-  unrealisedPnl: string;
-  cumRealisedPnl: string;
-  bonus: string;
-  collateralSwitch: boolean;
-  marginCollateral: boolean;
-  spotBorrow: string;
-}
-⋮----
-export interface WSWalletV5 {
-  accountType: string;
-  accountLTV: string;
-  accountIMRate: string;
-  accountMMRate: string;
-  accountIMRateByMp: string;
-  accountMMRateByMp: string;
-  totalInitialMarginByMp: string;
-  totalMaintenanceMarginByMp: string;
-  totalEquity: string;
-  totalWalletBalance: string;
-  totalMarginBalance: string;
-  totalAvailableBalance: string;
-  totalPerpUPL: string;
-  totalInitialMargin: string;
-  totalMaintenanceMargin: string;
-  coin: WSCoinV5[];
-}
-⋮----
-export type WSWalletEventV5 = WSPrivateTopicEventV5<'wallet', WSWalletV5[]>;
-⋮----
-export interface WSGreeksV5 {
-  baseCoin: string;
-  totalDelta: string;
-  totalGamma: string;
-  totalVega: string;
-  totalTheta: string;
-}
-⋮----
-export type WSGreeksEventV5 = WSPrivateTopicEventV5<'greeks', WSGreeksV5[]>;
-⋮----
-export interface WSSpreadOrderV5 {
-  category: 'combination' | 'spot_leg' | 'future_leg';
-  symbol: string;
-  parentOrderId: string;
-  orderId: string;
-  orderLinkId: string;
-  side: OrderSideV5;
-  orderStatus: OrderStatusV5;
-  cancelType: OrderCancelTypeV5;
-  rejectReason: OrderRejectReasonV5;
-  timeInForce: OrderTimeInForceV5;
-  price: string;
-  qty: string;
-  avgPrice: string;
-  leavesQty: string;
-  leavesValue: string;
-  cumExecQty: string;
-  cumExecValue: string;
-  cumExecFee: string;
-  orderType: OrderTypeV5;
-  isLeverage: string;
-  createdTime: string;
-  updatedTime: string;
-  feeCurrency: string;
-  createType: OrderCreateTypeV5;
-  closedPnl: string;
-  cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee and feeCurrency
-}
-⋮----
-cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee and feeCurrency
-⋮----
-export type WSSpreadOrderEventV5 = WSPrivateTopicEventV5<
-  'spread.order',
-  WSSpreadOrderV5[]
->;
-⋮----
-export interface WSSpreadExecutionV5 {
-  category: 'combination' | 'spot_leg' | 'future_leg';
-  symbol: string;
-  isLeverage: string;
-  orderId: string;
-  orderLinkId: string;
-  side: OrderSideV5;
-  orderPrice: string;
-  orderQty: string;
-  leavesQty: string;
-  createType: OrderCreateTypeV5;
-  orderType: OrderTypeV5;
-  execFee: string;
-  execFeeV2: string;
-  feeCurrency: string; // Trading fee currency
-  parentExecId: string;
-  execId: string;
-  execPrice: string;
-  execQty: string;
-  execPnl: string;
-  execType: ExecTypeV5;
-  execValue: string;
-  execTime: string;
-  isMaker: boolean;
-  feeRate: string;
-  markPrice: string;
-  closedSize: string;
-  seq: number;
-}
-⋮----
-feeCurrency: string; // Trading fee currency
-⋮----
-export type WSSpreadExecutionEventV5 = WSPrivateTopicEventV5<
-  'spread.execution',
-  WSSpreadExecutionV5[]
->;
-⋮----
-export interface WSInsuranceV5 {
-  coin: string;
-  symbols: string;
-  balance: string;
-  updateTime: string;
-}
-⋮----
-export type WSInsuranceEventV5 = WSPublicTopicEventV5<
-  'insurance.USDT' | 'insurance.USDC' | 'insurance.inverse',
-  'snapshot' | 'delta',
-  WSInsuranceV5[]
->;
-⋮----
-export interface WSPriceLimitV5 {
-  symbol: string;
-  buyLmt: string;
-  sellLmt: string;
-}
-⋮----
-export type WSPriceLimitEventV5 = WSPublicTopicEventV5<
-  string,
-  'snapshot',
-  WSPriceLimitV5
->;
-⋮----
-export interface WSADLAlertV5 {
-  c: string; // Token of the insurance pool
-  s: string; // Trading pair name
-  b: string; // Balance of the insurance fund. Used to determine if ADL is triggered
-  mb: string; // Maximum balance of the insurance pool in the last 8 hours
-  i_pr: string; // PnL ratio threshold for triggering contract PnL drawdown ADL
-  pr: string; // Symbol's PnL drawdown ratio in the last 8 hours. Used to determine whether ADL is triggered or stopped
-  adl_tt: string; // Trigger threshold for contract PnL drawdown ADL
-  adl_sr: string; // Stop ratio threshold for contract PnL drawdown ADL
-}
-⋮----
-c: string; // Token of the insurance pool
-s: string; // Trading pair name
-b: string; // Balance of the insurance fund. Used to determine if ADL is triggered
-mb: string; // Maximum balance of the insurance pool in the last 8 hours
-i_pr: string; // PnL ratio threshold for triggering contract PnL drawdown ADL
-pr: string; // Symbol's PnL drawdown ratio in the last 8 hours. Used to determine whether ADL is triggered or stopped
-adl_tt: string; // Trigger threshold for contract PnL drawdown ADL
-adl_sr: string; // Stop ratio threshold for contract PnL drawdown ADL
-⋮----
-export type WSADLAlertEventV5 = WSPublicTopicEventV5<
-  'adlAlert.USDT' | 'adlAlert.USDC' | 'adlAlert.inverse',
-  'snapshot',
-  WSADLAlertV5[]
->;
-⋮----
-export type WSSystemStatusEventV5 = WSPublicTopicEventV5<
-  'system.status',
-  'snapshot',
-  SystemStatusItemV5[]
->;
-⋮----
-/**
- * RFQ WebSocket Events
- */
-⋮----
-/**
- * RFQ Inquiry Channel
- * Private push for RFQ inquiries sent or received by the user
- * Topics: rfq.open.rfqs, rfq.site.rfqs
- */
-export type WSRFQInquiryEventV5 = WSPrivateTopicEventV5<
-  'rfq.open.rfqs' | 'rfq.site.rfqs',
-  RFQItemV5[]
->;
-⋮----
-/**
- * RFQ Quote Channel
- * Private push for quotes sent or received by the user
- * Topics: rfq.open.quotes, rfq.site.quotes
- */
-export type WSRFQQuoteEventV5 = WSPrivateTopicEventV5<
-  'rfq.open.quotes' | 'rfq.site.quotes',
-  RFQQuoteItemV5[]
->;
-⋮----
-/**
- * RFQ Trade Channel
- * Private push for block trades executed by the user
- * Topics: rfq.open.trades, rfq.site.trades
- */
-export type WSRFQTradeEventV5 = WSPrivateTopicEventV5<
-  'rfq.open.trades' | 'rfq.site.trades',
-  RFQTradeV5[]
->;
-⋮----
-/**
- * RFQ Public Trade Channel
- * Public push for all block trades
- * Topics: rfq.open.public.trades, rfq.site.public.trades
- */
-export type WSRFQPublicTradeEventV5 = WSPublicTopicEventV5<
-  'rfq.open.public.trades' | 'rfq.site.public.trades',
-  'snapshot',
-  RFQPublicTradeV5[]
->;
-
-================
-File: src/websocket-client.ts
-================
-import WebSocket from 'isomorphic-ws';
-⋮----
-import {
-  CategoryV5,
-  MessageEventLike,
-  WsKey,
-  WsMarket,
-  WsTopic,
-} from './types';
-import {
-  Exact,
-  WSAPIOperation,
-  WsAPIOperationResponseMap,
-  WSAPIRequest,
-  WsAPITopicRequestParamMap,
-  WsAPIWsKeyTopicMap,
-  WsOperation,
-  WsRequestOperationBybit,
-} from './types/websockets/ws-api';
-import {
-  APIID,
-  getMaxTopicsPerSubscribeEvent,
-  getNormalisedTopicRequests,
-  getPromiseRefForWSAPIRequest,
-  getTopicsPerWSKey,
-  getWsKeyForTopic,
-  getWsUrl,
-  isPrivateWsTopic,
-  isTopicSubscriptionConfirmation,
-  isTopicSubscriptionSuccess,
-  isWSAPIResponse,
-  isWsPong,
-  neverGuard,
-  WS_AUTH_ON_CONNECT_KEYS,
-  WS_KEY_MAP,
-  WS_LOGGER_CATEGORY,
-  WSConnectedResult,
-  WsTopicRequest,
-} from './util';
-import {
-  BaseWebsocketClient,
-  EmittableEvent,
-  MidflightWsRequestEvent,
-} from './util/BaseWSClient';
-import { SignAlgorithm, signMessage } from './util/webCryptoAPI';
-⋮----
-export class WebsocketClient extends BaseWebsocketClient<
-⋮----
-/**
-   * Request connection of all dependent (public & private) websockets, instead of waiting
-   * for automatic connection by SDK.
-   */
-public connectAll(): Promise<WSConnectedResult | undefined>[]
-⋮----
-/**
-   * Ensures the WS API connection is active and ready.
-   *
-   * You do not need to call this, but if you call this before making any WS API requests,
-   * it can accelerate the first request (by preparing the connection in advance).
-   */
-public connectWSAPI(): Promise<unknown>
-⋮----
-/** This call automatically ensures the connection is active AND authenticated before resolving */
-⋮----
-public connectPublic(): Promise<WSConnectedResult | undefined>[]
-⋮----
-public connectPrivate(): Promise<WebSocket | undefined>
-⋮----
-/**
-   * Subscribe to V5 topics & track/persist them.
-   * @param wsTopics - topic or list of topics
-   * @param category - the API category this topic is for (e.g. "linear").
-   * The value is only important when connecting to public topics and will be ignored for private topics.
-   * @param isPrivateTopic - optional - the library will try to detect private topics, you can use this
-   * to mark a topic as private (if the topic isn't recognised yet)
-   */
-public subscribeV5(
-    wsTopics: WsTopic[] | WsTopic,
-    category: CategoryV5,
-    isPrivateTopic?: boolean,
-): Promise<unknown>[]
-⋮----
-// Sort into per-WsKey batches, in case there is a mix of topics here
-⋮----
-// Prevent duplicate requests to the same topic
-⋮----
-// Batch sub topics per ws key
-⋮----
-// Return promise to resolve midflight WS request (only works if already connected before request)
-⋮----
-/**
-   * Unsubscribe from V5 topics & remove them from memory. They won't be re-subscribed to if the
-   * connection reconnects.
-   *
-   * @param wsTopics - topic or list of topics
-   * @param category - the API category this topic is for (e.g. "linear"). The value is only
-   * important when connecting to public topics and will be ignored for private topics.
-   * @param isPrivateTopic - optional - the library will try to detect private topics, you can
-   * use this to mark a topic as private (if the topic isn't recognised yet)
-   */
-public unsubscribeV5(
-    wsTopics: WsTopic[] | WsTopic,
-    category: CategoryV5,
-    isPrivateTopic?: boolean,
-): Promise<unknown>[]
-⋮----
-// Sort into per-WsKey batches, in case there is a mix of topics here
-⋮----
-// Batch sub topics per ws key
-⋮----
-// Return promise to resolve midflight WS request (only works if already connected before request)
-⋮----
-/**
-   * Note: subscribeV5() might be simpler to use. The end result is the same.
-   *
-   * Request subscription to one or more topics. Pass topics as either an array of strings,
-   * or array of objects (if the topic has parameters).
-   *
-   * Objects should be formatted as {topic: string, params: object, category: CategoryV5}.
-   *
-   * - Subscriptions are automatically routed to the correct websocket connection.
-   * - Authentication/connection is automatic.
-   * - Resubscribe after network issues is automatic.
-   *
-   * Call `unsubscribe(topics)` to remove topics
-   */
-public subscribe(
-    requests:
-      | (WsTopicRequest<WsTopic> | WsTopic)
-      | (WsTopicRequest<WsTopic> | WsTopic)[],
-    requestedWsKey?: WsKey,
-)
-⋮----
-// Batch sub topics per ws key
-⋮----
-/**
-   * Note: unsubscribe() might be simpler to use. The end result is the same.
-   * Unsubscribe from one or more topics. Similar to subscribe() but in reverse.
-   *
-   * - Requests are automatically routed to the correct websocket connection.
-   * - These topics will be removed from the topic cache, so they won't be subscribed to again.
-   */
-public unsubscribe(
-    requests:
-      | (WsTopicRequest<WsTopic> | WsTopic)
-      | (WsTopicRequest<WsTopic> | WsTopic)[],
-    wsKey?: WsKey,
-)
-⋮----
-// Batch sub topics per ws key
-⋮----
-/**
-   *
-   *
-   *
-   * WS API Methods - similar to the REST API, but via WebSockets
-   * https://bybit-exchange.github.io/docs/v5/websocket/trade/guideline
-   *
-   *
-   *
-   */
-⋮----
-/**
-   * Send a Websocket API command/request on a connection. Returns a promise that resolves on reply.
-   *
-   * WS API Documentation for list of operations and parameters:
-   * https://bybit-exchange.github.io/docs/v5/websocket/trade/guideline
-   *
-   * Returned promise is rejected if:
-   * - an exception is detected in the reply, OR
-   * - the connection disconnects for any reason (even if automatic reconnect will happen).
-   *
-   * Authentication is automatic. If you didn't request authentication yourself, there might
-   * be a small delay after your first request, while the SDK automatically authenticates.
-   *
-   * @param wsKey - The connection this event is for. Currently only "v5PrivateTrade" is supported
-   * for Bybit, since that is the dedicated WS API connection.
-   * @param operation - The command being sent, e.g. "order.create" to submit a new order.
-   * @param params - Any request parameters for the command. E.g. `OrderParamsV5` to submit a new
-   * order. Only send parameters for the request body. Everything else is automatically handled.
-   * @returns Promise - tries to resolve with async WS API response. Rejects if disconnected or exception is seen in async WS API response
-   */
-⋮----
-// This overload allows the caller to omit the 3rd param, if it isn't required
-sendWSAPIRequest<
-    TWSKey extends keyof WsAPIWsKeyTopicMap,
-    TWSOperation extends WsAPIWsKeyTopicMap[TWSKey],
-    TWSParams extends Exact<WsAPITopicRequestParamMap[TWSOperation]>,
-  >(
-    wsKey: TWSKey,
-    operation: TWSOperation,
-    ...params: TWSParams extends undefined ? [] : [TWSParams]
-  ): Promise<WsAPIOperationResponseMap[TWSOperation]>;
-⋮----
-// These overloads give stricter types than mapped generics, since generic constraints
-// do not trigger excess property checks
-// Without these overloads, TypeScript won't complain if you include an
-// unexpected property with your request (if it doesn't clash with an existing property)
-sendWSAPIRequest<TWSOperation extends WSAPIOperation = 'order.create'>(
-    wsKey: typeof WS_KEY_MAP.v5PrivateTrade,
-    operation: TWSOperation,
-    params: WsAPITopicRequestParamMap[TWSOperation],
-  ): Promise<WsAPIOperationResponseMap[TWSOperation]>;
-⋮----
-sendWSAPIRequest<TWSOperation extends WSAPIOperation = 'order.amend'>(
-    wsKey: typeof WS_KEY_MAP.v5PrivateTrade,
-    operation: TWSOperation,
-    params: WsAPITopicRequestParamMap[TWSOperation],
-  ): Promise<WsAPIOperationResponseMap[TWSOperation]>;
-⋮----
-sendWSAPIRequest<TWSOperation extends WSAPIOperation = 'order.cancel'>(
-    wsKey: typeof WS_KEY_MAP.v5PrivateTrade,
-    operation: TWSOperation,
-    params: WsAPITopicRequestParamMap[TWSOperation],
-  ): Promise<WsAPIOperationResponseMap[TWSOperation]>;
-⋮----
-async sendWSAPIRequest<
-    TWSKey extends keyof WsAPIWsKeyTopicMap,
-    TWSOperation extends WsAPIWsKeyTopicMap[TWSKey],
-    TWSParams extends Exact<WsAPITopicRequestParamMap[TWSOperation]>,
-    TWSAPIResponse extends
-      WsAPIOperationResponseMap[TWSOperation] = WsAPIOperationResponseMap[TWSOperation],
-  >(
-    wsKey: WsKey = WS_KEY_MAP.v5PrivateTrade,
-    operation: TWSOperation,
-    params: TWSParams,
-): Promise<WsAPIOperationResponseMap[TWSOperation]>
-⋮----
-// Sign, if needed
-⋮----
-// Store deferred promise, resolved within the "resolveEmittableEvents" method while parsing incoming events
-⋮----
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-⋮----
-// Enrich returned promise with request context for easier debugging
-⋮----
-// throw e;
-⋮----
-// Send event
-⋮----
-// Return deferred promise, so caller can await this call
-⋮----
-/**
-   *
-   *
-   * Internal methods - not intended for public use
-   *
-   *
-   */
-⋮----
-/**
-   * @returns The WS URL to connect to for this WS key
-   */
-protected async getWsUrl(wsKey: WsKey): Promise<string>
-⋮----
-// If auth is needed for this wsKey URL, this returns a suffix
-⋮----
-/**
-   * Return params required to make authorized request
-   */
-private async getWsAuthURLSuffix(): Promise<string>
-⋮----
-private async signMessage(
-    paramsStr: string,
-    secret: string,
-    method?: 'hex' | 'base64',
-    algorithm: SignAlgorithm = 'SHA-256',
-): Promise<string>
-⋮----
-protected async getWsAuthRequestEvent(
-    wsKey: WsKey,
-): Promise<WsRequestOperationBybit<string>>
-⋮----
-private async getWsAuthSignature(
-    wsKey: WsKey,
-): Promise<
-⋮----
-undefined, // Let the function automatically determine encoding based on key type
-⋮----
-private async signWSAPIRequest<TRequestParams = object>(
-    requestEvent: WSAPIRequest<TRequestParams>,
-): Promise<WSAPIRequest<TRequestParams>>
-⋮----
-// Not needed for Bybit. Auth happens only on connection open, automatically.
-⋮----
-protected sendPingEvent(wsKey: WsKey)
-⋮----
-protected sendPongEvent(wsKey: WsKey)
-⋮----
-/** Force subscription requests to be sent in smaller batches, if a number is returned */
-protected getMaxTopicsPerSubscribeEvent(wsKey: WsKey): number | null
-⋮----
-/**
-   * @returns one or more correctly structured request events for performing a operations over WS. This can vary per exchange spec.
-   */
-protected async getWsRequestEvents(
-    market: WsMarket,
-    operation: WsOperation,
-    requests: WsTopicRequest<string>[],
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-    wsKey: WsKey,
-): Promise<MidflightWsRequestEvent<WsRequestOperationBybit<WsTopic>>[]>
-⋮----
-// eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-⋮----
-// Previously used to track topics in a request. Keeping this for subscribe/unsubscribe requests, no need for incremental values
-⋮----
-protected getPrivateWSKeys(): WsKey[]
-⋮----
-protected isAuthOnConnectWsKey(wsKey: WsKey): boolean
-⋮----
-/**
-   * Determines if a topic is for a private channel, using a hardcoded list of strings
-   */
-protected isPrivateTopicRequest(request: WsTopicRequest<string>): boolean
-⋮----
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-protected isWsPing(msg: any): boolean
-⋮----
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-protected isWsPong(msg: any): boolean
-⋮----
-// public ws connections
-⋮----
-// private ws connections
-⋮----
-/**
-   * Abstraction called to sort ws events into emittable event types (response to a request, data update, etc)
-   */
-protected resolveEmittableEvents(
-    wsKey: WsKey,
-    event: MessageEventLike,
-): EmittableEvent[]
-⋮----
-// this.logger.trace('resolveEmittableEvents', {
-//   ...WS_LOGGER_CATEGORY,
-//   wsKey,
-//   parsed: JSON.stringify(parsed),
-// });
-⋮----
-// Only applies to the V5 WS topics
-⋮----
-// WS API response
-⋮----
-// eslint-disable-next-line max-len
-⋮----
-// WS API Exception
-⋮----
-// WS API Success
-⋮----
-// Messages for a subscribed topic all include the "topic" property
-⋮----
-// Messages that are a "reply" to a request/command (e.g. subscribe to these topics) typically include the "op" property
-⋮----
-// Failed request
-⋮----
-// These are r  equest/reply pattern events (e.g. after subscribing to topics or authenticating)
-⋮----
-// Request/reply pattern for authentication success
-⋮----
-// In case of catastrophic failure, fallback to noisy emit update
-
-================
 File: README.md
 ================
 # Node.js & JavaScript SDK for Bybit REST API, WebSocket API & WebSocket Events
@@ -9955,6 +9483,10 @@ Professional Node.js, JavaScript & TypeScript SDK for the Bybit REST APIs, WebSo
 - [Websocket API - Sending Orders via WebSockets](#websocket-api---sending-orders-via-websockets)
 - [Consumer Load Balancing](#balancing-load-across-multiple-connections)
 
+## Bybit EU & Other Regions
+
+- [REST API Usage with Bybit EU](#rest-api-usage-with-bybit-eu)
+
 ## Additional Features
 
 - [Logging](#logging)
@@ -9984,22 +9516,24 @@ Professional Node.js, JavaScript & TypeScript SDK for the Bybit REST APIs, WebSo
 
 <!-- template_related_projects -->
 
-## Related projects
+## Related Projects
 
-Check out my related JavaScript/TypeScript/Node.js projects:
+Check out our JavaScript/TypeScript/Node.js SDKs & Projects:
 
-- Try my REST API & WebSocket SDKs:
-  - [Bybit-api Node.js SDK](https://www.npmjs.com/package/bybit-api)
-  - [Okx-api Node.js SDK](https://www.npmjs.com/package/okx-api)
-  - [Binance Node.js SDK](https://www.npmjs.com/package/binance)
-  - [Gateio-api Node.js SDK](https://www.npmjs.com/package/gateio-api)
-  - [Bitget-api Node.js SDK](https://www.npmjs.com/package/bitget-api)
-  - [Kucoin-api Node.js SDK](https://www.npmjs.com/package/kucoin-api)
-  - [Coinbase-api Node.js SDK](https://www.npmjs.com/package/coinbase-api)
-  - [Bitmart-api Node.js SDK](https://www.npmjs.com/package/bitmart-api)
+- Visit our website: [https://Siebly.io](https://siebly.io/?ref=gh)
+- Try our REST API & WebSocket SDKs published on npmjs:
+  - [Bybit Node.js SDK: bybit-api](https://www.npmjs.com/package/bybit-api)
+  - [Kraken Node.js SDK: @siebly/kraken-api](https://www.npmjs.com/package/@siebly/kraken-api)
+  - [OKX Node.js SDK: okx-api](https://www.npmjs.com/package/okx-api)
+  - [Binance Node.js SDK: binance](https://www.npmjs.com/package/binance)
+  - [Gate (gate.com) Node.js SDK: gateio-api](https://www.npmjs.com/package/gateio-api)
+  - [Bitget Node.js SDK: bitget-api](https://www.npmjs.com/package/bitget-api)
+  - [Kucoin Node.js SDK: kucoin-api](https://www.npmjs.com/package/kucoin-api)
+  - [Coinbase Node.js SDK: coinbase-api](https://www.npmjs.com/package/coinbase-api)
+  - [Bitmart Node.js SDK: bitmart-api](https://www.npmjs.com/package/bitmart-api)
 - Try my misc utilities:
-  - [OrderBooks Node.js](https://www.npmjs.com/package/orderbooks)
-  - [Crypto Exchange Account State Cache](https://www.npmjs.com/package/accountstate)
+  - [OrderBooks Node.js: orderbooks](https://www.npmjs.com/package/orderbooks)
+  - [Crypto Exchange Account State Cache: accountstate](https://www.npmjs.com/package/accountstate)
 - Check out my examples:
   - [awesome-crypto-examples Node.js](https://github.com/tiagosiebler/awesome-crypto-examples)
   <!-- template_related_projects_end -->
@@ -10426,6 +9960,54 @@ Important: do not subscribe to the same topics on both clients or you will recei
 
 ---
 
+## Bybit EU & Other Regions
+
+By default, this Node.js, JavaScript & TypeScript SDK uses the Bybit Global API & WebSocket domains. For regions where Bybit has dedicated regional domains, including the alternative Bybit Global domain (bytick), these can be configured in the REST Client using the `apiRegion` property.
+
+The following values are currently supported in this option:
+
+- `apiRegion: undefined`: if missing or undefined, this SDK will default to the Bybit Global domain `api.bybit.com`.
+- `apiRegion: "default"`: the Bybit Global domain (same behaviour as above).
+- `apiRegion: "bytick"`: the alternative Bybit Global domain `api.bytick.com`.
+- `apiRegion: "NL"`: the dedicated Bybit Netherlands domain `api.bytick.nl`.
+- `apiRegion: "TK"`: the dedicated Bybit Turkey domain `api.bybit-tr.com`.
+- `apiRegion: "KZ"`: the dedicated Bybit Kazakhstan domain `api.bybit.kz`.
+- `apiRegion: "HK"`: the dedicated Bybit HK domain `api.byhkbit.com`.
+- `apiRegion: "GE"`: the dedicated Bybit Georgia domain `api.bybitgeorgia.ge`.
+- `apiRegion: "UAE"`: the dedicated Bybit United Arab Emirates domain `api.bybit.ae`.
+- `apiRegion: "EU"`: the dedicated Bybit EU/EEA domain `api.bybit.eu`.
+
+New regions will be supported when they become available in the Bybit API. If you notice any regions that have not been added yet, please open a new issue on GitHub.
+
+### REST API Usage with Bybit EU
+
+Below is an example for using this Node.js, TypeScript & JavaScript SDK for Bybit's APIs, using an account registered on the Bybit EU domain:
+
+```typescript
+const { RestClientV5 } = require('bybit-api');
+// or
+// import { RestClientV5 } from 'bybit-api';
+
+const client = new RestClientV5({
+  key: API_KEY,
+  secret: API_SECRET,
+  // demoTrading: true,
+
+  apiRegion: 'EU',
+});
+
+client
+  .getAccountInfo()
+  .then((result) => {
+    console.log('getAccountInfo result: ', result);
+  })
+  .catch((err) => {
+    console.error('getAccountInfo error: ', err);
+  });
+```
+
+---
+
 ## Logging
 
 ### Customise logging
@@ -10513,7 +10095,21 @@ Have my projects helped you? Share the love, there are many ways you can show yo
 - Have an interesting project? Get in touch & invite me to it.
 - Or buy me all the coffee:
   - ETH(ERC20): `0xA3Bda8BecaB4DCdA539Dc16F9C54a592553Be06C` <!-- metamask -->
+- Sign up with my referral links:
+  - OKX (receive a 20% fee discount!): https://www.okx.com/join/42013004
+  - Binance (receive a 20% fee discount!): https://accounts.binance.com/register?ref=OKFFGIJJ
+  - HyperLiquid (receive a 4% fee discount!): https://app.hyperliquid.xyz/join/SDK
+  - Gate: https://www.gate.io/signup/NODESDKS?ref_type=103
 
+<!---
+old ones:
+  - BTC: `1C6GWZL1XW3jrjpPTS863XtZiXL1aTK7Jk`
+  - BTC(SegWit): `bc1ql64wr9z3khp2gy7dqlmqw7cp6h0lcusz0zjtls`
+  - ETH(ERC20): `0xe0bbbc805e0e83341fadc210d6202f4022e50992`
+  - USDT(TRC20): `TA18VUywcNEM9ahh3TTWF3sFpt9rkLnnQa
+  - gate: https://www.gate.io/signup/AVNNU1WK?ref_type=103
+
+-->
 <!-- template_contributions_end -->
 
 ### Contributions & Pull Requests
@@ -10527,6 +10123,657 @@ Contributions are encouraged, I will review any incoming pull requests. See the 
 [![Star History Chart](https://api.star-history.com/svg?repos=tiagosiebler/bybit-api,tiagosiebler/okx-api,tiagosiebler/binance,tiagosiebler/bitget-api,tiagosiebler/bitmart-api,tiagosiebler/gateio-api,tiagosiebler/kucoin-api,tiagosiebler/coinbase-api,tiagosiebler/orderbooks,tiagosiebler/accountstate,tiagosiebler/awesome-crypto-examples&type=Date)](https://star-history.com/#tiagosiebler/bybit-api&tiagosiebler/okx-api&tiagosiebler/binance&tiagosiebler/bitget-api&tiagosiebler/bitmart-api&tiagosiebler/gateio-api&tiagosiebler/kucoin-api&tiagosiebler/coinbase-api&tiagosiebler/orderbooks&tiagosiebler/accountstate&tiagosiebler/awesome-crypto-examples&Date)
 
 <!-- template_star_history_end -->
+
+================
+File: src/types/websockets/ws-events.ts
+================
+import WebSocket from 'isomorphic-ws';
+⋮----
+import {
+  RFQItemV5,
+  RFQPublicTradeV5,
+  RFQQuoteItemV5,
+  RFQTradeV5,
+} from '../response/v5-rfq';
+import {
+  CategoryV5,
+  ExecTypeV5,
+  OCOTriggerTypeV5,
+  OrderCancelTypeV5,
+  OrderCreateTypeV5,
+  OrderRejectReasonV5,
+  OrderSideV5,
+  OrderSMPTypeV5,
+  OrderStatusV5,
+  OrderTimeInForceV5,
+  OrderTriggerByV5,
+  OrderTypeV5,
+  PositionIdx,
+  PositionSideV5,
+  PositionStatusV5,
+  StopOrderTypeV5,
+  SystemStatusItemV5,
+  TPSLModeV5,
+  TradeModeV5,
+} from '../shared-v5';
+import { WsKey } from './ws-general';
+⋮----
+export interface MessageEventLike {
+  target: WebSocket;
+  type: 'message';
+  data: string;
+}
+⋮----
+export function isMessageEvent(msg: unknown): msg is MessageEventLike
+⋮----
+export interface WSPublicTopicEventV5<TTopic extends string, TType, TData> {
+  id?: string;
+  topic: TTopic;
+  type: TType;
+  /** Cross sequence */
+  cs?: number;
+  /** Event timestamp */
+  ts: number;
+  data: TData;
+  /**
+   * matching engine timestamp (correlated with T from public trade channel)
+   */
+  cts: number;
+  /**
+   * Internal reference, can be used to determine if this is spot/linear/inverse/etc
+   */
+  wsKey: WsKey;
+}
+⋮----
+/** Cross sequence */
+⋮----
+/** Event timestamp */
+⋮----
+/**
+   * matching engine timestamp (correlated with T from public trade channel)
+   */
+⋮----
+/**
+   * Internal reference, can be used to determine if this is spot/linear/inverse/etc
+   */
+⋮----
+export interface WSPrivateTopicEventV5<TTopic extends string, TData> {
+  id?: string;
+  topic: TTopic;
+  creationTime: number;
+  data: TData;
+  wsKey: WsKey;
+}
+⋮----
+export interface WSOrderbookV5 {
+  /** Symbol */
+  s: string;
+  /** [price, qty][] */
+  b: [string, string][];
+  /** [price, qty][] */
+  a: [string, string][];
+  /** Update ID */
+  u: number;
+  /** Cross sequence */
+  seq: number;
+}
+⋮----
+/** Symbol */
+⋮----
+/** [price, qty][] */
+⋮----
+/** [price, qty][] */
+⋮----
+/** Update ID */
+⋮----
+/** Cross sequence */
+⋮----
+export type WSOrderbookEventV5 = WSPublicTopicEventV5<
+  string,
+  'delta' | 'snapshot',
+  WSOrderbookV5
+>;
+⋮----
+export interface WSTradeV5 {
+  T: number;
+  s: string;
+  S: OrderSideV5;
+  v: string;
+  p: string;
+  L?: string;
+  i: string;
+  BT: boolean;
+  RPI?: boolean;
+  mP?: string;
+  iP?: string;
+  mIv?: string;
+  iv?: string;
+}
+⋮----
+export type WSTradeEventV5 = WSPublicTopicEventV5<
+  string,
+  'snapshot',
+  WSTradeV5[]
+>;
+⋮----
+/**
+ *  WSTickerV5 is the data structure for the "linear" ticker channel
+ *  */
+export interface WSTickerV5 {
+  symbol: string;
+  tickDirection: string;
+  price24hPcnt: string;
+  lastPrice: string;
+  prevPrice24h: string;
+  highPrice24h: string;
+  lowPrice24h: string;
+  prevPrice1h: string;
+  markPrice: string;
+  indexPrice: string;
+  openInterest: string;
+  openInterestValue: string;
+  turnover24h: string;
+  volume24h: string;
+  nextFundingTime: string;
+  fundingRate: string;
+  bid1Price: string;
+  bid1Size: string;
+  ask1Price: string;
+  ask1Size: string;
+  deliveryTime?: string;
+  basisRate?: string;
+  deliveryFeeRate?: string;
+  predictedDeliveryPrice?: string;
+  preOpenPrice?: string;
+  preQty?: string;
+  curPreListingPhase?: string;
+  fundingIntervalHour?: string;
+  fundingCap?: string;
+  basisRateYear?: string;
+}
+⋮----
+export interface WSTickerOptionV5 {
+  symbol: string;
+  bidPrice: string;
+  bidSize: string;
+  bidIv: string;
+  askPrice: string;
+  askSize: string;
+  askIv: string;
+  lastPrice: string;
+  highPrice24h: string;
+  lowPrice24h: string;
+  markPrice: string;
+  indexPrice: string;
+  markPriceIv: string;
+  underlyingPrice: string;
+  openInterest: string;
+  turnover24h: string;
+  volume24h: string;
+  totalVolume: string;
+  totalTurnover: string;
+  delta: string;
+  gamma: string;
+  vega: string;
+  theta: string;
+  predictedDeliveryPrice: string;
+  change24h: string;
+}
+⋮----
+export interface WSTickerSpotV5 {
+  symbol: string;
+  lastPrice: string;
+  highPrice24h: string;
+  lowPrice24h: string;
+  prevPrice24h: string;
+  volume24h: string;
+  turnover24h: string;
+  price24hPcnt: string;
+  usdIndexPrice: string;
+}
+⋮----
+export type WSTickerEventV5 = WSPublicTopicEventV5<
+  string,
+  'snapshot' | 'delta',
+  WSTickerV5 | WSTickerOptionV5 | WSTickerSpotV5
+>;
+⋮----
+export interface WSKlineV5 {
+  start: number;
+  end: number;
+  interval: string;
+  open: string;
+  close: string;
+  high: string;
+  low: string;
+  volume: string;
+  turnover: string;
+  confirm: boolean;
+  timestamp: number;
+}
+⋮----
+export type WSKlineEventV5 = WSPublicTopicEventV5<
+  string,
+  'snapshot',
+  WSKlineV5[]
+>;
+⋮----
+export interface WSLiquidationV5 {
+  T: number;
+  s: string;
+  S: OrderSideV5;
+  v: string;
+  p: string;
+}
+⋮----
+export type WSLiquidationEventV5 = WSPublicTopicEventV5<
+  string,
+  'snapshot',
+  WSLiquidationV5[]
+>;
+⋮----
+export interface WSPositionV5 {
+  category: string;
+  symbol: string;
+  side: PositionSideV5;
+  size: string;
+  positionIdx: PositionIdx;
+  tradeMode: TradeModeV5;
+  positionValue: string;
+  riskId: number;
+  riskLimitValue: string;
+  entryPrice: string;
+  markPrice: string;
+  leverage: string;
+  breakEvenPrice?: string; // Break even price, only for linear & inverse
+  positionBalance: string;
+  autoAddMargin: number;
+  positionMM: string;
+  positionIM: string;
+  positionIMByMp: string;
+  positionMMByMp: string;
+  liqPrice: string;
+  bustPrice: string;
+  tpslMode: string;
+  takeProfit: string;
+  stopLoss: string;
+  trailingStop: string;
+  unrealisedPnl: string;
+  curRealisedPnl: string;
+  sessionAvgPrice: string;
+  delta: string;
+  gamma: string;
+  vega: string;
+  theta: string;
+  cumRealisedPnl: string;
+  positionStatus: PositionStatusV5;
+  adlRankIndicator: number;
+  isReduceOnly: boolean;
+  mmrSysUpdatedTime: string;
+  leverageSysUpdatedTime: string;
+  createdTime: string;
+  updatedTime: string;
+  seq: number;
+}
+⋮----
+breakEvenPrice?: string; // Break even price, only for linear & inverse
+⋮----
+export type WSPositionEventV5 = WSPrivateTopicEventV5<
+  'position',
+  WSPositionV5[]
+>;
+⋮----
+export interface WSAccountOrderV5 {
+  category: CategoryV5;
+  orderId: string;
+  orderLinkId: string;
+  parentOrderLinkId?: string; // Linked parent order for attached TP/SL orders (futures & options)
+  isLeverage: string;
+  blockTradeId: string;
+  symbol: string;
+  price: string;
+  qty: string;
+  side: OrderSideV5;
+  positionIdx: PositionIdx;
+  orderStatus: OrderStatusV5;
+  createType: OrderCreateTypeV5;
+  cancelType: OrderCancelTypeV5;
+  rejectReason?: OrderRejectReasonV5;
+  avgPrice?: string;
+  leavesQty?: string;
+  leavesValue?: string;
+  cumExecQty: string;
+  cumExecValue: string;
+  cumExecFee: string;
+  closedPnl: string;
+  feeCurrency: string;
+  timeInForce: OrderTimeInForceV5;
+  orderType: OrderTypeV5;
+  stopOrderType: StopOrderTypeV5;
+  ocoTriggerType?: OCOTriggerTypeV5;
+  orderIv: string;
+  marketUnit?: 'baseCoin' | 'quoteCoin';
+  triggerPrice: string;
+  takeProfit: string;
+  stopLoss: string;
+  tpslMode?: TPSLModeV5;
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
+  tpTriggerBy: string;
+  slTriggerBy: string;
+  triggerDirection: number;
+  triggerBy: OrderTriggerByV5;
+  lastPriceOnCreated: string;
+  reduceOnly: boolean;
+  closeOnTrigger: boolean;
+  placeType: string;
+  smpType: OrderSMPTypeV5;
+  smpGroup: number;
+  smpOrderId: string;
+  createdTime: string;
+  updatedTime: string;
+  cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee and feeCurrency
+}
+⋮----
+parentOrderLinkId?: string; // Linked parent order for attached TP/SL orders (futures & options)
+⋮----
+cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee and feeCurrency
+⋮----
+export type WSAccountOrderEventV5 = WSPrivateTopicEventV5<
+  'order',
+  WSAccountOrderV5[]
+>;
+⋮----
+export interface WSExecutionV5 {
+  category: CategoryV5;
+  symbol: string;
+  isLeverage: string;
+  orderId: string;
+  orderLinkId: string;
+  side: OrderSideV5;
+  orderPrice: string;
+  orderQty: string;
+  leavesQty: string;
+  createType: OrderCreateTypeV5;
+  orderType: OrderTypeV5;
+  stopOrderType: StopOrderTypeV5;
+  execFee: string;
+  feeCurrency: string; // Trading fee currency
+  execId: string;
+  execPrice: string;
+  execQty: string;
+  execPnl: string;
+  execType: ExecTypeV5;
+  execValue: string;
+  execTime: string;
+  isMaker: boolean;
+  feeRate: string;
+  tradeIv: string;
+  markIv: string;
+  markPrice: string;
+  indexPrice: string;
+  underlyingPrice: string;
+  blockTradeId: string;
+  closedSize: string;
+  extraFees: string;
+  seq: number;
+  marketUnit: string;
+}
+⋮----
+feeCurrency: string; // Trading fee currency
+⋮----
+export type WSExecutionEventV5 = WSPrivateTopicEventV5<
+  'execution',
+  WSExecutionV5[]
+>;
+⋮----
+export interface WSExecutionFastV5 {
+  category: CategoryV5;
+  symbol: string;
+  execId: string;
+  execPrice: string;
+  execQty: string;
+  orderId: string;
+  isMaker: boolean;
+  orderLinkId: string;
+  side: OrderSideV5;
+  execTime: string;
+  seq: number;
+}
+⋮----
+export type WSExecutionFastEventV5 = WSPrivateTopicEventV5<
+  'execution.fast',
+  WSExecutionFastV5[]
+>;
+⋮----
+export interface WSCoinV5 {
+  coin: string;
+  equity: string;
+  usdValue: string;
+  walletBalance: string;
+  free?: string;
+  locked: string;
+  spotHedgingQty: string;
+  borrowAmount: string;
+  availableToBorrow: string;
+  availableToWithdraw: string;
+  accruedInterest: string;
+  totalOrderIM: string;
+  totalPositionIM: string;
+  totalPositionMM: string;
+  unrealisedPnl: string;
+  cumRealisedPnl: string;
+  bonus: string;
+  collateralSwitch: boolean;
+  marginCollateral: boolean;
+  spotBorrow: string;
+}
+⋮----
+export interface WSWalletV5 {
+  accountType: string;
+  accountLTV: string;
+  accountIMRate: string;
+  accountMMRate: string;
+  accountIMRateByMp: string;
+  accountMMRateByMp: string;
+  totalInitialMarginByMp: string;
+  totalMaintenanceMarginByMp: string;
+  totalEquity: string;
+  totalWalletBalance: string;
+  totalMarginBalance: string;
+  totalAvailableBalance: string;
+  totalPerpUPL: string;
+  totalInitialMargin: string;
+  totalMaintenanceMargin: string;
+  coin: WSCoinV5[];
+}
+⋮----
+export type WSWalletEventV5 = WSPrivateTopicEventV5<'wallet', WSWalletV5[]>;
+⋮----
+export interface WSGreeksV5 {
+  baseCoin: string;
+  totalDelta: string;
+  totalGamma: string;
+  totalVega: string;
+  totalTheta: string;
+}
+⋮----
+export type WSGreeksEventV5 = WSPrivateTopicEventV5<'greeks', WSGreeksV5[]>;
+⋮----
+export interface WSSpreadOrderV5 {
+  category: 'combination' | 'spot_leg' | 'future_leg';
+  symbol: string;
+  parentOrderId: string;
+  orderId: string;
+  orderLinkId: string;
+  side: OrderSideV5;
+  orderStatus: OrderStatusV5;
+  cancelType: OrderCancelTypeV5;
+  rejectReason: OrderRejectReasonV5;
+  timeInForce: OrderTimeInForceV5;
+  price: string;
+  qty: string;
+  avgPrice: string;
+  leavesQty: string;
+  leavesValue: string;
+  cumExecQty: string;
+  cumExecValue: string;
+  cumExecFee: string;
+  orderType: OrderTypeV5;
+  isLeverage: string;
+  createdTime: string;
+  updatedTime: string;
+  feeCurrency: string;
+  createType: OrderCreateTypeV5;
+  closedPnl: string;
+  cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee and feeCurrency
+}
+⋮----
+cumFeeDetail?: Record<string, string>; // Cumulative trading fee details instead of cumExecFee and feeCurrency
+⋮----
+export type WSSpreadOrderEventV5 = WSPrivateTopicEventV5<
+  'spread.order',
+  WSSpreadOrderV5[]
+>;
+⋮----
+export interface WSSpreadExecutionV5 {
+  category: 'combination' | 'spot_leg' | 'future_leg';
+  symbol: string;
+  isLeverage: string;
+  orderId: string;
+  orderLinkId: string;
+  side: OrderSideV5;
+  orderPrice: string;
+  orderQty: string;
+  leavesQty: string;
+  createType: OrderCreateTypeV5;
+  orderType: OrderTypeV5;
+  execFee: string;
+  execFeeV2: string;
+  feeCurrency: string; // Trading fee currency
+  parentExecId: string;
+  execId: string;
+  execPrice: string;
+  execQty: string;
+  execPnl: string;
+  execType: ExecTypeV5;
+  execValue: string;
+  execTime: string;
+  isMaker: boolean;
+  feeRate: string;
+  markPrice: string;
+  closedSize: string;
+  seq: number;
+}
+⋮----
+feeCurrency: string; // Trading fee currency
+⋮----
+export type WSSpreadExecutionEventV5 = WSPrivateTopicEventV5<
+  'spread.execution',
+  WSSpreadExecutionV5[]
+>;
+⋮----
+export interface WSInsuranceV5 {
+  coin: string;
+  symbols: string;
+  balance: string;
+  updateTime: string;
+}
+⋮----
+export type WSInsuranceEventV5 = WSPublicTopicEventV5<
+  'insurance.USDT' | 'insurance.USDC' | 'insurance.inverse',
+  'snapshot' | 'delta',
+  WSInsuranceV5[]
+>;
+⋮----
+export interface WSPriceLimitV5 {
+  symbol: string;
+  buyLmt: string;
+  sellLmt: string;
+}
+⋮----
+export type WSPriceLimitEventV5 = WSPublicTopicEventV5<
+  string,
+  'snapshot',
+  WSPriceLimitV5
+>;
+⋮----
+export interface WSADLAlertV5 {
+  c: string; // Token of the insurance pool
+  s: string; // Trading pair name
+  b: string; // Balance of the insurance fund. For shared insurance pool, follows T+1 refresh (updated daily at 00:00 UTC)
+  mb: string; // Deprecated: always returns empty string. Previously: Maximum balance of the insurance pool in the last 8 hours
+  i_pr: string; // PnL ratio threshold for triggering contract PnL drawdown ADL
+  pr: string; // Symbol's PnL drawdown ratio in the last 8 hours. Used to determine whether ADL is triggered or stopped
+  adl_tt: string; // Trigger threshold for contract PnL drawdown ADL
+  adl_sr: string; // Stop ratio threshold for contract PnL drawdown ADL
+}
+⋮----
+c: string; // Token of the insurance pool
+s: string; // Trading pair name
+b: string; // Balance of the insurance fund. For shared insurance pool, follows T+1 refresh (updated daily at 00:00 UTC)
+mb: string; // Deprecated: always returns empty string. Previously: Maximum balance of the insurance pool in the last 8 hours
+i_pr: string; // PnL ratio threshold for triggering contract PnL drawdown ADL
+pr: string; // Symbol's PnL drawdown ratio in the last 8 hours. Used to determine whether ADL is triggered or stopped
+adl_tt: string; // Trigger threshold for contract PnL drawdown ADL
+adl_sr: string; // Stop ratio threshold for contract PnL drawdown ADL
+⋮----
+export type WSADLAlertEventV5 = WSPublicTopicEventV5<
+  'adlAlert.USDT' | 'adlAlert.USDC' | 'adlAlert.inverse',
+  'snapshot',
+  WSADLAlertV5[]
+>;
+⋮----
+export type WSSystemStatusEventV5 = WSPublicTopicEventV5<
+  'system.status',
+  'snapshot',
+  SystemStatusItemV5[]
+>;
+⋮----
+/**
+ * RFQ WebSocket Events
+ */
+⋮----
+/**
+ * RFQ Inquiry Channel
+ * Private push for RFQ inquiries sent or received by the user
+ * Topics: rfq.open.rfqs, rfq.site.rfqs
+ */
+export type WSRFQInquiryEventV5 = WSPrivateTopicEventV5<
+  'rfq.open.rfqs' | 'rfq.site.rfqs',
+  RFQItemV5[]
+>;
+⋮----
+/**
+ * RFQ Quote Channel
+ * Private push for quotes sent or received by the user
+ * Topics: rfq.open.quotes, rfq.site.quotes
+ */
+export type WSRFQQuoteEventV5 = WSPrivateTopicEventV5<
+  'rfq.open.quotes' | 'rfq.site.quotes',
+  RFQQuoteItemV5[]
+>;
+⋮----
+/**
+ * RFQ Trade Channel
+ * Private push for block trades executed by the user
+ * Topics: rfq.open.trades, rfq.site.trades
+ */
+export type WSRFQTradeEventV5 = WSPrivateTopicEventV5<
+  'rfq.open.trades' | 'rfq.site.trades',
+  RFQTradeV5[]
+>;
+⋮----
+/**
+ * RFQ Public Trade Channel
+ * Public push for all block trades
+ * Topics: rfq.open.public.trades, rfq.site.public.trades
+ */
+export type WSRFQPublicTradeEventV5 = WSPublicTopicEventV5<
+  'rfq.open.public.trades' | 'rfq.site.public.trades',
+  'snapshot',
+  RFQPublicTradeV5[]
+>;
 
 ================
 File: src/types/request/v5-crypto-loan.ts
@@ -10758,6 +11005,31 @@ export interface GetRenewOrderInfoFixedParamsV5 {
   limit?: string;
   cursor?: string;
 }
+⋮----
+// Max Loan Amount Request Types
+⋮----
+export interface GetMaxLoanAmountParamsV5 {
+  currency: string; // Coin to borrow
+  collateralList?: {
+    ccy: string; // Collateral coin
+    amount: string; // Collateral amount
+  }[];
+}
+⋮----
+currency: string; // Coin to borrow
+⋮----
+ccy: string; // Collateral coin
+amount: string; // Collateral amount
+⋮----
+// Institutional Loan Request Types
+⋮----
+export interface RepayInstitutionalLoanParamsV5 {
+  token: string; // Coin name
+  quantity: string; // The qty to be repaid
+}
+⋮----
+token: string; // Coin name
+quantity: string; // The qty to be repaid
 
 ================
 File: src/types/response/v5-crypto-loan.ts
@@ -11096,13 +11368,87 @@ export interface RenewOrderInfoFixedV5 {
   renewLoanNo: string;
   time: string;
 }
+⋮----
+// Institutional Loan Types
+⋮----
+export interface UnpaidInfoV5 {
+  token: string; // Coin
+  unpaidQty: string; // Unpaid principle
+  unpaidInterest: string; // Unpaid interest
+}
+⋮----
+token: string; // Coin
+unpaidQty: string; // Unpaid principle
+unpaidInterest: string; // Unpaid interest
+⋮----
+export interface BalanceInfoV5 {
+  token: string; // Margin coin
+  price: string; // Margin coin price
+  qty: string; // Margin coin quantity
+  convertedAmount: string; // Margin conversion amount
+}
+⋮----
+token: string; // Margin coin
+price: string; // Margin coin price
+qty: string; // Margin coin quantity
+convertedAmount: string; // Margin conversion amount
+⋮----
+export interface LTVInfoV5 {
+  ltv: string; // Risk rate (when liqStatus != 0, returns empty string)
+  rst: string; // Remaining liquidation time in UTC seconds (when liqStatus != 0, returns empty string)
+  parentUid: string; // The designated Risk Unit ID
+  subAccountUids: string[]; // Bound user IDs
+  unpaidAmount: string; // Total debt in USDT (when liqStatus != 0, returns empty string)
+  unpaidInfo: UnpaidInfoV5[]; // Debt details (when liqStatus != 0, returns empty array)
+  balance: string; // Total asset in USDT (when liqStatus != 0, returns empty string)
+  balanceInfo: BalanceInfoV5[]; // Asset details (when liqStatus != 0, returns empty array)
+  liqStatus?: number; // Liquidation status: 0=Normal, 1=Under liquidation, 2=Manual repayment in progress, 3=Transfer in progress
+}
+⋮----
+ltv: string; // Risk rate (when liqStatus != 0, returns empty string)
+rst: string; // Remaining liquidation time in UTC seconds (when liqStatus != 0, returns empty string)
+parentUid: string; // The designated Risk Unit ID
+subAccountUids: string[]; // Bound user IDs
+unpaidAmount: string; // Total debt in USDT (when liqStatus != 0, returns empty string)
+unpaidInfo: UnpaidInfoV5[]; // Debt details (when liqStatus != 0, returns empty array)
+balance: string; // Total asset in USDT (when liqStatus != 0, returns empty string)
+balanceInfo: BalanceInfoV5[]; // Asset details (when liqStatus != 0, returns empty array)
+liqStatus?: number; // Liquidation status: 0=Normal, 1=Under liquidation, 2=Manual repayment in progress, 3=Transfer in progress
+⋮----
+export interface InstitutionalLoanLTVV5 {
+  ltvInfo: LTVInfoV5[]; // LTV info array
+  liqStatus?: number; // Liquidation status: 0=Normal, 1=Under liquidation, 2=Manual repayment in progress, 3=Transfer in progress
+}
+⋮----
+ltvInfo: LTVInfoV5[]; // LTV info array
+liqStatus?: number; // Liquidation status: 0=Normal, 1=Under liquidation, 2=Manual repayment in progress, 3=Transfer in progress
+⋮----
+export interface RepayInstitutionalLoanResultV5 {
+  repayOrderStatus: string; // P: processing
+}
+⋮----
+repayOrderStatus: string; // P: processing
+⋮----
+// Max Loan Amount Response Types
+⋮----
+export interface MaxLoanAmountV5 {
+  currency: string; // Coin to borrow
+  maxLoan: string; // Maximum borrowable amount based on current collateral
+  notionalUsd: string; // Notional USD value
+  remainingQuota: string; // Remaining individual platform borrowing limit (shared between main and sub accounts)
+}
+⋮----
+currency: string; // Coin to borrow
+maxLoan: string; // Maximum borrowable amount based on current collateral
+notionalUsd: string; // Notional USD value
+remainingQuota: string; // Remaining individual platform borrowing limit (shared between main and sub accounts)
 
 ================
 File: package.json
 ================
 {
   "name": "bybit-api",
-  "version": "4.4.3",
+  "version": "4.5.1",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -11126,7 +11472,7 @@ File: package.json
   "author": "Tiago Siebler (https://github.com/tiagosiebler)",
   "contributors": [],
   "dependencies": {
-    "axios": "^1.10.0",
+    "axios": "^1.13.2",
     "isomorphic-ws": "^4.0.1",
     "ws": "^7.4.0"
   },
@@ -11149,7 +11495,7 @@ File: package.json
     "source-map-loader": "^2.0.0",
     "ts-loader": "^8.0.11",
     "webpack": "^5.4.0",
-    "webpack-bundle-analyzer": "^4.1.0",
+    "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^4.2.0"
   },
   "keywords": [
@@ -11191,6 +11537,8 @@ File: src/rest-client-v5.ts
 /* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
+  AcceptNonLPQuoteParamsV5,
+  AcceptNonLPQuoteResultV5,
   AccountBorrowCollateralLimitV5,
   AccountCoinBalanceV5,
   AccountInfoV5,
@@ -11210,9 +11558,11 @@ import {
   AmendOrderParamsV5,
   AmendSpreadOrderParamsV5,
   ApiKeyInfoV5,
+  APIP2PResponse,
   APIResponseV3,
   APIResponseV3WithTime,
   AssetInfoV5,
+  AutoRepayModeResultV5,
   AvailableAmountToRepayV5,
   BatchAmendOrderParamsV5,
   BatchAmendOrderResultV5,
@@ -11298,6 +11648,7 @@ import {
   ExecutionV5,
   FeeGroupStructureResponseV5,
   FeeRateV5,
+  FiatTradingPairListV5,
   FundingRateHistoryResponseV5,
   GetAccountCoinBalanceParamsV5,
   GetAccountHistoricOrdersParamsV5,
@@ -11308,6 +11659,7 @@ import {
   GetAllCoinsBalanceParamsV5,
   GetAllowedDepositCoinInfoParamsV5,
   GetAssetInfoParamsV5,
+  GetAutoRepayModeParamsV5,
   GetAvailableAmountToRepayParamsV5,
   GetBorrowableCoinsParamsV5,
   GetBorrowContractInfoFixedParamsV5,
@@ -11337,6 +11689,7 @@ import {
   GetExecutionListParamsV5,
   GetFeeGroupStructureParamsV5,
   GetFeeRateParamsV5,
+  GetFiatTradingPairListParamsV5,
   GetFundingRateHistoryParamsV5,
   GetHistoricalVolatilityParamsV5,
   GetIndexPriceComponentsParamsV5,
@@ -11351,6 +11704,7 @@ import {
   GetMarkPriceKlineParamsV5,
   GetMaxBorrowableAmountParamsV5,
   GetMaxCollateralAmountParamsV5,
+  GetMaxLoanAmountParamsV5,
   GetMovePositionHistoryParamsV5,
   GetOngoingFlexibleLoansParamsV5,
   GetOpenInterestParamsV5,
@@ -11386,6 +11740,7 @@ import {
   GetRiskLimitParamsV5,
   GetRPIOrderbookParamsV5,
   GetSettlementRecordParamsV5,
+  GetSmallBalanceListParamsV5,
   GetSpreadInstrumentsInfoParamsV5,
   GetSpreadOpenOrdersParamsV5,
   GetSpreadOrderHistoryParamsV5,
@@ -11406,6 +11761,7 @@ import {
   GetWithdrawalRecordsParamsV5,
   HistoricalVolatilityV5,
   IndexPriceComponentsResponseV5,
+  InstitutionalLoanLTVV5,
   InstrumentInfoResponseV5,
   InsuranceResponseV5,
   InternalDepositRecordV5,
@@ -11421,6 +11777,7 @@ import {
   ManualRepayWithoutConversionResultV5,
   MarkP2POrderAsPaidParamsV5,
   MaxBorrowableAmountV5,
+  MaxLoanAmountV5,
   MMPModifyParamsV5,
   MMPStateV5,
   MovePositionHistoryV5,
@@ -11463,6 +11820,8 @@ import {
   RepayFixedV5,
   RepayFlexibleParamsV5,
   RepayFlexibleV5,
+  RepayInstitutionalLoanParamsV5,
+  RepayInstitutionalLoanResultV5,
   RepayLiabilityParamsV5,
   RepayLiabilityResultV5,
   RepaymentHistoryFixedV5,
@@ -11478,6 +11837,7 @@ import {
   RPIOrderbookResponseV5,
   SendP2POrderMessageParamsV5,
   SetAutoAddMarginParamsV5,
+  SetAutoRepayModeParamsV5,
   SetCollateralCoinParamsV5,
   SetLeverageParamsV5,
   SetLimitPriceActionParamsV5,
@@ -11487,6 +11847,7 @@ import {
   SettlementRecordV5,
   SetTPSLModeParamsV5,
   SetTradingStopParamsV5,
+  SmallBalanceListV5,
   SpotBorrowCheckResultV5,
   SpotMarginStateV5,
   SpreadInstrumentInfoV5,
@@ -13084,6 +13445,31 @@ getConvertHistory(params?: GetConvertHistoryParamsV5): Promise<
     return this.getPrivate('/v5/asset/exchange/query-convert-history', params);
 ⋮----
 /**
+   * Get Small Balance Coins
+   * Query small-balance coins with a USDT equivalent of less than 10 USDT.
+   * Ensure total amount for each conversion transaction is between 1.0e-8 and 200 USDT.
+   *
+   * INFO:
+   * - API key permission: Convert
+   * - API rate limit: 10 req/s
+   */
+getSmallBalanceList(
+    params: GetSmallBalanceListParamsV5,
+): Promise<APIResponseV3WithTime<SmallBalanceListV5>>
+⋮----
+/**
+   * Get Fiat Trading Pair List
+   * Query for the list of coins you can convert to/from.
+   *
+   * INFO:
+   * - For buy side (side=0): buy crypto, sell fiat
+   * - For sell side (side=1): sell crypto, buy fiat
+   */
+getFiatTradingPairList(
+    params?: GetFiatTradingPairListParamsV5,
+): Promise<APIResponseV3WithTime<FiatTradingPairListV5>>
+⋮----
+/**
    *
    ****** User APIs
    *
@@ -13388,6 +13774,31 @@ getAvailableAmountToRepay(
 manualRepayWithoutConversion(
     params: ManualRepayWithoutConversionParamsV5,
 ): Promise<APIResponseV3WithTime<ManualRepayWithoutConversionResultV5>>
+⋮----
+/**
+   * Get Auto Repay Mode
+   * Get spot automatic repayment mode.
+   *
+   * INFO:
+   * - If currency is not passed, automatic repay mode for all currencies will be returned
+   */
+getAutoRepayMode(
+    params?: GetAutoRepayModeParamsV5,
+): Promise<APIResponseV3WithTime<AutoRepayModeResultV5>>
+⋮----
+/**
+   * Set Auto Repay Mode
+   * Set spot automatic repayment mode.
+   *
+   * INFO:
+   * - If currency is not passed, spot automatic repayment will be enabled for all currencies
+   * - If autoRepayMode of a currency is set to 1, the system will automatically make repayments
+   *   without asset conversion to that currency at 0 and 30 minutes every hour
+   * - The amount of repayments is the minimum of available spot balance and liability
+   */
+setAutoRepayMode(
+    params: SetAutoRepayModeParamsV5,
+): Promise<APIResponseV3WithTime<AutoRepayModeResultV5>>
 ⋮----
 /**
    *
@@ -13799,6 +14210,18 @@ getMaxCollateralAmount(params: GetMaxCollateralAmountParamsV5): Promise<
     );
 ⋮----
 /**
+   * Obtain Max Loan Amount
+   * Check the maximum borrowable amount & remaining individual platform limit for crypto loans.
+   *
+   * INFO:
+   * - Permission: "Spot trade"
+   * - UID rate limit: 5 req/s
+   */
+getMaxLoanAmount(
+    params: GetMaxLoanAmountParamsV5,
+): Promise<APIResponseV3WithTime<MaxLoanAmountV5>>
+⋮----
+/**
    * Adjust Collateral Amount New
    * You can increase or reduce your collateral amount. When you reduce, please obey the Get Max. Allowed Collateral Reduction Amount
    */
@@ -14133,7 +14556,7 @@ getInstitutionalLendingRepayOrders(params?: {
    * @deprecated
    */
 getInstitutionalLendingLTV(): Promise<
-    APIResponseV3WithTime<{ ltvInfo: any[] }>
+    APIResponseV3WithTime<InstitutionalLoanLTVV5>
   > {
     return this.getPrivate('/v5/ins-loan/ltv');
 ⋮----
@@ -14141,7 +14564,7 @@ getInstitutionalLendingLTV(): Promise<
    * Get LTV with Ladder Conversion Rate
    */
 getInstitutionalLendingLTVWithLadderConversionRate(): Promise<
-    APIResponseV3WithTime<{ ltvInfo: any[] }>
+    APIResponseV3WithTime<InstitutionalLoanLTVV5>
   > {
     return this.getPrivate('/v5/ins-loan/ltv-convert');
 ⋮----
@@ -14161,6 +14584,21 @@ bindOrUnbindUID(params: { uid: string; operate: '0' | '1' }): Promise<
     }>
   > {
     return this.postPrivate('/v5/ins-loan/association-uid', params);
+⋮----
+/**
+   * Repay Institutional Loan
+   * Repay INS loan independently.
+   *
+   * IMPORTANT:
+   * - Only the designated Risk Unit UID is allowed to call this API
+   * - The repayment is processed asynchronously and usually takes 2-3 minutes
+   * - Confirm repayment status via Get Repayment Orders before initiating next repayment
+   * - When repaying, principal amount will be deducted from Unified wallet (interest not included)
+   * - Please contact RM before executing
+   */
+repayInstitutionalLoan(
+    params: RepayInstitutionalLoanParamsV5,
+): Promise<APIResponseV3WithTime<RepayInstitutionalLoanResultV5>>
 ⋮----
 /**
    *
@@ -14495,6 +14933,17 @@ cursor: string; // Page turning mark
 list: RFQPublicTradeV5[]; // Array of public trade items
 ⋮----
 /**
+   * Accept non-LP Quote
+   * Accept non-LP Quote.
+   *
+   * INFO:
+   * - Up to 50 requests per second
+   */
+acceptNonLPQuote(
+    params: AcceptNonLPQuoteParamsV5,
+): Promise<APIResponseV3WithTime<AcceptNonLPQuoteResultV5>>
+⋮----
+/**
    *
    ****** P2P TRADING
    *
@@ -14648,7 +15097,7 @@ fileName: string; // Required: the filename (used for MIME type detection)
    */
 getP2POrderMessages(
     params: GetP2POrderMessagesParamsV5,
-): Promise<APIResponseV3WithTime<P2POrderMessageV5[]>>
+): Promise<APIP2PResponse<P2POrderMessageV5[]>>
 ⋮----
 /**
    *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bybit-api",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bybit-api",
-      "version": "4.5.0",
+      "version": "4.5.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -1,6 +1,8 @@
 /* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
+  AcceptNonLPQuoteParamsV5,
+  AcceptNonLPQuoteResultV5,
   AccountBorrowCollateralLimitV5,
   AccountCoinBalanceV5,
   AccountInfoV5,
@@ -24,6 +26,7 @@ import {
   APIResponseV3,
   APIResponseV3WithTime,
   AssetInfoV5,
+  AutoRepayModeResultV5,
   AvailableAmountToRepayV5,
   BatchAmendOrderParamsV5,
   BatchAmendOrderResultV5,
@@ -109,6 +112,7 @@ import {
   ExecutionV5,
   FeeGroupStructureResponseV5,
   FeeRateV5,
+  FiatTradingPairListV5,
   FundingRateHistoryResponseV5,
   GetAccountCoinBalanceParamsV5,
   GetAccountHistoricOrdersParamsV5,
@@ -119,6 +123,7 @@ import {
   GetAllCoinsBalanceParamsV5,
   GetAllowedDepositCoinInfoParamsV5,
   GetAssetInfoParamsV5,
+  GetAutoRepayModeParamsV5,
   GetAvailableAmountToRepayParamsV5,
   GetBorrowableCoinsParamsV5,
   GetBorrowContractInfoFixedParamsV5,
@@ -148,6 +153,7 @@ import {
   GetExecutionListParamsV5,
   GetFeeGroupStructureParamsV5,
   GetFeeRateParamsV5,
+  GetFiatTradingPairListParamsV5,
   GetFundingRateHistoryParamsV5,
   GetHistoricalVolatilityParamsV5,
   GetIndexPriceComponentsParamsV5,
@@ -162,6 +168,7 @@ import {
   GetMarkPriceKlineParamsV5,
   GetMaxBorrowableAmountParamsV5,
   GetMaxCollateralAmountParamsV5,
+  GetMaxLoanAmountParamsV5,
   GetMovePositionHistoryParamsV5,
   GetOngoingFlexibleLoansParamsV5,
   GetOpenInterestParamsV5,
@@ -197,6 +204,7 @@ import {
   GetRiskLimitParamsV5,
   GetRPIOrderbookParamsV5,
   GetSettlementRecordParamsV5,
+  GetSmallBalanceListParamsV5,
   GetSpreadInstrumentsInfoParamsV5,
   GetSpreadOpenOrdersParamsV5,
   GetSpreadOrderHistoryParamsV5,
@@ -217,6 +225,7 @@ import {
   GetWithdrawalRecordsParamsV5,
   HistoricalVolatilityV5,
   IndexPriceComponentsResponseV5,
+  InstitutionalLoanLTVV5,
   InstrumentInfoResponseV5,
   InsuranceResponseV5,
   InternalDepositRecordV5,
@@ -232,6 +241,7 @@ import {
   ManualRepayWithoutConversionResultV5,
   MarkP2POrderAsPaidParamsV5,
   MaxBorrowableAmountV5,
+  MaxLoanAmountV5,
   MMPModifyParamsV5,
   MMPStateV5,
   MovePositionHistoryV5,
@@ -274,6 +284,8 @@ import {
   RepayFixedV5,
   RepayFlexibleParamsV5,
   RepayFlexibleV5,
+  RepayInstitutionalLoanParamsV5,
+  RepayInstitutionalLoanResultV5,
   RepayLiabilityParamsV5,
   RepayLiabilityResultV5,
   RepaymentHistoryFixedV5,
@@ -289,6 +301,7 @@ import {
   RPIOrderbookResponseV5,
   SendP2POrderMessageParamsV5,
   SetAutoAddMarginParamsV5,
+  SetAutoRepayModeParamsV5,
   SetCollateralCoinParamsV5,
   SetLeverageParamsV5,
   SetLimitPriceActionParamsV5,
@@ -298,6 +311,7 @@ import {
   SettlementRecordV5,
   SetTPSLModeParamsV5,
   SetTradingStopParamsV5,
+  SmallBalanceListV5,
   SpotBorrowCheckResultV5,
   SpotMarginStateV5,
   SpreadInstrumentInfoV5,
@@ -2185,6 +2199,35 @@ export class RestClientV5 extends BaseRestClient {
   }
 
   /**
+   * Get Small Balance Coins
+   * Query small-balance coins with a USDT equivalent of less than 10 USDT.
+   * Ensure total amount for each conversion transaction is between 1.0e-8 and 200 USDT.
+   *
+   * INFO:
+   * - API key permission: Convert
+   * - API rate limit: 10 req/s
+   */
+  getSmallBalanceList(
+    params: GetSmallBalanceListParamsV5,
+  ): Promise<APIResponseV3WithTime<SmallBalanceListV5>> {
+    return this.getPrivate('/v5/asset/covert/small-balance-list', params);
+  }
+
+  /**
+   * Get Fiat Trading Pair List
+   * Query for the list of coins you can convert to/from.
+   *
+   * INFO:
+   * - For buy side (side=0): buy crypto, sell fiat
+   * - For sell side (side=1): sell crypto, buy fiat
+   */
+  getFiatTradingPairList(
+    params?: GetFiatTradingPairListParamsV5,
+  ): Promise<APIResponseV3WithTime<FiatTradingPairListV5>> {
+    return this.getPrivate('/v5/fiat/query-coin-list', params);
+  }
+
+  /**
    *
    ****** User APIs
    *
@@ -2539,6 +2582,38 @@ export class RestClientV5 extends BaseRestClient {
     params: ManualRepayWithoutConversionParamsV5,
   ): Promise<APIResponseV3WithTime<ManualRepayWithoutConversionResultV5>> {
     return this.postPrivate('/v5/account/no-convert-repay', params);
+  }
+
+  /**
+   * Get Auto Repay Mode
+   * Get spot automatic repayment mode.
+   *
+   * INFO:
+   * - If currency is not passed, automatic repay mode for all currencies will be returned
+   */
+  getAutoRepayMode(
+    params?: GetAutoRepayModeParamsV5,
+  ): Promise<APIResponseV3WithTime<AutoRepayModeResultV5>> {
+    return this.getPrivate('/v5/spot-margin-trade/get-auto-repay-mode', params);
+  }
+
+  /**
+   * Set Auto Repay Mode
+   * Set spot automatic repayment mode.
+   *
+   * INFO:
+   * - If currency is not passed, spot automatic repayment will be enabled for all currencies
+   * - If autoRepayMode of a currency is set to 1, the system will automatically make repayments
+   *   without asset conversion to that currency at 0 and 30 minutes every hour
+   * - The amount of repayments is the minimum of available spot balance and liability
+   */
+  setAutoRepayMode(
+    params: SetAutoRepayModeParamsV5,
+  ): Promise<APIResponseV3WithTime<AutoRepayModeResultV5>> {
+    return this.postPrivate(
+      '/v5/spot-margin-trade/set-auto-repay-mode',
+      params,
+    );
   }
 
   /**
@@ -2980,6 +3055,20 @@ export class RestClientV5 extends BaseRestClient {
   }
 
   /**
+   * Obtain Max Loan Amount
+   * Check the maximum borrowable amount & remaining individual platform limit for crypto loans.
+   *
+   * INFO:
+   * - Permission: "Spot trade"
+   * - UID rate limit: 5 req/s
+   */
+  getMaxLoanAmount(
+    params: GetMaxLoanAmountParamsV5,
+  ): Promise<APIResponseV3WithTime<MaxLoanAmountV5>> {
+    return this.postPrivate('/v5/crypto-loan-common/max-loan', params);
+  }
+
+  /**
    * Adjust Collateral Amount New
    * You can increase or reduce your collateral amount. When you reduce, please obey the Get Max. Allowed Collateral Reduction Amount
    */
@@ -3371,7 +3460,7 @@ export class RestClientV5 extends BaseRestClient {
    * @deprecated
    */
   getInstitutionalLendingLTV(): Promise<
-    APIResponseV3WithTime<{ ltvInfo: any[] }>
+    APIResponseV3WithTime<InstitutionalLoanLTVV5>
   > {
     return this.getPrivate('/v5/ins-loan/ltv');
   }
@@ -3380,7 +3469,7 @@ export class RestClientV5 extends BaseRestClient {
    * Get LTV with Ladder Conversion Rate
    */
   getInstitutionalLendingLTVWithLadderConversionRate(): Promise<
-    APIResponseV3WithTime<{ ltvInfo: any[] }>
+    APIResponseV3WithTime<InstitutionalLoanLTVV5>
   > {
     return this.getPrivate('/v5/ins-loan/ltv-convert');
   }
@@ -3401,6 +3490,23 @@ export class RestClientV5 extends BaseRestClient {
     }>
   > {
     return this.postPrivate('/v5/ins-loan/association-uid', params);
+  }
+
+  /**
+   * Repay Institutional Loan
+   * Repay INS loan independently.
+   *
+   * IMPORTANT:
+   * - Only the designated Risk Unit UID is allowed to call this API
+   * - The repayment is processed asynchronously and usually takes 2-3 minutes
+   * - Confirm repayment status via Get Repayment Orders before initiating next repayment
+   * - When repaying, principal amount will be deducted from Unified wallet (interest not included)
+   * - Please contact RM before executing
+   */
+  repayInstitutionalLoan(
+    params: RepayInstitutionalLoanParamsV5,
+  ): Promise<APIResponseV3WithTime<RepayInstitutionalLoanResultV5>> {
+    return this.postPrivate('/v5/ins-loan/repay-loan', params);
   }
 
   /**
@@ -3761,6 +3867,19 @@ export class RestClientV5 extends BaseRestClient {
     }>
   > {
     return this.getPrivate('/v5/rfq/public-trades', params);
+  }
+
+  /**
+   * Accept non-LP Quote
+   * Accept non-LP Quote.
+   *
+   * INFO:
+   * - Up to 50 requests per second
+   */
+  acceptNonLPQuote(
+    params: AcceptNonLPQuoteParamsV5,
+  ): Promise<APIResponseV3WithTime<AcceptNonLPQuoteResultV5>> {
+    return this.postPrivate('/v5/rfq/accept-other-quote', params);
   }
 
   /**

--- a/src/types/request/v5-asset.ts
+++ b/src/types/request/v5-asset.ts
@@ -191,3 +191,12 @@ export interface GetConvertHistoryParamsV5 {
   index?: number;
   limit?: number;
 }
+
+export interface GetSmallBalanceListParamsV5 {
+  accountType: 'eb_convert_uta'; // Wallet type, only supports Unified wallet
+  fromCoin?: string; // Source currency
+}
+
+export interface GetFiatTradingPairListParamsV5 {
+  side?: 0 | 1; // 0: buy (buy crypto, sell fiat), 1: sell (sell crypto, buy fiat)
+}

--- a/src/types/request/v5-crypto-loan.ts
+++ b/src/types/request/v5-crypto-loan.ts
@@ -222,3 +222,20 @@ export interface GetRenewOrderInfoFixedParamsV5 {
   limit?: string;
   cursor?: string;
 }
+
+// Max Loan Amount Request Types
+
+export interface GetMaxLoanAmountParamsV5 {
+  currency: string; // Coin to borrow
+  collateralList?: {
+    ccy: string; // Collateral coin
+    amount: string; // Collateral amount
+  }[];
+}
+
+// Institutional Loan Request Types
+
+export interface RepayInstitutionalLoanParamsV5 {
+  token: string; // Coin name
+  quantity: string; // The qty to be repaid
+}

--- a/src/types/request/v5-position.ts
+++ b/src/types/request/v5-position.ts
@@ -90,6 +90,7 @@ export interface GetExecutionListParamsV5 {
   orderId?: string;
   orderLinkId?: string;
   baseCoin?: string;
+  settleCoin?: string; // Settle coin, uppercase only. For linear, inverse, option
   startTime?: number;
   endTime?: number;
   execType?: ExecTypeV5;

--- a/src/types/request/v5-rfq.ts
+++ b/src/types/request/v5-rfq.ts
@@ -107,3 +107,7 @@ export interface GetRFQPublicTradesParamsV5 {
   limit?: number; // Return number of items, max 100, default 50
   cursor?: string; // Page turning mark
 }
+
+export interface AcceptNonLPQuoteParamsV5 {
+  rfqId: string; // Inquiry ID
+}

--- a/src/types/request/v5-spot-leverage-token.ts
+++ b/src/types/request/v5-spot-leverage-token.ts
@@ -58,3 +58,12 @@ export interface ManualRepayWithoutConversionParamsV5 {
   coin: string;
   amount?: string;
 }
+
+export interface GetAutoRepayModeParamsV5 {
+  currency?: string; // Coin name, uppercase only. If not passed, returns all currencies
+}
+
+export interface SetAutoRepayModeParamsV5 {
+  currency?: string; // Coin name, uppercase only. If not passed, enables for all currencies
+  autoRepayMode: '0' | '1'; // 0: Off, 1: On
+}

--- a/src/types/response/v5-asset.ts
+++ b/src/types/response/v5-asset.ts
@@ -282,3 +282,46 @@ export interface ConvertHistoryRecordV5 {
   convertRate: string;
   createdAt: string;
 }
+
+export interface SmallBalanceCoinV5 {
+  fromCoin: string; // Source currency
+  supportConvert: 1 | 2; // 1: support, 2: not supported
+  availableBalance: string; // Available balance
+  baseValue: string; // USDT equivalent value
+  toAmount: string; // Reserved field
+  exchangeRate: string; // Reserved field
+  feeInfo: null; // Reserved field
+  taxFeeInfo: null; // Reserved field
+}
+
+export interface SmallBalanceListV5 {
+  smallAssetCoins: SmallBalanceCoinV5[]; // Small balance info
+  supportToCoins: string[]; // Supported target coins (e.g., ["MNT","USDT","USDC"])
+}
+
+export interface FiatCoinInfoV5 {
+  coin: string; // Fiat coin code
+  fullName: string; // Fiat full coin name
+  icon: string; // Coin icon url
+  iconNight: string; // Coin icon url (dark mode)
+  precision: number; // Fiat precision
+  disable: boolean; // true: the coin is disabled, false: the coin is allowed
+  singleFromMinLimit: string; // For buy side, minimum amount of fiatCoin per transaction
+  singleFromMaxLimit: string; // For buy side, maximum amount of fiatCoin per transaction
+}
+
+export interface CryptoCoinInfoV5 {
+  coin: string; // Crypto coin code
+  fullName: string; // Crypto full coin name
+  icon: string; // Coin icon url
+  iconNight: string; // Coin icon url (dark mode)
+  precision: number; // Crypto precision
+  disable: boolean; // true: the coin is disabled, false: the coin is allowed
+  singleFromMinLimit: string; // For sell side, minimum amount of cryptoCoin per transaction
+  singleFromMaxLimit: string; // For sell side, maximum amount of cryptoCoin per transaction
+}
+
+export interface FiatTradingPairListV5 {
+  fiats: FiatCoinInfoV5[]; // Fiat coin list
+  cryptos: CryptoCoinInfoV5[]; // Crypto coin list
+}

--- a/src/types/response/v5-crypto-loan.ts
+++ b/src/types/response/v5-crypto-loan.ts
@@ -326,3 +326,48 @@ export interface RenewOrderInfoFixedV5 {
   renewLoanNo: string;
   time: string;
 }
+
+// Institutional Loan Types
+
+export interface UnpaidInfoV5 {
+  token: string; // Coin
+  unpaidQty: string; // Unpaid principle
+  unpaidInterest: string; // Unpaid interest
+}
+
+export interface BalanceInfoV5 {
+  token: string; // Margin coin
+  price: string; // Margin coin price
+  qty: string; // Margin coin quantity
+  convertedAmount: string; // Margin conversion amount
+}
+
+export interface LTVInfoV5 {
+  ltv: string; // Risk rate (when liqStatus != 0, returns empty string)
+  rst: string; // Remaining liquidation time in UTC seconds (when liqStatus != 0, returns empty string)
+  parentUid: string; // The designated Risk Unit ID
+  subAccountUids: string[]; // Bound user IDs
+  unpaidAmount: string; // Total debt in USDT (when liqStatus != 0, returns empty string)
+  unpaidInfo: UnpaidInfoV5[]; // Debt details (when liqStatus != 0, returns empty array)
+  balance: string; // Total asset in USDT (when liqStatus != 0, returns empty string)
+  balanceInfo: BalanceInfoV5[]; // Asset details (when liqStatus != 0, returns empty array)
+  liqStatus?: number; // Liquidation status: 0=Normal, 1=Under liquidation, 2=Manual repayment in progress, 3=Transfer in progress
+}
+
+export interface InstitutionalLoanLTVV5 {
+  ltvInfo: LTVInfoV5[]; // LTV info array
+  liqStatus?: number; // Liquidation status: 0=Normal, 1=Under liquidation, 2=Manual repayment in progress, 3=Transfer in progress
+}
+
+export interface RepayInstitutionalLoanResultV5 {
+  repayOrderStatus: string; // P: processing
+}
+
+// Max Loan Amount Response Types
+
+export interface MaxLoanAmountV5 {
+  currency: string; // Coin to borrow
+  maxLoan: string; // Maximum borrowable amount based on current collateral
+  notionalUsd: string; // Notional USD value
+  remainingQuota: string; // Remaining individual platform borrowing limit (shared between main and sub accounts)
+}

--- a/src/types/response/v5-position.ts
+++ b/src/types/response/v5-position.ts
@@ -24,6 +24,7 @@ export interface PositionV5 {
   autoAddMargin?: number;
   positionStatus: PositionStatusV5;
   leverage?: string;
+  breakEvenPrice?: string; // Break even price, only for linear & inverse
   markPrice: string;
   liqPrice: string | '';
   bustPrice?: string;

--- a/src/types/response/v5-rfq.ts
+++ b/src/types/response/v5-rfq.ts
@@ -96,6 +96,7 @@ export interface RFQItemV5 {
     | 'Filled'
     | 'Expired'
     | 'Failed'; // Status
+  acceptOtherQuoteStatus?: string; // Whether to accept non-LP quotes. "false": do not accept, "true": accept
   deskCode: string; // Unique identification code of the inquiry party
   createdAt: number; // Time when the trade is created in epoch
   updatedAt: number; // Time when the trade is updated in epoch
@@ -184,4 +185,8 @@ export interface RFQPublicTradeV5 {
   createdAt: number; // Time when trade is created in epoch
   updatedAt: number; // Time when trade is updated in epoch
   legs: RFQPublicTradeLegV5[]; // Combination transaction
+}
+
+export interface AcceptNonLPQuoteResultV5 {
+  rfqId: string; // Inquiry ID
 }

--- a/src/types/response/v5-spot-leverage-token.ts
+++ b/src/types/response/v5-spot-leverage-token.ts
@@ -133,3 +133,12 @@ export interface ManualRepayWithoutConversionResultV5 {
    */
   resultStatus: 'P' | 'SU' | 'FA';
 }
+
+export interface AutoRepayModeItemV5 {
+  currency: string; // Coin name, uppercase only
+  autoRepayMode: '0' | '1'; // 0: Off, 1: On
+}
+
+export interface AutoRepayModeResultV5 {
+  data: AutoRepayModeItemV5[];
+}

--- a/src/types/response/v5-trade.ts
+++ b/src/types/response/v5-trade.ts
@@ -20,6 +20,7 @@ export interface OrderResultV5 {
 export interface AccountOrderV5 {
   orderId: string;
   orderLinkId: string;
+  parentOrderLinkId?: string; // Linked parent order for attached TP/SL orders (futures & options)
   blockTradeId: string;
   symbol: string;
   price: string;

--- a/src/types/websockets/ws-events.ts
+++ b/src/types/websockets/ws-events.ts
@@ -241,6 +241,7 @@ export interface WSPositionV5 {
   entryPrice: string;
   markPrice: string;
   leverage: string;
+  breakEvenPrice?: string; // Break even price, only for linear & inverse
   positionBalance: string;
   autoAddMargin: number;
   positionMM: string;
@@ -280,6 +281,7 @@ export interface WSAccountOrderV5 {
   category: CategoryV5;
   orderId: string;
   orderLinkId: string;
+  parentOrderLinkId?: string; // Linked parent order for attached TP/SL orders (futures & options)
   isLeverage: string;
   blockTradeId: string;
   symbol: string;
@@ -543,8 +545,8 @@ export type WSPriceLimitEventV5 = WSPublicTopicEventV5<
 export interface WSADLAlertV5 {
   c: string; // Token of the insurance pool
   s: string; // Trading pair name
-  b: string; // Balance of the insurance fund. Used to determine if ADL is triggered
-  mb: string; // Maximum balance of the insurance pool in the last 8 hours
+  b: string; // Balance of the insurance fund. For shared insurance pool, follows T+1 refresh (updated daily at 00:00 UTC)
+  mb: string; // Deprecated: always returns empty string. Previously: Maximum balance of the insurance pool in the last 8 hours
   i_pr: string; // PnL ratio threshold for triggering contract PnL drawdown ADL
   pr: string; // Symbol's PnL drawdown ratio in the last 8 hours. Used to determine whether ADL is triggered or stopped
   adl_tt: string; // Trigger threshold for contract PnL drawdown ADL


### PR DESCRIPTION
Summary
Updated the Bybit API connector with all API changes from release notes dated 2025-12-18 through 2026-01-16, including new endpoints, updated response fields, and WebSocket updates.
New Endpoints (6)
RFQ Trading: Accept non-LP Quote (POST /v5/rfq/accept-other-quote)
Asset: Get Small Balance List (GET /v5/asset/covert/small-balance-list)
Asset: Get Fiat Trading Pair List (GET /v5/fiat/query-coin-list)
Crypto Loan: Obtain Max Loan Amount (POST /v5/crypto-loan-common/max-loan)
Institutional Loan: Repay (POST /v5/ins-loan/repay-loan)
Spot Margin (UTA): Get/Set Auto Repay Mode (GET/POST /v5/spot-margin-trade/*-auto-repay-mode)
Updated Fields
RFQ: Added acceptOtherQuoteStatus field to RFQ responses (REST & WebSocket)
Institutional Loan: Added liqStatus field to LTV responses (indicates liquidation status: 0=Normal, 1=Under liquidation, 2=Manual repayment, 3=Transfer)
Orders: Added parentOrderLinkId field linking TP/SL orders to parent orders (REST & WebSocket)
Positions: Added breakEvenPrice field for linear & inverse positions (REST & WebSocket)
Trade History: Added settleCoin parameter for linear, inverse, option
WebSocket Updates
ADL Alert: Updated b field (T+1 refresh for shared insurance pool), deprecated mb field
Order & Position: Automatically include new parentOrderLinkId and breakEvenPrice fields
Files Changed
Types: 9 files (request/response types for v5-rfq, v5-asset, v5-crypto-loan, v5-spot-leverage-token, v5-trade, v5-position, ws-events)
Client: rest-client-v5.ts (added 10 new methods)
Examples: 9 new example files across RFQ, Asset, Crypto-Loan-New, Institutional-Loan, and Spot-Margin-Trade-UTA folders