### PR TITLE
chore(v4.8.0): pin npm to v11 and update Node to v24.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bybit-api",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bybit-api",
-      "version": "4.7.0",
+      "version": "4.8.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Summary
- Pin npm publish workflow to npm v11 (npm v12 bug: https://github.com/npm/cli/issues/9722)
- Update `.nvmrc` to v24.18.0
- Bump package version to v4.8.0

## Test plan
- [x] npm i
- [x] npm run build
- [x] npm run lint

Made with [Cursor](https://cursor.com)